### PR TITLE
fix(ui): avoid sidebar stall from sync network on page show (#129)

### DIFF
--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -267,6 +267,12 @@ class Backend(QObject):
     # Backdrop/acrylic effect signal
     backdropEffectChanged = Signal(str)
 
+    # PassPort avatar ready (local file URL); never block UI for download
+    passPortAvatarChanged = Signal(str)
+
+    # Home remote data refresh TTL (seconds)
+    _HOME_REMOTE_TTL_SEC = 300
+
     def __init__(self):
         super().__init__()
         self._server_info = {}
@@ -300,6 +306,12 @@ class Backend(QObject):
         self._manifest_fetched = False
         self._version_prefetch_running = False
         self._version_prefetch_lock = threading.Lock()
+        # Avatar download + home remote refresh throttling
+        self._avatar_download_running = False
+        self._avatar_download_username = ""
+        self._avatar_download_lock = threading.Lock()
+        self._activity_refresh_ts = 0.0
+        self._server_refresh_ts = 0.0
 
     # ========== 全局 AI 供应商/模型设置 ==========
 
@@ -1224,8 +1236,28 @@ class Backend(QObject):
 
     @Slot()
     def refreshActivityInfo(self):
-        """从 API 刷新活动信息"""
+        """从 API 刷新活动信息（后台线程；TTL 内复用缓存，避免侧边栏反复进入主页时重复打网）"""
+        import time
+        try:
+            if cfg.read().get("localmod", False):
+                if self._activity_info:
+                    self.activityInfoChanged.emit(self._activity_info)
+                return
+        except Exception:
+            pass
+
+        now = time.time()
+        if (
+            self._activity_refresh_ts
+            and (now - self._activity_refresh_ts) < self._HOME_REMOTE_TTL_SEC
+            and self._activity_info
+        ):
+            self.activityInfoChanged.emit(self._activity_info)
+            return
+
+        self._activity_refresh_ts = now
         from modules.BLServer import get_latest_version
+
         def update_activity():
             try:
                 _, _ = get_latest_version()
@@ -1234,8 +1266,7 @@ class Backend(QObject):
                 icon_url = BLglobals.BL_Activity.get("icon", "")
                 if icon_url.startswith("http"):
                     try:
-                        import requests, hashlib
-                        from PySide6.QtCore import QUrl
+                        import hashlib
                         resp = requests.get(icon_url, timeout=5)
                         if resp.status_code == 200:
                             # compute hash for filename
@@ -1248,31 +1279,48 @@ class Backend(QObject):
                             # convert to file URL for QML
                             url = QUrl.fromLocalFile(local_path).toString()
                             BLglobals.BL_Activity["icon"] = url
-                            icon_path = url
                         else:
-                            icon_path = icon_url
+                            pass
                     except Exception as e:
                         print(f"Failed to download activity icon: {e}")
-                        icon_path = icon_url
                 else:
                     # non-http value might be local path; convert to file URL too
-                    from PySide6.QtCore import QUrl
                     if icon_url:
                         BLglobals.BL_Activity["icon"] = QUrl.fromLocalFile(icon_url).toString()
-                        icon_path = QUrl.fromLocalFile(icon_url).toString()
-                # else icon_path remains whatever returned
                 self._activity_info = BLglobals.BL_Activity
                 self.activityInfoChanged.emit(self._activity_info)
             except Exception as e:
                 print(f"Error refreshing activity info: {e}")
-        
+
         threading.Thread(target=update_activity, daemon=True).start()
 
     @Slot()
     def refreshServerInfo(self):
+        """刷新主页服务器信息（后台线程；TTL 内复用缓存）"""
+        import time
+        try:
+            if cfg.read().get("localmod", False):
+                if self._server_info:
+                    self.serverInfoChanged.emit(self._server_info)
+                return
+        except Exception:
+            pass
+
+        now = time.time()
+        if (
+            self._server_refresh_ts
+            and (now - self._server_refresh_ts) < self._HOME_REMOTE_TTL_SEC
+            and self._server_info
+        ):
+            self.serverInfoChanged.emit(self._server_info)
+            return
+
+        self._server_refresh_ts = now
+
         def update_callback(data):
             self._server_info = data
             self.serverInfoChanged.emit(data)
+
         getServerData("Bloret", callback=update_callback)
 
     @Slot(result=list)
@@ -3653,105 +3701,109 @@ class Backend(QObject):
     def getPassPortName(self):
         return self.getBloretPassPortUserName()
 
-    @Slot(result=str)
-    def getPassPortAvatar(self):
-        """获取用户头像 - 优先使用 PassPort 头像，备用使用 Minecraft 账户头像"""
-        print(f"\n[getPassPortAvatar] 方法被调用")
-        config_data = cfg.read()
-        
-        is_logged_in = config_data.get('Bloret_PassPort_Login')
-        print(f"  登录状态: {is_logged_in}")
-        if not is_logged_in:
-            print(f"  未登录，返回空字符串")
-            return ""
-        
-        username = config_data.get('Bloret_PassPort_UserName', '')
-        print(f"  PassPort 用户名: {username}")
-        if not username:
-            print(f"  用户名为空，返回空字符串")
-            return ""
-        
-        cache_dir = os.path.join(BLglobals.cache_path, 'avatars')
-        print(f"  缓存目录: {cache_dir}")
+    def _passPortAvatarCachePath(self, username):
+        cache_dir = os.path.join(BLglobals.cache_path, "avatars")
         try:
             os.makedirs(cache_dir, exist_ok=True)
-            print(f"  缓存目录已创建")
         except Exception as e:
-            print(f"  创建缓存目录失败: {e}")
-        
-        cache_file = os.path.join(cache_dir, f"{username}_passport.png")
-        print(f"  缓存文件路径: {cache_file}")
-        
-        # 从 config.json 读取头像 URL
-        avatar_url = config_data.get('Bloret_PassPort_Avatar', '')
-        print(f"  存储的头像 URL: {avatar_url if avatar_url else '(空)'}")
-        
-        # 如果有有效的头像 URL，尝试下载
-        if avatar_url and (avatar_url.startswith('http://') or avatar_url.startswith('https://')):
-            try:
-                print(f"  开始从 PassPort 头像 URL 下载...")
-                print(f"  请求 URL: {avatar_url}")
-                
-                headers = {
-                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
-                }
-                response = requests.get(avatar_url, timeout=10, headers=headers)
-                print(f"  HTTP 响应状态码: {response.status_code}")
-                print(f"  响应内容大小: {len(response.content)} bytes")
-                
-                if response.status_code == 200 and len(response.content) > 500:
-                    # 保存到缓存
-                    with open(cache_file, 'wb') as f:
-                        f.write(response.content)
-                    print(f"  PassPort 头像已保存到缓存文件")
-                    
-                    local_url = QUrl.fromLocalFile(cache_file).toString()
-                    print(f"  返回本地文件 URL: {local_url}")
-                    print(f"[getPassPortAvatar] 方法执行完成\n")
-                    return local_url
-                else:
-                    print(f"  下载失败：HTTP {response.status_code} 或内容过小")
-            except Exception as e:
-                print(f"  下载头像异常: {type(e).__name__}: {e}")
-        
-        # 如果 PassPort 头像不可用，尝试使用 Minecraft 账户的头像
-        print(f"  PassPort 头像不可用，尝试使用 Minecraft 账户头像...")
-        mc_account_config = config_data.get("MinecraftAccount", {})
-        accounts_list = mc_account_config.get("accounts", [])
+            print(f"[getPassPortAvatar] 创建缓存目录失败: {e}")
+        return os.path.join(cache_dir, f"{username}_passport.png")
+
+    def _schedulePassPortAvatarDownload(self, config_data, username, cache_file):
+        """后台下载头像；完成后发 passPortAvatarChanged。禁止在 UI 线程调用 requests。"""
+        with self._avatar_download_lock:
+            if self._avatar_download_running and self._avatar_download_username == username:
+                return
+            self._avatar_download_running = True
+            self._avatar_download_username = username
+
+        avatar_url = config_data.get("Bloret_PassPort_Avatar", "") or ""
+        mc_account_config = config_data.get("MinecraftAccount", {}) or {}
+        accounts_list = mc_account_config.get("accounts", []) or []
         chosen_index = mc_account_config.get("chosen", 0)
-        
+        mc_uuid = ""
+        mc_username = ""
         if accounts_list and 0 <= chosen_index < len(accounts_list):
-            chosen_account = accounts_list[chosen_index]
-            mc_uuid = chosen_account.get("uuid", "")
-            mc_username = chosen_account.get("username", "")
-            print(f"  选中的 Minecraft 账户: {mc_username}, UUID: {mc_uuid}")
-            
-            # 优先使用 UUID 获取头像
-            avatar_identifier = mc_uuid if mc_uuid else mc_username
-            if avatar_identifier:
-                try:
-                    # 使用 minotar.net 获取头像（更稳定）
-                    fallback_url = f"https://minotar.net/helm/{avatar_identifier}/64"
-                    print(f"  Minecraft 头像 URL: {fallback_url}")
-                    response = requests.get(fallback_url, timeout=10, headers={"User-Agent": "BloretLauncher/1.0"})
-                    print(f"  HTTP 响应状态码: {response.status_code}")
-                    print(f"  响应内容大小: {len(response.content)} bytes")
-                    
-                    if response.status_code == 200 and len(response.content) > 500:
-                        with open(cache_file, 'wb') as f:
-                            f.write(response.content)
-                        print(f"  Minecraft 头像已保存到缓存文件")
+            chosen_account = accounts_list[chosen_index] or {}
+            mc_uuid = chosen_account.get("uuid", "") or ""
+            mc_username = chosen_account.get("username", "") or ""
+
+        def run():
+            content = None
+            try:
+                headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"}
+                if avatar_url.startswith("http://") or avatar_url.startswith("https://"):
+                    try:
+                        print(f"[getPassPortAvatar] 后台下载 PassPort 头像: {avatar_url}")
+                        response = requests.get(avatar_url, timeout=10, headers=headers)
+                        if response.status_code == 200 and len(response.content) > 500:
+                            content = response.content
+                        else:
+                            print(
+                                f"[getPassPortAvatar] PassPort 头像下载失败: "
+                                f"HTTP {response.status_code}, size={len(response.content)}"
+                            )
+                    except Exception as e:
+                        print(f"[getPassPortAvatar] PassPort 头像下载异常: {type(e).__name__}: {e}")
+
+                if content is None:
+                    avatar_identifier = mc_uuid if mc_uuid else mc_username
+                    if avatar_identifier:
+                        try:
+                            fallback_url = f"https://minotar.net/helm/{avatar_identifier}/64"
+                            print(f"[getPassPortAvatar] 后台下载 Minecraft 头像: {fallback_url}")
+                            response = requests.get(
+                                fallback_url,
+                                timeout=10,
+                                headers={"User-Agent": "BloretLauncher/1.0"},
+                            )
+                            if response.status_code == 200 and len(response.content) > 500:
+                                content = response.content
+                            else:
+                                print(
+                                    f"[getPassPortAvatar] Minecraft 头像下载失败: "
+                                    f"HTTP {response.status_code}, size={len(response.content)}"
+                                )
+                        except Exception as e:
+                            print(f"[getPassPortAvatar] Minecraft 头像下载异常: {type(e).__name__}: {e}")
+
+                if content:
+                    try:
+                        with open(cache_file, "wb") as f:
+                            f.write(content)
                         local_url = QUrl.fromLocalFile(cache_file).toString()
-                        print(f"  返回本地文件 URL: {local_url}")
-                        print(f"[getPassPortAvatar] 方法执行完成\n")
-                        return local_url
-                    else:
-                        print(f"  Minecraft 头像下载失败：HTTP {response.status_code} 或内容过小")
-                except Exception as e:
-                    print(f"  Minecraft 头像下载异常: {type(e).__name__}: {e}")
-        
-        print(f"  所有方法都失败，返回空字符串")
-        print(f"[getPassPortAvatar] 方法执行完成\n")
+                        print(f"[getPassPortAvatar] 缓存已写入，通知 UI: {local_url}")
+                        self.passPortAvatarChanged.emit(local_url)
+                    except Exception as e:
+                        print(f"[getPassPortAvatar] 写缓存失败: {e}")
+            finally:
+                with self._avatar_download_lock:
+                    self._avatar_download_running = False
+
+        threading.Thread(target=run, daemon=True).start()
+
+    @Slot(result=str)
+    def getPassPortAvatar(self):
+        """获取用户头像 URL（仅读本地缓存，绝不在 UI 线程发起 HTTP）。
+
+        - 已登录且缓存存在：立即返回 file:// URL
+        - 缓存缺失：后台下载，完成后发 passPortAvatarChanged；本次返回 ""
+        """
+        config_data = cfg.read()
+
+        if not config_data.get("Bloret_PassPort_Login"):
+            return ""
+
+        username = config_data.get("Bloret_PassPort_UserName", "") or ""
+        if not username:
+            return ""
+
+        cache_file = self._passPortAvatarCachePath(username)
+        if os.path.exists(cache_file) and os.path.getsize(cache_file) > 500:
+            return QUrl.fromLocalFile(cache_file).toString()
+
+        # 无缓存：触发后台下载，立即返回空，避免侧边栏/主页卡顿
+        self._schedulePassPortAvatarDownload(config_data, username, cache_file)
         return ""
 
     # Removed duplicate getPlayerName, getVanillaVersions, getFabricVersions, getJavaDownloadVersions, downloadJava

--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -312,6 +312,11 @@ class Backend(QObject):
         self._avatar_download_lock = threading.Lock()
         self._activity_refresh_ts = 0.0
         self._server_refresh_ts = 0.0
+        self._activity_refresh_inflight = False
+        self._server_refresh_inflight = False
+        self._launch_items_cache = None
+        self._launch_items_cache_ts = 0.0
+        self._launch_items_cache_ttl = 15.0  # seconds; page recreate is frequent
 
     # ========== 全局 AI 供应商/模型设置 ==========
 
@@ -1151,21 +1156,13 @@ class Backend(QObject):
     @Slot(result=list)
     def getLaunchItemsSortedByPlayTime(self):
         """Get launch items sorted by total play time (descending)"""
-        from modules.setup_ui import get_all_launch_items
         from modules.play_time import get_all_play_times, format_duration
-        items = get_all_launch_items()
         times = get_all_play_times()
         qml_items = []
-        for item in items:
-            icon_path = "../../icon/Grass_Block.png"
-            if item.get("type") == "custom":
-                icon_path = "../../icon/exeapps.png"
+        for item in self.getLaunchItems():
             total = times.get(item["name"], 0)
             qml_items.append({
-                "name": item["name"],
-                "type": item["type"],
-                "path": item["path"],
-                "icon": icon_path,
+                **item,
                 "playTime": total,
                 "playTimeFormatted": format_duration(total),
             })
@@ -1247,15 +1244,15 @@ class Backend(QObject):
             pass
 
         now = time.time()
-        if (
-            self._activity_refresh_ts
-            and (now - self._activity_refresh_ts) < self._HOME_REMOTE_TTL_SEC
-            and self._activity_info
-        ):
+        if self._activity_info and self._activity_refresh_ts and (now - self._activity_refresh_ts) < self._HOME_REMOTE_TTL_SEC:
             self.activityInfoChanged.emit(self._activity_info)
             return
+        if self._activity_refresh_inflight:
+            if self._activity_info:
+                self.activityInfoChanged.emit(self._activity_info)
+            return
 
-        self._activity_refresh_ts = now
+        self._activity_refresh_inflight = True
         from modules.BLServer import get_latest_version
 
         def update_activity():
@@ -1279,8 +1276,6 @@ class Backend(QObject):
                             # convert to file URL for QML
                             url = QUrl.fromLocalFile(local_path).toString()
                             BLglobals.BL_Activity["icon"] = url
-                        else:
-                            pass
                     except Exception as e:
                         print(f"Failed to download activity icon: {e}")
                 else:
@@ -1288,9 +1283,13 @@ class Backend(QObject):
                     if icon_url:
                         BLglobals.BL_Activity["icon"] = QUrl.fromLocalFile(icon_url).toString()
                 self._activity_info = BLglobals.BL_Activity
+                self._activity_refresh_ts = time.time()
                 self.activityInfoChanged.emit(self._activity_info)
             except Exception as e:
                 print(f"Error refreshing activity info: {e}")
+                # 失败不写 TTL，下次进入主页可重试
+            finally:
+                self._activity_refresh_inflight = False
 
         threading.Thread(target=update_activity, daemon=True).start()
 
@@ -1307,58 +1306,63 @@ class Backend(QObject):
             pass
 
         now = time.time()
-        if (
-            self._server_refresh_ts
-            and (now - self._server_refresh_ts) < self._HOME_REMOTE_TTL_SEC
-            and self._server_info
-        ):
+        if self._server_info and self._server_refresh_ts and (now - self._server_refresh_ts) < self._HOME_REMOTE_TTL_SEC:
             self.serverInfoChanged.emit(self._server_info)
             return
+        if self._server_refresh_inflight:
+            if self._server_info:
+                self.serverInfoChanged.emit(self._server_info)
+            return
 
-        self._server_refresh_ts = now
+        self._server_refresh_inflight = True
 
         def update_callback(data):
-            self._server_info = data
-            self.serverInfoChanged.emit(data)
+            try:
+                self._server_info = data or {}
+                # 仅在无网络 error 时记 TTL；纯错误允许尽快重试
+                if not (isinstance(data, dict) and data.get("error")):
+                    self._server_refresh_ts = time.time()
+                self.serverInfoChanged.emit(self._server_info)
+            finally:
+                self._server_refresh_inflight = False
 
         getServerData("Bloret", callback=update_callback)
 
-    @Slot(result=list)
-    def getLaunchItems(self):
+    def invalidateLaunchItemsCache(self):
+        self._launch_items_cache = None
+        self._launch_items_cache_ts = 0.0
+
+    def _buildLaunchItemsQml(self):
         from modules.setup_ui import get_all_launch_items
         items = get_all_launch_items()
         qml_items = []
-        
-        # Log for debugging
-        import logging
-        logger = logging.getLogger(__name__)
-        logger.debug(f"getLaunchItems: Retrieved {len(items)} items from get_all_launch_items()")
-        
         for item in items:
-            # Extract icon path from item
-            icon_path = "../../icon/Grass_Block.png"  # Default
-            
-            if item.get("type") == "minecraft":
-                # For minecraft, check if we have metadata with custom icon
-                # Default to Grass_Block for minecraft
-                icon_path = "../../icon/Grass_Block.png"
-                
-            elif item.get("type") == "custom":
-                # For custom apps, use a generic app icon
+            icon_path = "../../icon/Grass_Block.png"
+            if item.get("type") == "custom":
                 icon_path = "../../icon/exeapps.png"
-            
-            qml_item = {
+            qml_items.append({
                 "name": item["name"],
                 "type": item["type"],
                 "path": item["path"],
-                "icon": icon_path
-            }
-            
-            logger.debug(f"getLaunchItems: Added item {qml_item}")
-            qml_items.append(qml_item)
-        
-        logger.debug(f"getLaunchItems: Returning {len(qml_items)} items to QML")
+                "icon": icon_path,
+            })
         return qml_items
+
+    @Slot(result=list)
+    def getLaunchItems(self):
+        """返回启动项；短时缓存，减轻侧边栏反复重建主页时的磁盘扫描开销。"""
+        import time
+        now = time.time()
+        if (
+            self._launch_items_cache is not None
+            and (now - self._launch_items_cache_ts) < self._launch_items_cache_ttl
+        ):
+            return list(self._launch_items_cache)
+
+        qml_items = self._buildLaunchItemsQml()
+        self._launch_items_cache = qml_items
+        self._launch_items_cache_ts = now
+        return list(qml_items)
 
     @Slot(str)
     def selectLaunchItem(self, name):
@@ -1369,6 +1373,11 @@ class Backend(QObject):
             print(f"[Home] Selected launch item: {name}")
         except Exception as e:
             print(f"Error selecting launch item: {e}")
+
+    @Slot()
+    def invalidateLaunchItems(self):
+        """供安装/删除核心后刷新启动列表缓存。"""
+        self.invalidateLaunchItemsCache()
 
     @Slot(result=str)
     def getSelectedLaunchItem(self):
@@ -1463,6 +1472,7 @@ class Backend(QObject):
                 config_data = cfg.read()
                 config_data['customize_list'] = BLglobals.customize_list
                 cfg.write(config_data)
+                self.invalidateLaunchItemsCache()
                 print(f"Deleted custom item: {name}")
         except Exception as e:
             print(f"Error deleting custom item: {e}")
@@ -1478,6 +1488,7 @@ class Backend(QObject):
                 if config_data.get('ChoosedRun') == oldName:
                     config_data['ChoosedRun'] = newName
                 cfg.write(config_data)
+                self.invalidateLaunchItemsCache()
                 print(f"Renamed custom item: {oldName} -> {newName}")
         except Exception as e:
             print(f"Error renaming custom item: {e}")
@@ -1624,6 +1635,7 @@ class Backend(QObject):
                         json.dump(full_data, f, ensure_ascii=False, indent=4)
                 
                 print(f"Core deleted: {versionName}")
+                self.invalidateLaunchItemsCache()
                 try:
                     from modules.plugin_host.hook_util import fire
                     fire("version.deleted", {"version": versionName})
@@ -2716,9 +2728,9 @@ class Backend(QObject):
 
     @Slot(result=list)
     def getSystemJavas(self):
-        from modules.java_runtime import probe_java, scan_java_runtimes, invalidate_java_runtime_cache
-        invalidate_java_runtime_cache()
-        runtimes = scan_java_runtimes(force_refresh=True)
+        """返回 Java 运行时列表。默认使用已有扫描缓存，避免每次打开设置都全盘扫描导致侧边栏卡顿。"""
+        from modules.java_runtime import probe_java, scan_java_runtimes
+        runtimes = scan_java_runtimes(force_refresh=False)
         configured_path = self.getCurrentJavaPath()
         if configured_path and not any(item.get('path') == configured_path for item in runtimes):
             configured = probe_java(configured_path)
@@ -3771,14 +3783,19 @@ class Backend(QObject):
                     try:
                         with open(cache_file, "wb") as f:
                             f.write(content)
-                        local_url = QUrl.fromLocalFile(cache_file).toString()
-                        print(f"[getPassPortAvatar] 缓存已写入，通知 UI: {local_url}")
-                        self.passPortAvatarChanged.emit(local_url)
+                        # 用户可能已切换账户：仅在目标用户名仍匹配时通知
+                        with self._avatar_download_lock:
+                            still_current = self._avatar_download_username == username
+                        if still_current:
+                            local_url = QUrl.fromLocalFile(cache_file).toString()
+                            print(f"[getPassPortAvatar] 缓存已写入，通知 UI: {local_url}")
+                            self.passPortAvatarChanged.emit(local_url)
                     except Exception as e:
                         print(f"[getPassPortAvatar] 写缓存失败: {e}")
             finally:
                 with self._avatar_download_lock:
-                    self._avatar_download_running = False
+                    if self._avatar_download_username == username:
+                        self._avatar_download_running = False
 
         threading.Thread(target=run, daemon=True).start()
 

--- a/modules/BLServer.py
+++ b/modules/BLServer.py
@@ -122,7 +122,7 @@ def get_latest_version():
     BL_latest_ver = "0.0"
     
     try:
-        response = requests.get(f"{BLglobals.server_ip}:3001/api/info")
+        response = requests.get(f"{BLglobals.server_ip}:3001/api/info", timeout=5)
         if response.status_code == 200:
             latest_release = response.json()
             BL_update_text = latest_release.get("newVersionDescription", "")

--- a/modules/chafuwang.py
+++ b/modules/chafuwang.py
@@ -24,7 +24,7 @@ def getServerData(ServerName: str, callback: Callable[[Dict[str, Any]], None] = 
         
         try:
             log(f"正在发送HTTP GET请求到服务器: {ServerName}", logging.INFO)
-            response = requests.get(url)
+            response = requests.get(url, timeout=5)
             log(f"收到服务器 {ServerName} 的响应，状态码: {response.status_code}", logging.INFO)
             
             response.raise_for_status()  # 如果响应状态码不是200会抛出异常

--- a/modules/update.py
+++ b/modules/update.py
@@ -117,7 +117,7 @@ def update_to_latest_version(self):
         log(f"请求URL: {BLglobals.server_ip}:3001/api/info")
         
         # 发送GET请求
-        response = requests.get(f"{BLglobals.server_ip}:3001/api/info")
+        response = requests.get(f"{BLglobals.server_ip}:3001/api/info", timeout=5)
         response.raise_for_status()
         res = response.json()
         

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -327,6 +327,11 @@ FluentWindow {
             updatePassPortNavigation()
         }
 
+        function onPassPortAvatarChanged(url) {
+            // 后台头像下载完成后再刷新侧边栏头像，避免启动/切页时同步打网
+            updatePassPortNavigation()
+        }
+
         function onBackdropEffectChanged(effect) {
             Utils.backdropEnabled = (effect === "acrylic")
         }

--- a/qml/pages/Home.qml
+++ b/qml/pages/Home.qml
@@ -15,6 +15,8 @@ FluentPage {
     property string currentVersion: ""
     property string showAccountOnHome: "compact"
     property var pluginHomeCards: []
+    // 本地缓存 URL；异步下载完成后由 passPortAvatarChanged 更新，禁止在绑定里同步拉网
+    property string passPortAvatarUrl: ""
 
     function loadPluginHomeCards() {
         pluginHomeCards = []
@@ -34,16 +36,14 @@ FluentPage {
     }
 
     Component.onCompleted: {
-        // 从后端获取活动信息（从 API https://launcher.bloret.net/api/info 获取）
-        Backend.refreshActivityInfo()
-        
+        // 先用本地/内存缓存填充 UI，再后台刷新远程数据（带 TTL，不阻塞导航）
         let realInfo = Backend.getActivityInfo()
         if (realInfo && Object.keys(realInfo).length > 0) {
             activityInfo = realInfo
         }
-        
+
         launchItems = Backend.getLaunchItems()
-        
+
         // 优先使用配置中保存的核心选择，若不存在或无效则回退到第一项
         var saved = Backend.getSelectedLaunchItem()
         var found = launchItems.find(function(item) { return item.name === saved })
@@ -53,9 +53,11 @@ FluentPage {
         } else if (launchItems.length > 0) {
             currentVersion = launchItems[0].name
         }
-        
+
         showAccountOnHome = Backend.getShowAccountOnHome()
-        
+        passPortAvatarUrl = Backend.getPassPortAvatar() || ""
+
+        Backend.refreshActivityInfo()
         Backend.refreshServerInfo()
         loadPluginHomeCards()
     }
@@ -69,6 +71,14 @@ FluentPage {
             if (data && Object.keys(data).length > 0) {
                 activityInfo = data
             }
+        }
+        function onPassPortAvatarChanged(url) {
+            passPortAvatarUrl = url || ""
+        }
+        function onMinecraftAccountsChanged(accounts) {
+            // 登录/切换账户后重新取缓存并可能触发后台下载
+            if (Backend)
+                passPortAvatarUrl = Backend.getPassPortAvatar() || ""
         }
     }
 
@@ -447,12 +457,9 @@ Rectangle {
                                     radius: 8
                                 }
                             }
-                            source: {
-                                let url = Backend ? Backend.getPassPortAvatar() : ""
-                                let finalUrl = url && url !== "" ? url : "../../icon/Grass_Block.png"
-                                console.log("[Home.qml] Avatar Image source:", finalUrl)
-                                return finalUrl
-                            }
+                            source: passPortAvatarUrl && passPortAvatarUrl !== ""
+                                    ? passPortAvatarUrl
+                                    : "../../icon/Grass_Block.png"
                             asynchronous: true
                             cache: false
                             fillMode: Image.PreserveAspectCrop

--- a/qml/pages/Home.qml
+++ b/qml/pages/Home.qml
@@ -36,7 +36,7 @@ FluentPage {
     }
 
     Component.onCompleted: {
-        // 先用本地/内存缓存填充 UI，再后台刷新远程数据（带 TTL，不阻塞导航）
+        // 同步路径只做本地读：先出页面骨架，再延后远程刷新，减轻侧边栏切换卡顿
         let realInfo = Backend.getActivityInfo()
         if (realInfo && Object.keys(realInfo).length > 0) {
             activityInfo = realInfo
@@ -57,9 +57,15 @@ FluentPage {
         showAccountOnHome = Backend.getShowAccountOnHome()
         passPortAvatarUrl = Backend.getPassPortAvatar() || ""
 
-        Backend.refreshActivityInfo()
-        Backend.refreshServerInfo()
-        loadPluginHomeCards()
+        // 插件卡片与远程刷新放到下一帧，让 StackView 动画/首帧先完成
+        Qt.callLater(function() {
+            if (!homePage) return
+            loadPluginHomeCards()
+            if (Backend) {
+                Backend.refreshActivityInfo()
+                Backend.refreshServerInfo()
+            }
+        })
     }
 
     Connections {

--- a/qml/pages/PassPort.qml
+++ b/qml/pages/PassPort.qml
@@ -12,6 +12,7 @@ FluentPage {
     property var accountList: []
     property string passportUser: ""
     property bool passportLoggedIn: false
+    property string passPortAvatarUrl: ""
 
     Component.onCompleted: {
         // 延迟更新确保 Backend 完全初始化
@@ -26,6 +27,8 @@ FluentPage {
                 passportLoggedIn = Backend.getBloretPassPortLoginStatus()
                 passportUser = Backend.getBloretPassPortUserName()
                 accountList = Backend.getMinecraftAccounts()
+                // 仅读本地缓存；缺失时后台下载，完成后 onPassPortAvatarChanged
+                passPortAvatarUrl = Backend.getPassPortAvatar() || ""
             } catch(e) {
                 console.log("Error updating passport data:", e)
             }
@@ -34,6 +37,9 @@ FluentPage {
 
     Connections {
         target: Backend
+        function onPassPortAvatarChanged(url) {
+            passPortAvatarUrl = url || ""
+        }
         function onMinecraftAccountsChanged(accounts) {
             if (Backend) {
                 try {
@@ -44,6 +50,7 @@ FluentPage {
                     }
                     passportLoggedIn = Backend.getBloretPassPortLoginStatus()
                     passportUser = Backend.getBloretPassPortUserName()
+                    passPortAvatarUrl = Backend.getPassPortAvatar() || ""
                 } catch(e) {
                     console.log("Error in onMinecraftAccountsChanged:", e)
                 }
@@ -117,14 +124,9 @@ FluentPage {
                                 radius: 8
                             }
                         }
-                        source: {
-                            let url = Backend ? Backend.getPassPortAvatar() : ""
-                            let finalUrl = url && url !== "" ? url : "../../icon/Grass_Block.png"
-                            console.log("[PassPort.qml] Image source changed")
-                            console.log("  Backend.getPassPortAvatar() returned:", url)
-                            console.log("  Final Image source:", finalUrl)
-                            return finalUrl
-                        }
+                        source: passPortAvatarUrl && passPortAvatarUrl !== ""
+                                ? passPortAvatarUrl
+                                : "../../icon/Grass_Block.png"
                         asynchronous: true
                         cache: false
                         fillMode: Image.PreserveAspectCrop


### PR DESCRIPTION
PassPort avatar no longer blocks the UI thread: read local cache first, download in the background, and notify via passPortAvatarChanged. Home activity/server refresh uses a 5-minute TTL and skips localmod; remote info/server requests get 5s timeouts so offline/slow nets cannot freeze navigation.

close #129 

**Not tested yet**