### PR TITLE
[Linux软件包优化] 更改Linux系统打包流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
           - src: "LICENSE"
             dst: "/usr/share/bloret-launcher/LICENSE"
           - src: "server.dat"
-            dst: "/usr/share/bloret-launcher/server.dat"
+            dst: "/usr/share/bloret-launcher/servers.dat"
           - src: "ui/"
             dst: "/usr/share/bloret-launcher/ui"
           - src: "lang/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,22 @@ jobs:
             dst: "/usr/share/bloret-launcher"
           - src: "linux_pkg_ready/bloret-launcher.desktop"
             dst: "/usr/share/applications/bloret-launcher.desktop"
+          - src: "bloret.ico"
+            dst: "/usr/share/bloret-launcher/bloret.ico"
+          - src: "config.json"
+            dst: "/usr/share/bloret-launcher/config.json"
+          - src: "JavaWrapper.jar"
+            dst: "/usr/share/bloret-launcher/JavaWrapper.jar"
+          - src: "LICENSE"
+            dst: "/usr/share/bloret-launcher/LICENSE"
+          - src: "server.dat"
+            dst: "/usr/share/bloret-launcher/server.dat"
+          - src: "ui/"
+            dst: "/usr/share/bloret-launcher/ui"
+          - src: "lang/"
+            dst: "/usr/share/bloret-launcher/lang"
+          - src: "easytier/"
+            dst: "/usr/share/bloret-launcher/easytier"
         scripts:
           postinstall: ./linux_pkg_ready/postinstall.sh
           postremove: ./linux_pkg_ready/postremove.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
             dst: "/usr/share/bloret-launcher/JavaWrapper.jar"
           - src: "LICENSE"
             dst: "/usr/share/bloret-launcher/LICENSE"
-          - src: "server.dat"
+          - src: "servers.dat"
             dst: "/usr/share/bloret-launcher/servers.dat"
           - src: "ui/"
             dst: "/usr/share/bloret-launcher/ui"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,9 +155,26 @@ jobs:
           cp dist/Bloret-Launcher.exe ${{ env.OUTPUT_DIR }}/
         elif [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/
-        else
+        elif [ "${{ runner.os }}" == "Linux" ]; then
           cp dist/Bloret-Launcher ${{ env.OUTPUT_DIR }}/
           VERSION=$(python -c "import json; print(json.load(open('config.json'))['ver'])")
+          mkdir linux_pkg_ready
+          # 生成 bloret-launcher.desktop 条目，为创建启动菜单快捷方式作准备
+          cat > linux_pkg_ready/bloret-launcher.desktop << EOF
+        [Desktop Entry]
+        Type=Application
+        Name=Bloret Launcher
+        GenericName=Minecraft
+        Comment=A Minecraft Launcher designed by BloretValley administrator.
+        Exec=/usr/share/bloret-launcher/Bloret-Launcher %U
+        Icon=/usr/share/bloret-launcher/bloret.ico
+        Terminal=false
+        Categories=Development;Game
+        EOF
+          # 生成安装后执行脚本，用于刷新启动菜单软件库
+          echo "update-desktop-database /usr/share/applications" > ./linux_pkg_ready/postinstall.sh
+          # 生成卸载后执行脚本，还是用于刷新启动菜单软件库（
+          echo "update-desktop-database /usr/share/applications" > ./linux_pkg_ready/postremove.sh
           # 生成 nfpm 配置
           cat > nfpm.yaml <<EOF
         name: "bloret-launcher"
@@ -171,8 +188,13 @@ jobs:
         homepage: "https://launcher.bloret.net"
         license: "GPL-3.0"
         contents:
-          - src: "dist/Bloret-Launcher"
-            dst: "/usr/bin/bloret-launcher"
+          - src: "dist/"
+            dst: "/usr/share/bloret-launcher"
+          - src: "linux_pkg_ready/bloret-launcher.desktop"
+            dst: "/usr/share/applications/bloret-launcher.desktop"
+        scripts:
+          postinstall: ./linux_pkg_ready/postinstall.sh
+          postremove: ./linux_pkg_ready/postremove.sh
         EOF
           # 安装 nfpm
           curl -sfL https://github.com/goreleaser/nfpm/releases/download/v2.41.2/nfpm_2.41.2_Linux_x86_64.tar.gz | tar xz nfpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,7 @@ jobs:
           curl -sfL https://github.com/goreleaser/nfpm/releases/download/v2.41.2/nfpm_2.41.2_Linux_x86_64.tar.gz | tar xz nfpm
           ./nfpm pkg --target ${{ env.OUTPUT_DIR }}/ --packager deb
           ./nfpm pkg --target ${{ env.OUTPUT_DIR }}/ --packager rpm
+          ./nfpm pkg --target ${{ env.OUTPUT_DIR }}/ --packager archlinux
           mkdir -p zip_contents
           cp dist/Bloret-Launcher zip_contents/
           cp -r ui lang easytier config.json LICENSE bloret.ico JavaWrapper.jar zip_contents/ || true


### PR DESCRIPTION
此更改保证百络谷启动器能通过软件包正常安装并启动
至于刚刚测出来的上游的打字崩溃问题……我不会python,我不会修.jpg

RPM软件包已在openSUSE Tumbleweed-Slowroll (Linux 6.16.9)通过测试，dpkg我没对应系统，但应该大差不差（