### PR TITLE
feat: Modrinth feature gap P0–P2 (content lifecycle + modern launcher UX)

### DIFF
--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -318,6 +318,16 @@ class Backend(QObject):
     # Resource Pack Editor signal
     resourcePackEditorRequested = Signal()
 
+    # P0–P2 feature signals
+    contentUpdatesReady = Signal(str, list)          # versionName, updates
+    contentActionFinished = Signal(str, str, bool, str)  # action, versionName, ok, message
+    instanceSettingsReady = Signal(str, "QVariant")  # versionName, settings
+    worldsListReady = Signal(str, list)
+    skinsListReady = Signal(list)
+    crashReportsReady = Signal(str, list)
+    importInstancesReady = Signal(list)
+    importInstanceFinished = Signal(bool, str, str)  # ok, name, message
+
     # Backdrop/acrylic effect signal
     backdropEffectChanged = Signal(str)
 
@@ -713,6 +723,12 @@ class Backend(QObject):
 
                 # 最终会话校验与 Popen 在同一把锁内串行化；取消操作也取得此锁，
                 # 从而消除“检查通过后、Popen 前”被取消的竞态。
+                try:
+                    from modules.services.feature_bridge import apply_pending_launch_side_effects
+                    _launch_env = apply_pending_launch_side_effects(None, _launch_env)
+                except Exception as _side_pre:
+                    print(f"[Launch] 预应用实例 env 失败: {_side_pre}")
+
                 with self._launch_start_lock:
                     if abort_if_cancelled("before_process_start"):
                         return
@@ -727,6 +743,12 @@ class Backend(QObject):
                         **hidden_process_kwargs(),
                     )
                     print(f"[Launch] Popen 已完成: session={launch_session_id}, pid={proc.pid}")
+
+                try:
+                    from modules.services.feature_bridge import apply_pending_launch_side_effects
+                    apply_pending_launch_side_effects(proc, None)
+                except Exception as _side:
+                    print(f"[Launch] post hook/discord 失败: {_side}")
 
                 import uuid as _uuid
                 instance_id = str(_uuid.uuid4())
@@ -1668,6 +1690,282 @@ class Backend(QObject):
     def showMrpackExport(self, versionName):
         self.mrpackExportRequested.emit(versionName)
 
+    # ---- P0–P2 feature slots ----
+    @Slot(str)
+    def checkContentUpdates(self, versionName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.check_content_updates(versionName)
+                updates = res.get("data") if res.get("ok") else []
+                self.contentUpdatesReady.emit(versionName, updates or [])
+                self.contentActionFinished.emit(
+                    "check_updates",
+                    versionName,
+                    bool(res.get("ok")),
+                    res.get("message") or f"{len(updates or [])} updates",
+                )
+            except Exception as e:
+                self.contentUpdatesReady.emit(versionName, [])
+                self.contentActionFinished.emit("check_updates", versionName, False, str(e))
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str)
+    def updateAllContent(self, versionName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                def progress_cb(frac, status):
+                    self.downloadProgressUpdated.emit(float(frac) * 100.0, status or "", "", "", "")
+                self.downloadDialogRequested.emit(str(self.tr("更新内容")) + f": {versionName}")
+                res = fb.update_all_content(versionName, progress_cb=progress_cb)
+                ok = bool(res.get("ok"))
+                msg = res.get("message") or json.dumps(res.get("data") or {}, ensure_ascii=False)[:200]
+                self.downloadCompleted.emit(msg)
+                self.contentActionFinished.emit("update_all", versionName, ok, msg)
+            except Exception as e:
+                self.downloadCompleted.emit(str(e))
+                self.contentActionFinished.emit("update_all", versionName, False, str(e))
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str)
+    def enrichContentIndex(self, versionName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.scan_and_enrich(versionName)
+                self.contentActionFinished.emit(
+                    "enrich",
+                    versionName,
+                    bool(res.get("ok")),
+                    res.get("message") or json.dumps(res.get("data") or {}, ensure_ascii=False)[:200],
+                )
+            except Exception as e:
+                self.contentActionFinished.emit("enrich", versionName, False, str(e))
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str, result="QVariant")
+    def getInstanceSettings(self, versionName):
+        try:
+            from modules.services import feature_bridge as fb
+            res = fb.get_instance_settings(versionName)
+            return res.get("data") if res.get("ok") else {}
+        except Exception as e:
+            print(f"getInstanceSettings: {e}")
+            return {}
+
+    @Slot(str, "QVariant", result=bool)
+    def saveInstanceSettings(self, versionName, patch):
+        try:
+            from modules.services import feature_bridge as fb
+            data = dict(patch) if patch else {}
+            res = fb.save_instance_settings(versionName, data)
+            if res.get("ok"):
+                self.instanceSettingsReady.emit(versionName, res.get("data") or {})
+            return bool(res.get("ok"))
+        except Exception as e:
+            print(f"saveInstanceSettings: {e}")
+            return False
+
+    @Slot(str)
+    def requestWorlds(self, versionName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.list_worlds(versionName)
+                self.worldsListReady.emit(versionName, res.get("data") or [])
+            except Exception:
+                self.worldsListReady.emit(versionName, [])
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str, str, result=bool)
+    def setQuickPlayWorld(self, versionName, worldFolder):
+        try:
+            from modules.services import feature_bridge as fb
+            return bool(fb.set_quick_play_world(versionName, worldFolder).get("ok"))
+        except Exception:
+            return False
+
+    @Slot(str, str, int, result=bool)
+    def setQuickPlayServer(self, versionName, address, port):
+        try:
+            from modules.services import feature_bridge as fb
+            return bool(fb.set_quick_play_server(versionName, address, int(port or 0)).get("ok"))
+        except Exception:
+            return False
+
+    @Slot(str, result=bool)
+    def clearQuickPlay(self, versionName):
+        try:
+            from modules.services import feature_bridge as fb
+            return bool(fb.clear_quick_play(versionName).get("ok"))
+        except Exception:
+            return False
+
+    @Slot()
+    def requestSkins(self):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.list_skins()
+                self.skinsListReady.emit(res.get("data") or [])
+            except Exception:
+                self.skinsListReady.emit([])
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str, str, str, result="QVariant")
+    def importSkinFile(self, path, name, variant):
+        try:
+            from modules.services import feature_bridge as fb
+            return fb.import_skin(path, name=name or "", variant=variant or "classic")
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+
+    @Slot(str, result=bool)
+    def deleteSkin(self, skinId):
+        try:
+            from modules.services import feature_bridge as fb
+            return bool(fb.delete_skin(skinId).get("ok"))
+        except Exception:
+            return False
+
+    @Slot(str, str, result="QVariant")
+    def equipSkin(self, skinId, variant):
+        try:
+            from modules.services import feature_bridge as fb
+            return fb.equip_skin(skinId, variant=variant or "")
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+
+    @Slot(result=str)
+    def selectSkinPng(self):
+        try:
+            from PySide6.QtWidgets import QFileDialog
+            path, _ = QFileDialog.getOpenFileName(
+                None,
+                self.tr("选择皮肤 PNG"),
+                "",
+                "PNG Images (*.png)",
+            )
+            return path or ""
+        except Exception as e:
+            print(f"selectSkinPng: {e}")
+            return ""
+
+    @Slot(result=str)
+    def selectImportLauncherFolder(self):
+        try:
+            from PySide6.QtWidgets import QFileDialog
+            path = QFileDialog.getExistingDirectory(
+                None,
+                self.tr("选择 Prism / MultiMC 目录或 instances 目录"),
+                "",
+            )
+            return path or ""
+        except Exception as e:
+            print(f"selectImportLauncherFolder: {e}")
+            return ""
+
+    @Slot(str)
+    def requestCrashReports(self, versionName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.list_crashes(versionName)
+                self.crashReportsReady.emit(versionName, res.get("data") or [])
+            except Exception:
+                self.crashReportsReady.emit(versionName, [])
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str, result="QVariant")
+    def readCrashLog(self, path):
+        try:
+            from modules.services import feature_bridge as fb
+            return fb.read_crash_log(path)
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+
+    @Slot(str)
+    def requestImportableInstances(self, basePath):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.list_importable(basePath)
+                self.importInstancesReady.emit(res.get("data") or [])
+            except Exception:
+                self.importInstancesReady.emit([])
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(str, str)
+    def importExternalInstance(self, path, targetName):
+        def _run():
+            try:
+                from modules.services import feature_bridge as fb
+                res = fb.import_instance(path, target_name=targetName or "")
+                ok = bool(res.get("ok"))
+                data = res.get("data") or {}
+                name = data.get("name") or targetName or ""
+                msg = res.get("message") or data.get("note") or ("ok" if ok else "failed")
+                if ok:
+                    self.invalidateLaunchItemsCache()
+                self.importInstanceFinished.emit(ok, name, str(msg))
+            except Exception as e:
+                self.importInstanceFinished.emit(False, "", str(e))
+        threading.Thread(target=_run, daemon=True).start()
+
+    @Slot(result="QVariant")
+    def getDefaultImportPaths(self):
+        try:
+            from modules.services import feature_bridge as fb
+            return fb.default_import_paths()
+        except Exception:
+            return {"ok": False, "prism": "", "multimc": ""}
+
+    @Slot(str, result="QVariant")
+    def getMrpackExportCandidates(self, versionName):
+        try:
+            config_data = cfg.read()
+            mc_dir = config_data.get("minecraft_dir", BLglobals.minecraft_dir)
+            path = os.path.join(mc_dir, "versions", versionName)
+            from modules.services import feature_bridge as fb
+            return fb.mrpack_export_candidates(path)
+        except Exception as e:
+            return {"ok": False, "message": str(e)}
+
+    @Slot(bool)
+    def setDiscordRpcEnabled(self, enabled):
+        try:
+            from modules.services import feature_bridge as fb
+            fb.set_discord_rpc(bool(enabled))
+        except Exception as e:
+            print(f"setDiscordRpcEnabled: {e}")
+
+    @Slot(result=bool)
+    def isDiscordRpcEnabled(self):
+        try:
+            from modules.services.runtime_extras import discord_is_enabled
+            return bool(discord_is_enabled())
+        except Exception:
+            return False
+
+    @Slot(str, result="QVariant")
+    def listShaderpacks(self, versionName):
+        try:
+            from modules.services.content_service import list_shaderpacks
+            res = list_shaderpacks(versionName)
+            return res.data if res.ok else []
+        except Exception:
+            return []
+
+    @Slot(str, result="QVariant")
+    def listDatapacks(self, versionName):
+        try:
+            from modules.services.content_service import list_datapacks
+            res = list_datapacks(versionName)
+            return res.data if res.ok else []
+        except Exception:
+            return []
+
     @Slot(str, result="QVariant")
     def getCoreData(self, versionName):
         try:
@@ -2481,6 +2779,13 @@ class Backend(QObject):
         print(f"Requested download NeoForge: {version} as {versionName}")
         dm = DownloadManager()
         dm.start_download(version, versionName, "neoforge", self)
+
+    @Slot(str, str)
+    def downloadQuilt(self, version, versionName):
+        from modules.download_manager import DownloadManager
+        print(f"Requested download Quilt: {version} as {versionName}")
+        dm = DownloadManager()
+        dm.start_download(version, versionName, "quilt", self)
 
     @Slot()
     def toggleDownloadPause(self):
@@ -3629,80 +3934,36 @@ class Backend(QObject):
 
     def _download_one_mod(self, mod_id, version_name, progress_cb=None):
         """
-        同步下载单个模组到 versions/{version_name}/mods。
-
-        progress_cb(frac 0-1, status_str) 可选。
-        Returns:
-            tuple: (ok: bool, message: str)
+        同步下载单个模组（含 required 依赖）到 versions/{version_name}/mods，
+        并写入 content-index。
         """
-        from modules.modrinth import Get_Mod_File_Download_Url
         from modules.log import log as _log
         import logging as _logging
-
         try:
-            config_data = cfg.read()
-            mc_dir = config_data.get("minecraft_dir", BLglobals.minecraft_dir)
-            game_version = self._resolve_game_version_for_folder(version_name, mc_dir)
-            _log(
-                f"[ModInstall] 下载 {mod_id} -> {version_name} (mc={game_version})",
-                _logging.INFO,
-            )
-            if progress_cb:
-                progress_cb(0.05, f"解析下载地址: {mod_id}")
+            from modules.services.content_lifecycle import install_project
+            from modules.services.paths_util import detect_loader
 
-            url = Get_Mod_File_Download_Url(
+            loader = detect_loader(version_name)
+            loaders = [loader] if loader not in ("", "vanilla") else None
+            res = install_project(
+                version_name,
                 mod_id,
-                loaders=["fabric"],
-                game_versions=[game_version] if game_version else None,
+                with_dependencies=True,
+                project_type="mod",
+                loaders=loaders,
+                progress_cb=progress_cb,
             )
-            if not url:
-                url = Get_Mod_File_Download_Url(
-                    mod_id,
-                    loaders=None,
-                    game_versions=[game_version] if game_version else None,
-                )
-            if not url:
-                msg = f"未找到 {mod_id} 的下载链接"
-                _log(f"[ModInstall] {msg}", _logging.WARNING)
-                return False, msg
-
-            filename = url.split("/")[-1].split("?")[0]
-            if not filename or "." not in filename:
-                filename = f"{mod_id}.jar"
-            if filename.endswith(".mrpack"):
-                return False, f"{mod_id}: 得到 mrpack 而非 jar，已跳过"
-
-            mods_dir = os.path.join(mc_dir, "versions", version_name, "mods")
-            os.makedirs(mods_dir, exist_ok=True)
-            file_path = os.path.join(mods_dir, filename)
-
-            if progress_cb:
-                progress_cb(0.1, f"下载中: {filename}")
-
-            with requests.get(url, timeout=120, stream=True) as response:
-                if response.status_code != 200:
-                    msg = f"{mod_id}: HTTP {response.status_code}"
-                    _log(f"[ModInstall] {msg}", _logging.ERROR)
-                    return False, msg
-                total = int(response.headers.get("Content-Length") or 0)
-                downloaded = 0
-                chunk_size = 64 * 1024
-                with open(file_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=chunk_size):
-                        if not chunk:
-                            continue
-                        f.write(chunk)
-                        downloaded += len(chunk)
-                        if progress_cb and total > 0:
-                            frac = 0.1 + 0.9 * min(1.0, downloaded / total)
-                            mb_d = downloaded / (1024 * 1024)
-                            mb_t = total / (1024 * 1024)
-                            progress_cb(frac, f"下载中: {filename} ({mb_d:.1f}/{mb_t:.1f} MB)")
-                        elif progress_cb and downloaded % (512 * 1024) < chunk_size:
-                            progress_cb(0.5, f"下载中: {filename} ({downloaded // 1024} KB)")
-
-            _log(f"[ModInstall] 成功: {file_path}", _logging.INFO)
-            return True, f"{filename} -> {mods_dir}"
+            if res.ok:
+                data = res.data or {}
+                n = int(data.get("count") or 0)
+                fails = data.get("failed") or []
+                msg = f"{mod_id}: 安装 {n} 个文件"
+                if fails:
+                    msg += f"（部分失败: {', '.join(fails[:2])}）"
+                _log(f"[ModInstall] 成功: {msg}", _logging.INFO)
+                return True, msg
+            _log(f"[ModInstall] 失败 {mod_id}: {res.error}", _logging.WARNING)
+            return False, res.error or "install failed"
         except Exception as e:
             _log(f"[ModInstall] 异常 {mod_id}: {e}", _logging.ERROR)
             import traceback

--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -1551,7 +1551,7 @@ class Backend(QObject):
             print(f"获取实例信息失败：{e}")
             return {}
 
-    def _export_mrpack_sync(self, versionName, packName, packVersion, outputPath):
+    def _export_mrpack_sync(self, versionName, packName, packVersion, outputPath, selected_paths=None):
         from modules.mrpack_export import export_to_mrpack
         config_data = cfg.read()
         minecraft_dir = config_data.get('minecraft_dir', BLglobals.minecraft_dir)
@@ -1560,7 +1560,14 @@ class Backend(QObject):
         summary = f"从 {versionName} 导出的整合包"
         temp_path = actual_path + f".{threading.get_ident()}.part"
         try:
-            success = export_to_mrpack(instance_path, temp_path, packName, packVersion, summary)
+            success = export_to_mrpack(
+                instance_path,
+                temp_path,
+                packName,
+                packVersion,
+                summary,
+                selected_paths=selected_paths,
+            )
             if success:
                 os.replace(temp_path, actual_path)
             return bool(success), actual_path, "" if success else "导出失败"
@@ -1582,6 +1589,12 @@ class Backend(QObject):
 
     @Slot(str, str, str, str, str, result=bool)
     def requestMrpackExport(self, versionName, packName, packVersion, outputPath, requestId):
+        return self.requestMrpackExportWithSelection(
+            versionName, packName, packVersion, outputPath, requestId, []
+        )
+
+    @Slot(str, str, str, str, str, "QVariantList", result=bool)
+    def requestMrpackExportWithSelection(self, versionName, packName, packVersion, outputPath, requestId, selectedPaths):
         actual_path = outputPath if outputPath.lower().endswith('.mrpack') else outputPath + '.mrpack'
         path_key = os.path.normcase(os.path.abspath(actual_path))
         with self._export_paths_lock:
@@ -1589,12 +1602,19 @@ class Backend(QObject):
                 return False
             self._active_export_paths.add(path_key)
 
+        selected = None
+        try:
+            cleaned = [str(x) for x in (list(selectedPaths) if selectedPaths is not None else []) if x]
+            selected = cleaned if cleaned else None
+        except Exception:
+            selected = None
+
         def _run():
             success = False
             error = ""
             try:
                 success, _, error = self._export_mrpack_sync(
-                    versionName, packName, packVersion, outputPath
+                    versionName, packName, packVersion, outputPath, selected_paths=selected
                 )
             except Exception as exc:
                 error = str(exc)
@@ -1965,6 +1985,33 @@ class Backend(QObject):
             return res.data if res.ok else []
         except Exception:
             return []
+
+    @Slot(str, bool, result=bool)
+    def toggleContentPack(self, path, enabled):
+        try:
+            from modules.services.content_service import toggle_pack_enabled
+            return bool(toggle_pack_enabled(path, bool(enabled)).ok)
+        except Exception as e:
+            print(f"toggleContentPack: {e}")
+            return False
+
+    @Slot(str, result=bool)
+    def deleteContentPack(self, path):
+        try:
+            from PySide6.QtWidgets import QMessageBox
+            reply = QMessageBox.question(
+                None,
+                self.tr("确认删除"),
+                f"{self.tr('将删除')}: {os.path.basename(path)}",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return False
+            from modules.services.content_service import delete_content_path
+            return bool(delete_content_path(path).ok)
+        except Exception as e:
+            print(f"deleteContentPack: {e}")
+            return False
 
     @Slot(str, result="QVariant")
     def getCoreData(self, versionName):

--- a/docs/modrinth-feature-gap-analysis.md
+++ b/docs/modrinth-feature-gap-analysis.md
@@ -1,0 +1,282 @@
+# Bloret Launcher vs Modrinth App 功能差距分析
+
+> 分支：`analysis/modrinth-feature-gap`  
+> 对照源码：`/data/modrinth-code`（sparse checkout：`apps/app` + `apps/app-frontend` + `packages/app-lib` + `packages/daedalus`）  
+> 对照仓库：https://github.com/modrinth/code  
+> 分析日期：2026-08-05
+
+## 0. 一句话结论
+
+| 维度 | Bloret | Modrinth App |
+|------|--------|--------------|
+| 定位 | AI + 联机 + 通行证 + 插件的「个人创新启动器」 | 内容生态 + 实例管理 + 社交同步的「Modrinth 官方客户端」 |
+| 技术栈 | Python + PySide6/RinUI (QML) | Rust (Theseus) + Vue + Tauri |
+| 架构模型 | 版本目录（`.minecraft/versions/<name>`） | 真·实例（独立目录 + SQLite 元数据） |
+| 独有优势 | AI、EasyTier/Live、PassPort、资源包编辑器、插件宿主、FreeBSD | 整合包生态深度、跨启动器导入、Shared Instance、好友、皮肤库、Hosting |
+| 最大短板（相对对方） | 内容/实例/社交基础设施偏薄 | 无 AI、无国内联机、无自有通行证生态 |
+
+**不要照搬 Modrinth 全套。** 优先补「用户迁移成本 + 内容生命周期」相关缺口；AI/联机/PassPort 继续当差异化护城河。
+
+---
+
+## 1. 源码地图
+
+### Modrinth App（Theseus）
+
+```
+packages/app-lib/src/
+  api/          # 对外能力面
+    instance/   # 实例生命周期 / 内容 / 导出 / Shared
+    pack/       # mrpack 安装 + 跨启动器导入
+    minecraft_skins / worlds / friends / process / jre / logs ...
+  launcher/     # 参数、下载、hooks、Quick Play
+  install/      # 安装流水线（可恢复、分阶段进度）
+  state/        # SQLite + Discord RPC + 好友 socket
+apps/app-frontend/src/pages/
+  library/ instance/ project/ Browse / Skins / Servers / hosting/
+```
+
+### Bloret Launcher
+
+```
+Bloret-Launcher.py          # Backend 大一统（~6k 行）
+modules/
+  install / launch / versions / modrinth / mrpack_export
+  easytier / bbbs_live / Bloriko / plugin_host / resourcepack_editor
+  services/{versions,content,launch,config}_service
+qml/pages/
+  Home Download Cores Mods Live Multiplayer Bloriko PassPort Tools Settings ...
+```
+
+---
+
+## 2. 功能对照总表
+
+图例：✅ 有　🟡 部分/简陋　❌ 无　⭐ 我方独有
+
+| 能力域 | Bloret | Modrinth | 差距等级 |
+|--------|--------|----------|----------|
+| 原版安装 | ✅ | ✅ | — |
+| Fabric | ✅ | ✅ | — |
+| Forge / NeoForge | ✅ | ✅ | — |
+| Quilt | ❌ | ✅ | 中 |
+| 实例/版本管理 | 🟡 版本目录 | ✅ 真实例 + SQLite | **高** |
+| 每实例设置（内存/分辨率/Java/env/hooks） | 🟡 偏全局 | ✅ 实例级完整 | **高** |
+| mrpack 导入 | ✅ | ✅ 深度（依赖、hash、并发） | 中 |
+| mrpack 导出 | ✅ 基础 | ✅ 候选文件树 + 智能默认勾选 | 中 |
+| 跨启动器导入（Prism/MMC/ATL/GDL/CF） | ❌ | ✅ | **高** |
+| CurseForge 内容源 | ❌ | 🟡 导入侧有 | 中 |
+| Mod 安装（Modrinth） | ✅ | ✅ + 依赖解析 | **高** |
+| Mod 一键更新 / 全量更新 | ❌/弱 | ✅ `update_all_projects` | **高** |
+| 内容修复 repair | ❌ | ✅ `repair_managed_modrinth` | 中 |
+| 依赖自动安装 | ❌ | ✅ `install_project_with_dependencies` | **高** |
+| 资源包 / 光影 / 数据包 | 🟡 资源包为主；浏览含 shader/datapack | ✅ 一等公民 content type | 中 |
+| 服务器列表 | ✅ | ✅ worlds 统一模型 | 低 |
+| 单人世界浏览 / 编辑 / 导出 | ❌ | ✅ worlds API（NBT、icon、last played） | **高** |
+| Quick Play（直进世界/服务器） | ❌ | ✅ Builtin/Legacy/Injected | **高** |
+| 皮肤管理（上传/装备/披风/预览） | 🟡 仅 URL 查询 | ✅ 完整皮肤库 | **高** |
+| 微软账号 | ✅ | ✅ | — |
+| 离线账号 | ✅ | ❌/弱 | ⭐ |
+| Bloret PassPort | ✅ | ❌ | ⭐ |
+| Shared Instance（云同步分享） | ❌ | ✅ 邀请/角色/内容 diff/config bundle | **高** |
+| 好友在线状态 | ❌ | ✅ friends socket | 中 |
+| Discord Rich Presence | ❌ | ✅ | 低 |
+| 启动 Hooks（pre/wrapper/post） | 🟡 插件 hook，非用户实例 hook | ✅ 用户可配 hooks | 中 |
+| 进程管理 | ✅ | ✅ UUID 级 | 低 |
+| 日志 / 崩溃报告 | 🟡 日志 | ✅ InfoLog + CrashReport + 脱敏 | 中 |
+| 游玩时长 | ✅ 细（焦点/日统计） | 🟡 有 playtime | ⭐ 我方更细 |
+| Hosting（租用服务器面板） | ❌ | ✅ hosting/* | 低（商业能力） |
+| 安装进度 / 可恢复安装 | 🟡 | ✅ InstallPhase + recovery | 中 |
+| 自动 Java | ✅ | ✅ | — |
+| 自动更新启动器 | ✅ | ✅ | — |
+| 插件系统 | ✅ | ❌ | ⭐ |
+| AI 助手 Bloriko | ✅ | ❌ | ⭐ |
+| 资源包编辑器 | ✅ | ❌ | ⭐ |
+| EasyTier / Live 联机 | ✅ | ❌ | ⭐ |
+| FreeBSD | ✅ | ❌ | ⭐ |
+| 托盘 / 浮动工具栏 | ✅ | ❌/弱 | ⭐ |
+| 深浅色 / i18n | ✅ | ✅（语种更多） | 低 |
+| 架构：状态持久化 | JSON 配置 | SQLite + 迁移 + 备份 | **高** |
+
+---
+
+## 3. 结构性差距（比「缺功能」更重要）
+
+### 3.1 实例模型
+
+**Modrinth**：每个实例独立目录 + `instances` 表元数据；内容用 content set / content item 建模；支持 linked modpack、managed content、sync state。
+
+**Bloret**：更接近「一个 Minecraft 根目录下的多个 version 文件夹」；`bl.json` 做轻量标注。
+
+影响：
+- 很难做干净的实例级设置、实例复制、共享同步
+- 内容更新/依赖图难做（没有 content 实体层）
+- 跨启动器导入/导出语义对不齐
+
+**建议**：不必立刻 SQLite 化全盘，但应引入 **Instance 抽象层**（路径、loader、MC 版本、内容清单、设置 overrides），现有 version 目录做 adapter。
+
+### 3.2 内容生命周期
+
+Modrinth `projects.rs` 已有：
+- `install_project_with_dependencies`
+- `switch_project_version_with_dependencies`
+- `update_all_projects` / `update_project`
+- `repair_managed_modrinth`
+- hash → Modrinth 文件反查（`is_file_on_modrinth`）
+
+Bloret 目前：
+- 能下 Mod、能列本地 jar、能开关/删
+- **缺依赖图、缺批量更新、缺修复、缺「这个 jar 对应哪个 project/version」的稳定映射**
+
+这是用户感知最强的差距之一（「为什么 Modrinth 一键更新，我们要一个个找」）。
+
+### 3.3 安装流水线
+
+Modrinth `install/`：分 phase、进度事件、recovery、shared instance 安装数据。
+
+Bloret `install.py` 很重（~2.5k 行）但阶段语义、失败恢复、取消一致性仍偏脚本化。
+
+---
+
+## 4. 按优先级的缺失清单
+
+### P0 — 直接影响「能不能当主力启动器」
+
+| # | 缺口 | 说明 | 参考 |
+|---|------|------|------|
+| 1 | **Mod 依赖自动解析与安装** | 装一个模组应拉齐 required 依赖 | `install_project_with_dependencies` |
+| 2 | **已装内容检测更新 / 一键更新** | 按 hash 或 project_id 对照 Modrinth | `update_all_projects` / `check_content_updates` |
+| 3 | **内容元数据持久化** | 记录 project_id / version_id / hash / 文件路径 | content set 模型 |
+| 4 | **实例级设置** | 内存、Java、JVM 参数、环境变量、窗口、自定义目录 | instance settings modal |
+
+### P1 — 迁移与生态
+
+| # | 缺口 | 说明 | 参考 |
+|---|------|------|------|
+| 5 | **从 Prism / MultiMC / ATL / GDL / CurseForge 导入** | 用户换启动器零成本 | `api/pack/import/*` |
+| 6 | **Quilt 安装** | 加载器矩阵补全 | ModLoader |
+| 7 | **更强的 mrpack 导出** | 文件树勾选、默认路径、排除缓存/native | `export_mrpack` candidates |
+| 8 | **光影包 / 数据包一等管理** | 与 mods/resourcepacks 同级 UI + 服务 | content types |
+
+### P2 — 体验与「现代启动器」体感
+
+| # | 缺口 | 说明 | 参考 |
+|---|------|------|------|
+| 9 | **世界管理 + Quick Play** | 主页最近世界、直进单人/服务器 | `api/worlds.rs` + `quick_play_version.rs` |
+| 10 | **皮肤库** | 保存/上传/装备/披风/模型变体，不只查 URL | `api/minecraft_skins` |
+| 11 | **用户级 Launch Hooks** | pre-launch / wrapper / post-exit | `launcher/hooks.rs` |
+| 12 | **崩溃报告浏览 + 日志脱敏** | 启动失败可自助 | `api/logs.rs` |
+| 13 | **Discord RPC** | 可选，成本低 | `state/discord.rs` |
+
+### P3 — 可后置 / 或用差异化替代
+
+| # | 缺口 | 说明 |
+|---|------|------|
+| 14 | Shared Instance 云同步 | 强依赖 Modrinth 账号与后端；可用 EasyTier + 整合包分享部分替代 |
+| 15 | Friends 社交 | 同上；Live 房间已是另一种社交 |
+| 16 | Hosting 面板 | 商业能力，非启动器核心 |
+| 17 | Feature flags / 遥测 | 工程设施，非用户功能 |
+
+---
+
+## 5. Bloret 已领先 / 不该丢掉的差异化
+
+这些是 **Modrinth 没有、我们有** 的，分析时不要被「缺功能」带偏：
+
+1. **Bloriko AI**（对话装模组、DeepThink、多 IM connector）
+2. **EasyTier + BBBS Live 联机**（免端口映射的房间制联机）
+3. **Bloret PassPort**（自有账号体系 + 与微软/离线融合）
+4. **资源包编辑器**（整套 Agent + 纹理/模型/音效/语言…）
+5. **插件宿主**（hooks / 权限 / 进程与声明式加载）
+6. **细粒度游玩统计**（焦点时间、日统计）
+7. **FreeBSD / 托盘 / 浮动工具栏 / Bark 通知** 等桌面体验
+
+策略建议：**用 AI + 联机降低「内容管理不足」的痛感，同时把 P0 内容生命周期补齐**，而不是去堆 Shared Instance / Hosting。
+
+---
+
+## 6. 建议落地路线（可执行）
+
+### Phase A — 内容实体层（2–4 周量级）
+
+1. 为每个 version/instance 增加 `content-index.json`（或 SQLite 表）：
+   - path, sha1/sha512, project_id, version_id, source(modrinth/local), enabled
+2. 安装 Mod 时写入索引；本地扫描 jar 时尝试 hash 反查 Modrinth
+3. UI：Mods 页显示「可更新」角标
+
+### Phase B — 依赖与更新（接 A）
+
+1. 调 Labrinth dependencies API，装 required
+2. `更新全部` / `更新选中`
+3. 可选：`修复`（按 version_id 重下）
+
+### Phase C — 实例设置与导入
+
+1. 实例 overrides：memory / java / jvm args / env / resolution
+2. Prism/MultiMC 导入（二者格式接近，ROI 最高）
+3. Quilt
+
+### Phase D — 体验件
+
+1. Quick Play（至少服务器直进；单人世界 NBT 解析可复用现有 `SimpleNBT`）
+2. 皮肤库 MVP（本地保存 + 装备到微软账号）
+3. 用户 hooks + Discord RPC
+
+---
+
+## 7. 风险与注意
+
+- **许可证**：Modrinth monorepo 各包许可证不同，**禁止直接拷代码**；只学模型与流程。
+- **实例模型迁移**：现有用户 version 目录不能破坏；用 adapter + 渐进迁移。
+- **主文件过大**：`Bloret-Launcher.py` ~6k 行，新能力应进 `modules/services/` + QML，避免继续堆 Backend。
+- **不要为对齐而对齐**：Shared Instance / Hosting 没有自有后端就不要硬做壳。
+
+---
+
+## 8. 本地对照路径
+
+| 用途 | 路径 |
+|------|------|
+| 本分析文档 | `/data/Bloret-Launcher/docs/modrinth-feature-gap-analysis.md` |
+| Bloret 分支 | `analysis/modrinth-feature-gap`（基于 `Windows`） |
+| Modrinth 源码（sparse） | `/data/modrinth-code` |
+| Modrinth 能力面入口 | `packages/app-lib/src/api/mod.rs` |
+| 导入实现 | `packages/app-lib/src/api/pack/import/` |
+| 内容/依赖 | `packages/app-lib/src/api/instance/projects.rs` |
+| 世界 / Quick Play | `api/worlds.rs` + `launcher/quick_play_version.rs` |
+| 皮肤 | `api/minecraft_skins.rs` |
+| Shared Instance | `api/instance/shared/` |
+
+---
+
+## 9. 总结
+
+Bloret 在 **AI、联机、通行证、插件、资源包创作** 上已经走出差异化；  
+相对官方 Modrinth App，短板集中在：
+
+1. **真实例 + 持久化内容模型**  
+2. **依赖 / 更新 / 修复的内容生命周期**  
+3. **跨启动器迁移**  
+4. **世界 / 皮肤 / Quick Play 等「现代启动器」体感**
+
+先做 P0（内容索引 + 依赖 + 更新），再做导入与实例设置，性价比最高。
+
+---
+
+## 10. 实现状态（analysis/modrinth-feature-gap，2026-08-05）
+
+| 项 | 状态 | 落点 |
+|----|------|------|
+| P0 content-index + hash | ✅ | `modules/services/content_index.py` |
+| P0 依赖安装 / 一键更新 | ✅ | `content_lifecycle.py` + `modrinth_content.py`；`Backend._download_one_mod` 已走依赖安装 |
+| P0 实例级设置 | ✅ | `instance_settings.py`；`launch.py` 合并 overrides；CoreManager 高级页 UI |
+| P1 Prism/MMC 导入 | ✅ 服务层 | `instance_import.py` + Backend slots |
+| P1 Quilt | ✅ | `install.py` Quilt 分支；Download.qml 卡片；`downloadQuilt` |
+| P1 光影/数据包 | ✅ | content_service list + 安装目录创建 |
+| P1 mrpack 候选导出 | ✅ | `mrpack_export.get_export_candidates` / selected_paths |
+| P2 世界 + Quick Play | ✅ | `worlds_service.py`；CoreManager 世界页；launch 注入参数 |
+| P2 皮肤库 | ✅ 服务层 | `skins_service.py` + Backend slots（独立皮肤页 UI 可再补） |
+| P2 hooks / Discord / 崩溃日志 | ✅ | `runtime_extras.py`；launch + feature_bridge |
+| 单测 | ✅ | `test_p0_p2_features.py`（7 passed） |
+
+验证：`python3 test_p0_p2_features.py -v`

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -55,6 +55,7 @@ git_protocol = "https"  # "https" | "ssh"  Git 连接方式
 git_ssh_available = None  # None=未检测, True=可用, False=不可用
 current_minecraft_version = None  # 当前安装中的 Minecraft 版本，供 gitcode 源使用
 proxy = ""  # 网络代理地址，如 "http://127.0.0.1:7890"，为空则不使用代理
+_pending_launch_hooks = None  # launch.py 写入；Backend 启动后消费
 
 def get_proxies():
     """根据 proxy 设置返回 requests 库可用的 proxies 字典"""

--- a/modules/install.py
+++ b/modules/install.py
@@ -730,6 +730,8 @@ def _install_forge_like_loader(loader_type, minecraft_version, minecraft_dir, ve
 
     os.makedirs(os.path.join(target_dir, "mods"), exist_ok=True)
     os.makedirs(os.path.join(target_dir, "resourcepacks"), exist_ok=True)
+    os.makedirs(os.path.join(target_dir, "shaderpacks"), exist_ok=True)
+    os.makedirs(os.path.join(target_dir, "datapacks"), exist_ok=True)
     return target_id
 
 # 初始化全局变量
@@ -2208,6 +2210,145 @@ def _install_minecraft_version_threaded(version, minecraft_dir=None, Fabric_Load
                         )
 
                 update_progress_ui(88, i18nText("资源文件下载完成!"), "", f"{assets_count}", f"{assets_count}")
+
+        # 如果需要安装 Quilt Loader（API 与 Fabric meta 同形）
+        if Loader_Type == "quilt":
+            log(f"开始安装 Quilt Loader 到 Minecraft {version}")
+            update_progress({
+                'status': f'正在安装 Quilt Loader...',
+                'value': 0.9,
+                'valueStringOverride': '90%'
+            })
+            try:
+                quilt_api_urls = dl_source_launcher_or_meta_get(
+                    "https://meta.quiltmc.org/v3/versions/loader/" + version
+                )
+                log(f"正在获取 Quilt Loader 版本列表: {quilt_api_urls}")
+                quilt_versions = None
+                for url in quilt_api_urls:
+                    try:
+                        qr = get_session().get(url, timeout=30)
+                        if qr.status_code == 200:
+                            quilt_versions = qr.json()
+                            break
+                        log(f"获取 Quilt Loader 版本列表失败: {url}, HTTP {qr.status_code}", logging.WARNING)
+                    except requests.exceptions.RequestException as e:
+                        log(f"请求错误: {url}, {e}", logging.WARNING)
+                if not quilt_versions:
+                    raise RuntimeError(f"未找到适用于 Minecraft {version} 的 Quilt Loader 版本")
+                latest_quilt = quilt_versions[0]
+                loader_version = latest_quilt["loader"]["version"]
+                log(f"找到最新的 Quilt Loader 版本: {loader_version}")
+                quilt_version_id = f"{VersionName}-Quilt {loader_version}"
+                quilt_version_dir = os.path.join(versions_dir, quilt_version_id)
+                os.makedirs(quilt_version_dir, exist_ok=True)
+                quilt_json_urls = dl_source_launcher_or_meta_get(
+                    f"https://meta.quiltmc.org/v3/versions/loader/{version}/{loader_version}/profile/json"
+                )
+                quilt_json_data = None
+                for url in quilt_json_urls:
+                    try:
+                        qjr = get_session().get(url, timeout=30)
+                        if qjr.status_code == 200:
+                            quilt_json_data = qjr.json()
+                            break
+                    except requests.exceptions.RequestException as e:
+                        log(f"请求错误: {url}, {e}", logging.WARNING)
+                if not quilt_json_data:
+                    raise RuntimeError("所有 Quilt 安装 JSON URL 均获取失败")
+                quilt_json_data["id"] = quilt_version_id
+                original_version_data = version_data
+                if original_version_data is None:
+                    original_version_data, _ = _load_version_json(version_dir, VersionName, version)
+                if "downloads" not in quilt_json_data and original_version_data:
+                    for key in (
+                        "assetIndex", "assets", "complianceLevel", "javaVersion",
+                        "logging", "minimumLauncherVersion", "releaseTime", "time", "type",
+                    ):
+                        if key in original_version_data:
+                            quilt_json_data[key] = original_version_data[key]
+                    original_libraries = original_version_data.get("libraries", [])
+                    quilt_libraries = quilt_json_data.get("libraries", [])
+                    existing_lib_names = {lib.get("name", "") for lib in quilt_libraries}
+                    for lib in original_libraries:
+                        name = lib.get("name", "")
+                        if name not in existing_lib_names:
+                            quilt_libraries.append(lib)
+                            existing_lib_names.add(name)
+                    quilt_json_data["libraries"] = quilt_libraries
+                quilt_json_data.pop("inheritsFrom", None)
+                quilt_json_data.pop("jar", None)
+                quilt_json_path = os.path.join(quilt_version_dir, f"{quilt_version_id}.json")
+                with open(quilt_json_path, "w", encoding="utf-8") as f:
+                    json.dump(quilt_json_data, f, ensure_ascii=False, indent=4)
+                quilt_client_jar_path = os.path.join(quilt_version_dir, f"{quilt_version_id}.jar")
+                if "downloads" in quilt_json_data and "client" in quilt_json_data["downloads"]:
+                    client_info = quilt_json_data["downloads"]["client"]
+                    client_urls = dl_source_launcher_or_meta_get(client_info["url"])
+                    if not secure_download(
+                        client_urls + [client_info["url"]],
+                        quilt_client_jar_path,
+                        client_info,
+                        "Quilt 客户端 JAR",
+                        **_dl_kwargs(task_state),
+                    ):
+                        raise RuntimeError("Quilt 客户端 JAR 下载或校验失败")
+                else:
+                    original_client_jar_path = _resolve_version_file(
+                        version_dir, VersionName, version, "jar"
+                    )
+                    if os.path.exists(original_client_jar_path):
+                        shutil.copy2(original_client_jar_path, quilt_client_jar_path)
+                    else:
+                        raise RuntimeError(f"原始版本的客户端 JAR 不存在: {original_client_jar_path}")
+                quilt_natives_dir = os.path.join(quilt_version_dir, f"{quilt_version_id}-natives")
+                os.makedirs(quilt_natives_dir, exist_ok=True)
+                processed_quilt_libraries = _library_download_items(
+                    quilt_json_data.get("libraries", []), minecraft_dir
+                )
+                if processed_quilt_libraries:
+                    library_downloader = LibraryDownloader(
+                        processed_quilt_libraries,
+                        max_workers=max_thread_value,
+                        natives_dir=quilt_natives_dir,
+                        pause_event=task_state.get("pause_event") if task_state else None,
+                    )
+                    task_state["downloader"] = library_downloader
+                    if task_state["cancel_event"].is_set():
+                        library_downloader.cancel()
+                    if not library_downloader.download_libraries():
+                        raise RuntimeError("Quilt Loader 依赖库/native 下载失败")
+                os.makedirs(os.path.join(quilt_version_dir, "mods"), exist_ok=True)
+                os.makedirs(os.path.join(quilt_version_dir, "resourcepacks"), exist_ok=True)
+                os.makedirs(os.path.join(quilt_version_dir, "shaderpacks"), exist_ok=True)
+                os.makedirs(os.path.join(quilt_version_dir, "datapacks"), exist_ok=True)
+                update_progress({
+                    "status": "Quilt Loader 安装完成!",
+                    "value": 1,
+                    "valueStringOverride": "100%",
+                })
+                update_bl_json(minecraft_dir, quilt_version_id, False, None)
+                try:
+                    bl_json_path = os.path.join(minecraft_dir, "versions", ".BL.json")
+                    if os.path.isfile(bl_json_path):
+                        with open(bl_json_path, "r", encoding="utf-8") as f:
+                            bl_data = json.load(f)
+                        entry = (bl_data.get("versions") or {}).get(quilt_version_id) or {}
+                        entry.update({
+                            "version": version,
+                            "loader": "quilt",
+                            "Quilt": True,
+                            "Fabric": False,
+                        })
+                        bl_data.setdefault("versions", {})[quilt_version_id] = entry
+                        with open(bl_json_path, "w", encoding="utf-8") as f:
+                            json.dump(bl_data, f, ensure_ascii=False, indent=4)
+                except Exception as e:
+                    log(f"写入 Quilt 标记失败: {e}", logging.WARNING)
+                log(f"Quilt Loader 安装完成到 {quilt_version_id}")
+            except Exception as e:
+                log(f"安装 Quilt Loader 失败: {e}", logging.ERROR)
+                return fail_install(f"Quilt Loader 安装失败: {e}")
 
         # 如果需要安装Fabric Loader
         if Fabric_Loader:

--- a/modules/launch.py
+++ b/modules/launch.py
@@ -507,7 +507,12 @@ def Get_Run_Script(mc_version, skip_completion=False, cancellation_event=None):
     classpath = _rewrite_classpath_with_system_lwjgl(classpath)
 
     library_names = [lib.get("name", "").lower() for lib in version_data.get("libraries", [])]
-    is_fabric = "fabric" in mc_version.lower() or any("fabric" in name for name in library_names)
+    is_fabric = (
+        "fabric" in mc_version.lower()
+        or "quilt" in mc_version.lower()
+        or any("fabric" in name or "quilt" in name for name in library_names)
+    )
+    is_quilt = "quilt" in mc_version.lower() or any("quilt" in name for name in library_names)
     is_forge_like = (
         "forge" in mc_version.lower()
         or any("minecraftforge" in name or "neoforged" in name for name in library_names)
@@ -515,20 +520,49 @@ def Get_Run_Script(mc_version, skip_completion=False, cancellation_event=None):
         or "cpw.mods" in version_data.get("mainClass", "")
     )
 
-    if is_fabric:
+    if is_quilt:
+        log(f"检测到 Quilt 版本: {mc_version}")
+    elif is_fabric:
         log(f"检测到 Fabric 版本: {mc_version}")
     elif is_forge_like:
         log(f"检测到 Forge/NeoForge 版本: {mc_version}")
     else:
         log(f"检测到原版: {mc_version}")
     
-    java_min_memory = config_data.get('java_min_memory', 512)
-    java_max_memory = config_data.get('java_max_memory', 4096)
+    # 实例级 overrides（内存 / 额外 JVM / 自定义 Java）
+    try:
+        from modules.services.instance_settings import resolve_launch_overrides
+        _inst_over = resolve_launch_overrides(mc_version, config_data, minecraft_dir)
+    except Exception as _ov_err:
+        log(f"读取实例设置失败，使用全局配置: {_ov_err}", logging.WARNING)
+        _inst_over = {
+            "java_min_memory": config_data.get("java_min_memory", 512),
+            "java_max_memory": config_data.get("java_max_memory", 4096),
+            "extra_jvm_args": [],
+            "env_vars": {},
+            "hooks": {},
+            "quick_play": {},
+            "custom_game_args": "",
+            "java_path": "",
+        }
+
+    # 若实例指定了 java_path 且存在，覆盖前面选中的 Java
+    override_java = str(_inst_over.get("java_path") or "").strip()
+    if override_java and os.path.isfile(override_java):
+        java_path = override_java
+        java_arg = java_path
+        log(f"使用实例指定 Java: {java_path}")
+
+    java_min_memory = _inst_over.get("java_min_memory", config_data.get("java_min_memory", 512))
+    java_max_memory = _inst_over.get("java_max_memory", config_data.get("java_max_memory", 4096))
     
     launch_args.extend([
         f"-Xms{java_min_memory}m",
         f"-Xmx{java_max_memory}m"
     ])
+    for extra in _inst_over.get("extra_jvm_args") or []:
+        if extra and extra not in launch_args:
+            launch_args.append(str(extra))
     
     if is_fabric:
         launch_args.append("-DFabricMcEmu=net.minecraft.client.main.Main")
@@ -609,8 +643,10 @@ def Get_Run_Script(mc_version, skip_completion=False, cancellation_event=None):
         f'-Djava.io.tmpdir={temp_dir}',
     ])
     if is_fabric and os.path.exists(mods_dir):
-        log(f"添加 Fabric mods 目录: {mods_dir}")
+        log(f"添加 Fabric/Quilt mods 目录: {mods_dir}")
         pending_launcher_jvm_args.append(f'-Dfabric.addMods={mods_dir}')
+        if is_quilt:
+            pending_launcher_jvm_args.append(f'-Dloader.addMods={mods_dir}')
 
     seen_jvm_args = set(launch_args[1:])
     for arg in pending_launcher_jvm_args:
@@ -710,6 +746,77 @@ def Get_Run_Script(mc_version, skip_completion=False, cancellation_event=None):
         launch_args.extend(["--clientId", client_id])
     if login_method == 2 and "${auth_xuid}" in template_text and xuid and "--xuid" not in existing_flags:
         launch_args.extend(["--xuid", xuid])
+
+    # Quick Play + 自定义游戏参数
+    try:
+        from modules.services.worlds_service import quick_play_game_args
+        qp_args = quick_play_game_args(_inst_over.get("quick_play") or {})
+        if qp_args:
+            launch_args.extend(qp_args)
+            log(f"已注入 Quick Play 参数: {qp_args}")
+        custom_game = str(_inst_over.get("custom_game_args") or "").strip()
+        if custom_game:
+            import shlex as _shlex
+            try:
+                extra_g = _shlex.split(custom_game, posix=(os.name != "nt"))
+            except ValueError:
+                extra_g = custom_game.split()
+            launch_args.extend(extra_g)
+    except Exception as _qp_err:
+        log(f"Quick Play 参数注入失败: {_qp_err}", logging.WARNING)
+
+    # 用户 wrapper hook
+    hooks = _inst_over.get("hooks") or {}
+    wrapper = str(hooks.get("wrapper") or "").strip()
+    if wrapper:
+        try:
+            from modules.services.runtime_extras import wrap_launch_args
+            launch_args = wrap_launch_args(
+                wrapper,
+                launch_args,
+                {
+                    "INST_NAME": mc_version,
+                    "INST_ID": mc_version,
+                    "INST_DIR": versions_dir,
+                    "INST_MC_DIR": versions_dir,
+                    "INST_JAVA": java_path,
+                },
+            )
+            log(f"已应用 wrapper hook")
+        except Exception as _wh:
+            log(f"wrapper hook 失败: {_wh}", logging.WARNING)
+
+    # pre-launch hook（失败则中止启动）
+    pre = str(hooks.get("pre_launch") or "").strip()
+    if pre:
+        try:
+            from modules.services.runtime_extras import run_pre_launch_hook
+            pre_res = run_pre_launch_hook(
+                pre,
+                instance_name=mc_version,
+                instance_dir=versions_dir,
+                java_path=java_path,
+                cwd=versions_dir,
+            )
+            if not pre_res.ok:
+                raise RuntimeError(pre_res.error or "pre-launch hook failed")
+            log("pre-launch hook 完成")
+        except Exception as _ph:
+            log(f"pre-launch hook 失败: {_ph}", logging.ERROR)
+            raise
+
+    # 把 hooks / env 挂到返回值之外：调用方可通过全局读取
+    try:
+        import modules.globals as _g
+        _g._pending_launch_hooks = {
+            "post_exit": str(hooks.get("post_exit") or ""),
+            "instance_name": mc_version,
+            "instance_dir": versions_dir,
+            "java_path": java_path,
+            "env_vars": dict(_inst_over.get("env_vars") or {}),
+        }
+    except Exception:
+        pass
 
     # 返回启动参数列表和游戏目录；日志必须脱敏。
     sensitive_values = {value for value in (access_token, client_id, xuid) if value}

--- a/modules/mrpack_export.py
+++ b/modules/mrpack_export.py
@@ -94,63 +94,129 @@ def detect_loader(instance_path):
     return None
 
 
-def collect_files(instance_path):
-    """收集实例中的文件"""
+NEVER_EXPORT_PREFIXES = (
+    "modrinth_logs",
+    "logs",
+    "crash-reports",
+    ".fabric",
+    ".quilt",
+    "natives",
+    "versions",
+    "libraries",
+    "assets",
+    "__MACOSX",
+    "content-index.json",
+    "instance-settings.json",
+)
+DEFAULT_SELECTED_PREFIXES = ("mods", "datapacks", "resourcepacks", "shaderpacks", "config")
+
+
+def _should_skip_rel(rel: str) -> bool:
+    rel = rel.replace("\\", "/").lstrip("./")
+    lower = rel.lower()
+    if lower.endswith(".disabled") or lower.endswith(".ds_store"):
+        return True
+    for p in NEVER_EXPORT_PREFIXES:
+        if lower == p or lower.startswith(p + "/"):
+            return True
+    return False
+
+
+def get_export_candidates(instance_path):
+    """返回可导出候选文件树（供 UI 勾选）。"""
+    instance = Path(instance_path)
+    candidates = []
+    if not instance.exists():
+        return candidates
+
+    def add_file(abs_path: Path, rel: str, default_selected: bool):
+        rel = rel.replace(os.sep, "/")
+        if _should_skip_rel(rel):
+            return
+        try:
+            st = abs_path.stat()
+            size = st.st_size
+            mtime = int(st.st_mtime)
+        except OSError:
+            size, mtime = 0, 0
+        candidates.append(
+            {
+                "path": rel,
+                "type": "file",
+                "size": size,
+                "modified": mtime,
+                "disabled": abs_path.name.endswith(".disabled"),
+                "default_selected": default_selected and not abs_path.name.endswith(".disabled"),
+                "source": str(abs_path),
+            }
+        )
+
+    for prefix in ("mods", "config", "resourcepacks", "shaderpacks", "datapacks", "options.txt"):
+        target = instance / prefix
+        default_sel = any(prefix.startswith(p) or prefix == p for p in DEFAULT_SELECTED_PREFIXES)
+        if target.is_file():
+            add_file(target, prefix, default_sel)
+            continue
+        if not target.is_dir():
+            continue
+        for f in target.rglob("*"):
+            if not f.is_file():
+                continue
+            rel = f"{prefix}/{f.relative_to(target)}".replace(os.sep, "/")
+            add_file(f, rel, default_sel)
+    return candidates
+
+
+def collect_files(instance_path, selected_paths=None):
+    """收集实例中的文件。
+
+    selected_paths: 可选，相对路径列表；None 表示使用默认前缀全选。
+    """
     files_list = []
     instance = Path(instance_path)
-    
-    # 收集 mods 目录
+    selected = None
+    if selected_paths is not None:
+        selected = {str(p).replace("\\", "/") for p in selected_paths}
+
+    def want(rel: str) -> bool:
+        rel = rel.replace("\\", "/")
+        if _should_skip_rel(rel):
+            return False
+        if selected is None:
+            return any(rel == p or rel.startswith(p + "/") for p in DEFAULT_SELECTED_PREFIXES)
+        return rel in selected
+
+    # mods
     mods_dir = instance / "mods"
     if mods_dir.exists():
         for mod_file in mods_dir.glob("*.jar"):
             rel_path = f"mods/{mod_file.name}"
-            files_list.append({
-                "path": rel_path,
-                "source": str(mod_file),
-                "env": {"client": "required", "server": "required"}
-            })
-    
-    # 收集 config 目录
-    config_dir = instance / "config"
-    if config_dir.exists():
-        for config_file in config_dir.rglob("*"):
-            if config_file.is_file():
-                rel_path = f"config/{config_file.relative_to(config_dir)}"
-                # 使用正斜杠
-                rel_path = rel_path.replace(os.sep, '/')
+            if want(rel_path):
                 files_list.append({
                     "path": rel_path,
-                    "source": str(config_file)
+                    "source": str(mod_file),
+                    "env": {"client": "required", "server": "required"}
                 })
-    
-    # 收集 resourcepacks 目录
-    rp_dir = instance / "resourcepacks"
-    if rp_dir.exists():
-        for rp_file in rp_dir.rglob("*"):
-            if rp_file.is_file():
-                rel_path = f"resourcepacks/{rp_file.relative_to(rp_dir)}"
-                rel_path = rel_path.replace(os.sep, '/')
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(rp_file)
-                })
-    
-    # 收集 shaderpacks 目录
-    shader_dir = instance / "shaderpacks"
-    if shader_dir.exists():
-        for shader_file in shader_dir.rglob("*"):
-            if shader_file.is_file():
-                rel_path = f"shaderpacks/{shader_file.relative_to(shader_dir)}"
-                rel_path = rel_path.replace(os.sep, '/')
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(shader_file)
-                })
-    
+
+    for folder in ("config", "resourcepacks", "shaderpacks", "datapacks"):
+        d = instance / folder
+        if not d.exists():
+            continue
+        for f in d.rglob("*"):
+            if not f.is_file():
+                continue
+            rel_path = f"{folder}/{f.relative_to(d)}".replace(os.sep, "/")
+            if want(rel_path):
+                files_list.append({"path": rel_path, "source": str(f)})
+
+    options = instance / "options.txt"
+    if options.is_file() and want("options.txt"):
+        files_list.append({"path": "options.txt", "source": str(options)})
+
     return files_list
 
 
-def export_to_mrpack(instance_path, output_path, name, version, summary=""):
+def export_to_mrpack(instance_path, output_path, name, version, summary="", selected_paths=None):
     """
     导出 Minecraft 实例为 .mrpack 文件
     
@@ -160,6 +226,7 @@ def export_to_mrpack(instance_path, output_path, name, version, summary=""):
         name: 整合包名称
         version: 整合包版本号
         summary: 整合包简介
+        selected_paths: 可选，要导出的相对路径列表
     
     Returns:
         bool: 是否成功
@@ -186,7 +253,7 @@ def export_to_mrpack(instance_path, output_path, name, version, summary=""):
             dependencies[loader['name']] = loader['version']
         
         # 收集文件
-        files_list = collect_files(instance_path)
+        files_list = collect_files(instance_path, selected_paths=selected_paths)
         log(f"收集到 {len(files_list)} 个文件", logging.INFO)
         
         if not files_list:

--- a/modules/services/__init__.py
+++ b/modules/services/__init__.py
@@ -1,7 +1,8 @@
 """启动器业务服务门面。
 
 PluginAPI 与 Web API 应优先调用本包，避免在 Backend / web 中重复实现。
-Phase 0 仅提供薄封装；后续 Phase 逐步把业务逻辑迁入。
+子模块请直接 `from modules.services import x` 或 `from modules.services.x import ...`；
+本包 __init__ 仅 re-export 轻量门面，避免导入时拖入 GUI 依赖。
 """
 
 from modules.services import config_service, content_service, launch_service, versions_service

--- a/modules/services/content_index.py
+++ b/modules/services/content_index.py
@@ -1,0 +1,521 @@
+"""实例内容索引：path / hash / Modrinth project+version 元数据。
+
+存储：versions/<name>/content-index.json
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from modules.services.base import ServiceResult, err, ok
+from modules.services.paths_util import content_dir, minecraft_dir, safe_version_dir
+
+_LOCKS: Dict[str, threading.RLock] = {}
+_LOCKS_GUARD = threading.Lock()
+
+INDEX_VERSION = 1
+CONTENT_KINDS = ("mod", "resourcepack", "shader", "datapack")
+
+_KIND_TO_DIR = {
+    "mod": "mods",
+    "resourcepack": "resourcepacks",
+    "shader": "shaderpacks",
+    "datapack": "datapacks",
+}
+
+_DIR_TO_KIND = {v: k for k, v in _KIND_TO_DIR.items()}
+
+_EXT_OK = {
+    "mod": (".jar", ".jar.disabled", ".disabled"),
+    "resourcepack": (".zip", ".zip.disabled"),
+    "shader": (".zip", ".zip.disabled"),
+    "datapack": (".zip", ".zip.disabled"),
+}
+
+
+def _lock_for(path: str) -> threading.RLock:
+    key = os.path.normcase(os.path.abspath(path))
+    with _LOCKS_GUARD:
+        lock = _LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _LOCKS[key] = lock
+        return lock
+
+
+def index_path(version_name: str, mc_dir: Optional[str] = None) -> str:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return ""
+    return os.path.join(vdir, "content-index.json")
+
+
+def empty_index() -> Dict[str, Any]:
+    return {"version": INDEX_VERSION, "items": {}, "updated_at": int(time.time())}
+
+
+def _atomic_write(path: str, data: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def load_index(version_name: str, mc_dir: Optional[str] = None) -> Dict[str, Any]:
+    path = index_path(version_name, mc_dir)
+    if not path:
+        return empty_index()
+    lock = _lock_for(path)
+    with lock:
+        if not os.path.isfile(path):
+            return empty_index()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                return empty_index()
+            if "items" not in data or not isinstance(data["items"], dict):
+                data["items"] = {}
+            data.setdefault("version", INDEX_VERSION)
+            return data
+        except Exception:
+            return empty_index()
+
+
+def save_index(version_name: str, data: Dict[str, Any], mc_dir: Optional[str] = None) -> bool:
+    path = index_path(version_name, mc_dir)
+    if not path:
+        return False
+    lock = _lock_for(path)
+    with lock:
+        payload = dict(data or {})
+        payload["version"] = INDEX_VERSION
+        payload["updated_at"] = int(time.time())
+        if "items" not in payload or not isinstance(payload["items"], dict):
+            payload["items"] = {}
+        try:
+            _atomic_write(path, payload)
+            return True
+        except Exception:
+            return False
+
+
+def file_hashes(file_path: str) -> Dict[str, str]:
+    """返回 sha1 / sha512；失败返回空 dict。"""
+    h1 = hashlib.sha1()
+    h512 = hashlib.sha512()
+    try:
+        with open(file_path, "rb") as f:
+            while True:
+                chunk = f.read(1024 * 1024)
+                if not chunk:
+                    break
+                h1.update(chunk)
+                h512.update(chunk)
+        return {"sha1": h1.hexdigest(), "sha512": h512.hexdigest()}
+    except Exception:
+        return {}
+
+
+def rel_content_path(kind: str, filename: str) -> str:
+    folder = _KIND_TO_DIR.get(kind, "mods")
+    name = os.path.basename(filename).replace("\\", "/")
+    return f"{folder}/{name}"
+
+
+def _is_enabled_name(name: str) -> bool:
+    return not name.endswith(".disabled")
+
+
+def _normalize_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(item or {})
+    out.setdefault("path", "")
+    out.setdefault("filename", os.path.basename(out.get("path") or ""))
+    out.setdefault("sha1", "")
+    out.setdefault("sha512", "")
+    out.setdefault("project_id", "")
+    out.setdefault("version_id", "")
+    out.setdefault("source", "local")
+    out.setdefault("project_type", "mod")
+    out.setdefault("enabled", True)
+    out.setdefault("title", out.get("filename") or "")
+    out.setdefault("file_size", 0)
+    out.setdefault("updated_at", int(time.time()))
+    return out
+
+
+def upsert_item(
+    version_name: str,
+    *,
+    path: str,
+    kind: str = "mod",
+    sha1: str = "",
+    sha512: str = "",
+    project_id: str = "",
+    version_id: str = "",
+    source: str = "local",
+    title: str = "",
+    file_size: int = 0,
+    enabled: Optional[bool] = None,
+    extra: Optional[Dict[str, Any]] = None,
+    mc_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """写入/更新一条内容记录。path 可为绝对路径或 mods/xxx.jar 相对路径。"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return {}
+
+    rel = path.replace("\\", "/")
+    if os.path.isabs(path):
+        try:
+            rel = os.path.relpath(path, vdir).replace("\\", "/")
+        except ValueError:
+            rel = rel_content_path(kind, os.path.basename(path))
+    if ".." in rel.split("/"):
+        return {}
+
+    abs_path = os.path.join(vdir, rel.replace("/", os.sep))
+    filename = os.path.basename(rel)
+    if enabled is None:
+        enabled = _is_enabled_name(filename)
+    if not sha1 or not sha512:
+        if os.path.isfile(abs_path):
+            hashes = file_hashes(abs_path)
+            sha1 = sha1 or hashes.get("sha1", "")
+            sha512 = sha512 or hashes.get("sha512", "")
+    if not file_size and os.path.isfile(abs_path):
+        try:
+            file_size = os.path.getsize(abs_path)
+        except OSError:
+            file_size = 0
+
+    item = _normalize_item(
+        {
+            "path": rel,
+            "filename": filename,
+            "sha1": sha1,
+            "sha512": sha512,
+            "project_id": project_id or "",
+            "version_id": version_id or "",
+            "source": source or ("modrinth" if project_id else "local"),
+            "project_type": kind if kind in CONTENT_KINDS else "mod",
+            "enabled": bool(enabled),
+            "title": title or filename,
+            "file_size": int(file_size or 0),
+            "updated_at": int(time.time()),
+        }
+    )
+    if extra:
+        for k, v in extra.items():
+            if k not in item and v is not None:
+                item[k] = v
+
+    idx = load_index(version_name, mc_dir)
+    # 同 path 覆盖；若旧 path 因改名失效，按 project_id 清掉旧条目
+    items = idx.setdefault("items", {})
+    if project_id:
+        stale = [
+            k
+            for k, v in items.items()
+            if isinstance(v, dict)
+            and v.get("project_id") == project_id
+            and k != rel
+            and v.get("project_type", "mod") == item["project_type"]
+        ]
+        for k in stale:
+            items.pop(k, None)
+    items[rel] = item
+    save_index(version_name, idx, mc_dir)
+    return item
+
+
+def remove_item(version_name: str, rel_or_abs: str, mc_dir: Optional[str] = None) -> bool:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return False
+    rel = rel_or_abs.replace("\\", "/")
+    if os.path.isabs(rel_or_abs):
+        try:
+            rel = os.path.relpath(rel_or_abs, vdir).replace("\\", "/")
+        except ValueError:
+            rel = os.path.basename(rel_or_abs)
+    idx = load_index(version_name, mc_dir)
+    items = idx.get("items") or {}
+    if rel in items:
+        items.pop(rel, None)
+        save_index(version_name, idx, mc_dir)
+        return True
+    # 尝试 basename 匹配
+    base = os.path.basename(rel)
+    hit = [k for k in list(items.keys()) if os.path.basename(k) == base]
+    for k in hit:
+        items.pop(k, None)
+    if hit:
+        save_index(version_name, idx, mc_dir)
+        return True
+    return False
+
+
+def mark_enabled(version_name: str, rel_or_abs: str, enabled: bool, mc_dir: Optional[str] = None) -> bool:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return False
+    rel = rel_or_abs.replace("\\", "/")
+    if os.path.isabs(rel_or_abs):
+        try:
+            rel = os.path.relpath(rel_or_abs, vdir).replace("\\", "/")
+        except ValueError:
+            rel = os.path.basename(rel_or_abs)
+    idx = load_index(version_name, mc_dir)
+    item = (idx.get("items") or {}).get(rel)
+    if not isinstance(item, dict):
+        # 可能发生 .jar <-> .jar.disabled 改名
+        base = os.path.basename(rel).replace(".disabled", "")
+        for k, v in list((idx.get("items") or {}).items()):
+            if not isinstance(v, dict):
+                continue
+            kb = os.path.basename(k).replace(".disabled", "")
+            if kb == base:
+                item = v
+                # 迁移 key
+                folder = os.path.dirname(k).replace("\\", "/") or "mods"
+                new_name = base if enabled else (base if base.endswith(".disabled") else base + ".disabled")
+                # 更稳：根据 enabled 构造
+                raw = base[:-9] if base.endswith(".disabled") else base
+                new_name = raw if enabled else raw + ".disabled"
+                new_rel = f"{folder}/{new_name}"
+                idx["items"].pop(k, None)
+                item = dict(v)
+                item["path"] = new_rel
+                item["filename"] = new_name
+                item["enabled"] = bool(enabled)
+                idx["items"][new_rel] = item
+                save_index(version_name, idx, mc_dir)
+                return True
+        return False
+    item["enabled"] = bool(enabled)
+    item["updated_at"] = int(time.time())
+    save_index(version_name, idx, mc_dir)
+    return True
+
+
+def list_indexed(
+    version_name: str,
+    kind: Optional[str] = None,
+    mc_dir: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    idx = load_index(version_name, mc_dir)
+    out: List[Dict[str, Any]] = []
+    for rel, item in (idx.get("items") or {}).items():
+        if not isinstance(item, dict):
+            continue
+        if kind and item.get("project_type") != kind and not rel.startswith(_KIND_TO_DIR.get(kind, "???") + "/"):
+            continue
+        row = _normalize_item(item)
+        row["path"] = rel
+        out.append(row)
+    out.sort(key=lambda x: (x.get("path") or "").lower())
+    return out
+
+
+def scan_filesystem(
+    version_name: str,
+    kinds: Optional[Iterable[str]] = None,
+    mc_dir: Optional[str] = None,
+    compute_hash: bool = True,
+) -> Dict[str, Any]:
+    """扫描磁盘内容并与索引合并（不删除索引中已有的 modrinth 元数据）。"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return empty_index()
+
+    kinds_list = list(kinds) if kinds else list(CONTENT_KINDS)
+    idx = load_index(version_name, mc_dir)
+    items = dict(idx.get("items") or {})
+    seen_rels = set()
+
+    for kind in kinds_list:
+        folder = _KIND_TO_DIR.get(kind)
+        if not folder:
+            continue
+        abs_dir = os.path.join(vdir, folder)
+        if not os.path.isdir(abs_dir):
+            continue
+        try:
+            names = os.listdir(abs_dir)
+        except OSError:
+            continue
+        for name in names:
+            path = os.path.join(abs_dir, name)
+            if kind == "resourcepack" and os.path.isdir(path):
+                # 文件夹资源包
+                rel = f"{folder}/{name}"
+                seen_rels.add(rel)
+                prev_raw = items.get(rel)
+                prev: Dict[str, Any] = dict(prev_raw) if isinstance(prev_raw, dict) else {}
+                items[rel] = _normalize_item(
+                    {
+                        **prev,
+                        "path": rel,
+                        "filename": name,
+                        "project_type": kind,
+                        "enabled": True,
+                        "source": prev.get("source") or "local",
+                        "title": prev.get("title") or name,
+                        "file_size": 0,
+                    }
+                )
+                continue
+            if not os.path.isfile(path):
+                continue
+            lower = name.lower()
+            exts = _EXT_OK.get(kind, ())
+            if kind == "mod":
+                if not (lower.endswith(".jar") or lower.endswith(".jar.disabled") or lower.endswith(".disabled")):
+                    continue
+            elif exts and not any(lower.endswith(e) for e in exts) and not os.path.isdir(path):
+                # 允许无扩展的目录已处理；文件需 zip
+                if not lower.endswith(".zip") and not lower.endswith(".zip.disabled"):
+                    continue
+            rel = f"{folder}/{name}"
+            seen_rels.add(rel)
+            prev_raw = items.get(rel)
+            prev = dict(prev_raw) if isinstance(prev_raw, dict) else {}
+            # 尝试从旧 disabled 键迁移
+            if not prev:
+                if name.endswith(".disabled"):
+                    alt = f"{folder}/{name[:-9]}"
+                else:
+                    alt = f"{folder}/{name}.disabled"
+                alt_raw = items.get(alt)
+                if isinstance(alt_raw, dict):
+                    prev = dict(items.pop(alt))
+
+            need_hash = compute_hash and (not prev.get("sha1") or not prev.get("sha512"))
+            hashes = file_hashes(path) if need_hash else {}
+            try:
+                size = os.path.getsize(path)
+            except OSError:
+                size = int(prev.get("file_size") or 0)
+            items[rel] = _normalize_item(
+                {
+                    **prev,
+                    "path": rel,
+                    "filename": name,
+                    "sha1": hashes.get("sha1") or prev.get("sha1") or "",
+                    "sha512": hashes.get("sha512") or prev.get("sha512") or "",
+                    "project_type": kind,
+                    "enabled": _is_enabled_name(name),
+                    "source": prev.get("source") or ("modrinth" if prev.get("project_id") else "local"),
+                    "title": prev.get("title") or name,
+                    "file_size": size,
+                    "updated_at": int(time.time()) if need_hash else prev.get("updated_at", int(time.time())),
+                }
+            )
+
+    # 清理索引中指向已删除文件的 local 条目（保留有 project_id 的也可清——文件没了就没了）
+    for rel in list(items.keys()):
+        folder = rel.split("/", 1)[0] if "/" in rel else ""
+        kind = _DIR_TO_KIND.get(folder)
+        if kind and kind in kinds_list and rel not in seen_rels:
+            abs_p = os.path.join(vdir, rel.replace("/", os.sep))
+            if not os.path.exists(abs_p):
+                items.pop(rel, None)
+
+    idx["items"] = items
+    save_index(version_name, idx, mc_dir)
+    return idx
+
+
+def get_by_project(version_name: str, project_id: str, mc_dir: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    if not project_id:
+        return None
+    for item in list_indexed(version_name, mc_dir=mc_dir):
+        if item.get("project_id") == project_id:
+            return item
+    return None
+
+
+def get_by_path(version_name: str, rel_or_abs: str, mc_dir: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return None
+    rel = rel_or_abs.replace("\\", "/")
+    if os.path.isabs(rel_or_abs):
+        try:
+            rel = os.path.relpath(rel_or_abs, vdir).replace("\\", "/")
+        except ValueError:
+            rel = os.path.basename(rel_or_abs)
+    idx = load_index(version_name, mc_dir)
+    item = (idx.get("items") or {}).get(rel)
+    return _normalize_item(item) if isinstance(item, dict) else None
+
+
+def hashes_needing_lookup(version_name: str, mc_dir: Optional[str] = None, limit: int = 64) -> List[str]:
+    """返回尚无 project_id 但有 sha1 的条目，供 version_files 反查。"""
+    out: List[str] = []
+    for item in list_indexed(version_name, mc_dir=mc_dir):
+        if item.get("project_id"):
+            continue
+        sha1 = item.get("sha1") or ""
+        if len(sha1) == 40:
+            out.append(sha1)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def apply_modrinth_lookup(
+    version_name: str,
+    sha1_to_meta: Dict[str, Dict[str, Any]],
+    mc_dir: Optional[str] = None,
+) -> int:
+    """把 hash 反查结果写回索引。返回更新条数。"""
+    if not sha1_to_meta:
+        return 0
+    idx = load_index(version_name, mc_dir)
+    items = idx.get("items") or {}
+    updated = 0
+    for rel, item in items.items():
+        if not isinstance(item, dict):
+            continue
+        sha1 = item.get("sha1") or ""
+        meta = sha1_to_meta.get(sha1)
+        if not meta:
+            continue
+        item["project_id"] = meta.get("project_id") or item.get("project_id") or ""
+        item["version_id"] = meta.get("version_id") or item.get("version_id") or ""
+        item["title"] = meta.get("title") or item.get("title") or item.get("filename")
+        item["source"] = "modrinth"
+        if meta.get("project_type"):
+            item["project_type"] = meta["project_type"]
+        item["updated_at"] = int(time.time())
+        updated += 1
+    if updated:
+        save_index(version_name, idx, mc_dir)
+    return updated
+
+
+def service_scan(version_name: str, compute_hash: bool = True) -> ServiceResult[Dict[str, Any]]:
+    if not version_name:
+        return err("version required", "invalid_version")
+    if not safe_version_dir(version_name):
+        return err("invalid version path", "invalid_version")
+    try:
+        idx = scan_filesystem(version_name, compute_hash=compute_hash)
+        return ok(
+            {
+                "count": len(idx.get("items") or {}),
+                "items": list_indexed(version_name),
+                "updated_at": idx.get("updated_at"),
+            }
+        )
+    except Exception as e:
+        return err(str(e), "content_scan_failed")

--- a/modules/services/content_lifecycle.py
+++ b/modules/services/content_lifecycle.py
@@ -1,0 +1,367 @@
+"""内容安装 / 依赖 / 更新（P0 核心）。"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+import requests
+
+from modules.services import content_index
+from modules.services.base import ServiceResult, err, ok
+from modules.services.modrinth_content import (
+    collect_required_dependencies,
+    get_versions_by_hashes,
+    latest_for_project,
+    meta_from_version_file,
+    resolve_download_info,
+)
+from modules.services.paths_util import (
+    content_dir,
+    detect_loader,
+    minecraft_dir,
+    resolve_game_version,
+    safe_version_dir,
+)
+
+ProgressCb = Optional[Callable[[float, str], None]]
+
+
+def _download_url(url: str, dest: str, progress_cb: ProgressCb = None, timeout: int = 120) -> Tuple[bool, str]:
+    try:
+        os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+        with requests.get(url, timeout=timeout, stream=True, headers={"User-Agent": "Bloret-Launcher/content"}) as resp:
+            if resp.status_code != 200:
+                return False, f"HTTP {resp.status_code}"
+            total = int(resp.headers.get("Content-Length") or 0)
+            downloaded = 0
+            tmp = dest + ".part"
+            with open(tmp, "wb") as f:
+                for chunk in resp.iter_content(64 * 1024):
+                    if not chunk:
+                        continue
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if progress_cb and total > 0:
+                        progress_cb(min(1.0, downloaded / total), f"下载 {os.path.basename(dest)}")
+            os.replace(tmp, dest)
+        return True, dest
+    except Exception as e:
+        try:
+            if os.path.isfile(dest + ".part"):
+                os.remove(dest + ".part")
+        except OSError:
+            pass
+        return False, str(e)
+
+
+def _folder_for_type(project_type: str) -> str:
+    t = (project_type or "mod").lower()
+    if t in ("resourcepack", "resourcepacks"):
+        return "resourcepacks"
+    if t in ("shader", "shaderpack", "shaderpacks"):
+        return "shaderpacks"
+    if t in ("datapack", "datapacks"):
+        return "datapacks"
+    return "mods"
+
+
+def _kind_for_type(project_type: str) -> str:
+    t = (project_type or "mod").lower()
+    if t.startswith("resource"):
+        return "resourcepack"
+    if t.startswith("shader"):
+        return "shader"
+    if t.startswith("data"):
+        return "datapack"
+    return "mod"
+
+
+def install_project(
+    version_name: str,
+    project_id_or_slug: str,
+    *,
+    with_dependencies: bool = True,
+    version_id: Optional[str] = None,
+    project_type: str = "mod",
+    loaders: Optional[Sequence[str]] = None,
+    game_version: Optional[str] = None,
+    progress_cb: ProgressCb = None,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    """安装 Modrinth 项目（可选依赖）到实例，并写入 content-index。"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return err("invalid version", "invalid_version")
+    mc = mc_dir or minecraft_dir()
+    gv = game_version or resolve_game_version(version_name, mc)
+    loader = detect_loader(version_name, mc)
+    if loaders is None:
+        if loader == "vanilla":
+            loaders = ["fabric", "quilt", "forge", "neoforge"]
+        else:
+            loaders = [loader]
+
+    if progress_cb:
+        progress_cb(0.02, f"解析 {project_id_or_slug}")
+
+    info = resolve_download_info(
+        project_id_or_slug,
+        loaders=loaders,
+        game_versions=[gv] if gv else None,
+        version_id=version_id,
+    )
+    if not info:
+        return err(f"未找到可下载版本: {project_id_or_slug}", "not_found")
+
+    plan: List[Dict[str, Any]] = [info]
+    if with_dependencies:
+        deps = collect_required_dependencies(
+            info.get("dependencies") or [],
+            loaders=loaders,
+            game_versions=[gv] if gv else None,
+        )
+        # 依赖在前
+        plan = deps + [info]
+
+    # project_id 去重，保留最后（主项目优先覆盖同 id 时其实不会）
+    dedup: Dict[str, Dict[str, Any]] = {}
+    for p in plan:
+        pid = p.get("project_id") or p.get("version_id") or p.get("filename")
+        dedup[str(pid)] = p
+    # 保持依赖优先顺序
+    ordered: List[Dict[str, Any]] = []
+    seen = set()
+    for p in plan:
+        pid = str(p.get("project_id") or p.get("version_id") or p.get("filename"))
+        if pid in seen:
+            continue
+        seen.add(pid)
+        ordered.append(dedup[pid])
+
+    installed: List[Dict[str, Any]] = []
+    failed: List[str] = []
+    total = max(1, len(ordered))
+
+    for i, item in enumerate(ordered):
+        base = i / total
+        span = 1.0 / total
+        filename = item.get("filename") or f"{item.get('project_id')}.jar"
+        # 主项目用传入 project_type；依赖默认 mod
+        ptype = project_type if item is info or item.get("project_id") == info.get("project_id") else "mod"
+        folder = _folder_for_type(ptype)
+        kind = _kind_for_type(ptype)
+        dest_dir = os.path.join(vdir, folder)
+        os.makedirs(dest_dir, exist_ok=True)
+        dest = os.path.join(dest_dir, filename)
+
+        # 若已装同 project_id 的旧文件，先移除
+        pid = item.get("project_id") or ""
+        if pid:
+            existing = content_index.get_by_project(version_name, pid, mc)
+            if existing and existing.get("path"):
+                old_abs = os.path.join(vdir, existing["path"].replace("/", os.sep))
+                if os.path.isfile(old_abs) and os.path.normcase(old_abs) != os.path.normcase(dest):
+                    try:
+                        os.remove(old_abs)
+                    except OSError:
+                        pass
+                content_index.remove_item(version_name, existing["path"], mc)
+
+        def _cb(frac, status, _b=base, _s=span):
+            if progress_cb:
+                progress_cb(_b + _s * float(frac) * 0.95, status)
+
+        if progress_cb:
+            progress_cb(base, f"下载 {filename} ({i + 1}/{total})")
+        ok_dl, msg = _download_url(item["url"], dest, progress_cb=_cb)
+        if not ok_dl:
+            failed.append(f"{filename}: {msg}")
+            continue
+
+        hashes = content_index.file_hashes(dest)
+        row = content_index.upsert_item(
+            version_name,
+            path=dest,
+            kind=kind,
+            sha1=item.get("sha1") or hashes.get("sha1", ""),
+            sha512=item.get("sha512") or hashes.get("sha512", ""),
+            project_id=item.get("project_id") or "",
+            version_id=item.get("version_id") or "",
+            source="modrinth",
+            title=item.get("title") or filename,
+            file_size=item.get("size") or 0,
+            enabled=True,
+            extra={"version_number": item.get("version_number") or ""},
+            mc_dir=mc,
+        )
+        installed.append(row)
+
+    if not installed and failed:
+        return err("; ".join(failed[:3]), "install_failed")
+    return ok(
+        {
+            "installed": installed,
+            "failed": failed,
+            "count": len(installed),
+            "primary": info.get("project_id"),
+        }
+    )
+
+
+def enrich_from_modrinth(version_name: str, mc_dir: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    """扫描 + hash 反查 Modrinth，回填 project_id/version_id。"""
+    if not safe_version_dir(version_name, mc_dir):
+        return err("invalid version", "invalid_version")
+    content_index.scan_filesystem(version_name, mc_dir=mc_dir, compute_hash=True)
+    hashes = content_index.hashes_needing_lookup(version_name, mc_dir=mc_dir)
+    if not hashes:
+        return ok({"looked_up": 0, "updated": 0, "items": content_index.list_indexed(version_name, mc_dir=mc_dir)})
+    raw = get_versions_by_hashes(hashes, algorithm="sha1")
+    mapping = {h: meta_from_version_file(v) for h, v in raw.items()}
+    updated = content_index.apply_modrinth_lookup(version_name, mapping, mc_dir=mc_dir)
+    return ok(
+        {
+            "looked_up": len(hashes),
+            "matched": len(mapping),
+            "updated": updated,
+            "items": content_index.list_indexed(version_name, mc_dir=mc_dir),
+        }
+    )
+
+
+def check_updates(
+    version_name: str,
+    *,
+    mc_dir: Optional[str] = None,
+    game_version: Optional[str] = None,
+    loaders: Optional[Sequence[str]] = None,
+) -> ServiceResult[List[Dict[str, Any]]]:
+    """检查可更新内容。返回列表，每项含 current / latest。"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return err("invalid version", "invalid_version")
+    mc = mc_dir or minecraft_dir()
+    # 先尽量补齐元数据
+    enrich_from_modrinth(version_name, mc)
+    gv = game_version or resolve_game_version(version_name, mc)
+    loader = detect_loader(version_name, mc)
+    if loaders is None:
+        loaders = [loader] if loader != "vanilla" else ["fabric", "forge", "neoforge", "quilt"]
+
+    updates: List[Dict[str, Any]] = []
+    for item in content_index.list_indexed(version_name, mc_dir=mc):
+        pid = item.get("project_id") or ""
+        if not pid:
+            continue
+        latest = latest_for_project(pid, loaders=loaders, game_versions=[gv] if gv else None)
+        if not latest:
+            continue
+        cur_vid = item.get("version_id") or ""
+        new_vid = latest.get("version_id") or ""
+        if new_vid and cur_vid and new_vid == cur_vid:
+            continue
+        # 同 hash 也算最新
+        if item.get("sha1") and latest.get("sha1") and item["sha1"] == latest["sha1"]:
+            continue
+        updates.append(
+            {
+                "path": item.get("path"),
+                "filename": item.get("filename"),
+                "title": item.get("title") or item.get("filename"),
+                "project_id": pid,
+                "current_version_id": cur_vid,
+                "latest_version_id": new_vid,
+                "latest_version_number": latest.get("version_number") or "",
+                "latest_title": latest.get("title") or "",
+                "project_type": item.get("project_type") or "mod",
+            }
+        )
+    return ok(updates)
+
+
+def update_projects(
+    version_name: str,
+    project_ids: Optional[Sequence[str]] = None,
+    *,
+    progress_cb: ProgressCb = None,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    """更新指定（或全部可更新）项目。"""
+    checked = check_updates(version_name, mc_dir=mc_dir)
+    if not checked.ok:
+        return err(checked.error, checked.code)
+    updates = list(checked.data or [])
+    if project_ids is not None:
+        want = {str(x) for x in project_ids}
+        updates = [u for u in updates if u.get("project_id") in want]
+    if not updates:
+        return ok({"updated": [], "count": 0, "message": "已是最新"})
+
+    done = []
+    failed = []
+    total = len(updates)
+    for i, u in enumerate(updates):
+        def _cb(frac, status, _i=i, _t=total):
+            if progress_cb:
+                progress_cb((_i + frac) / _t, status)
+
+        if progress_cb:
+            progress_cb(i / total, f"更新 {u.get('title') or u.get('project_id')}")
+        res = install_project(
+            version_name,
+            u["project_id"],
+            with_dependencies=True,
+            version_id=u.get("latest_version_id"),
+            project_type=u.get("project_type") or "mod",
+            progress_cb=_cb,
+            mc_dir=mc_dir,
+        )
+        if res.ok:
+            done.append(u["project_id"])
+        else:
+            failed.append(f"{u.get('project_id')}: {res.error}")
+    return ok({"updated": done, "failed": failed, "count": len(done)})
+
+
+def repair_project(
+    version_name: str,
+    project_id: str,
+    *,
+    progress_cb: ProgressCb = None,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    """按索引中的 version_id 重下；若无 version_id 则装最新。"""
+    item = content_index.get_by_project(version_name, project_id, mc_dir)
+    vid = (item or {}).get("version_id") if item else None
+    ptype = (item or {}).get("project_type") if item else "mod"
+    return install_project(
+        version_name,
+        project_id,
+        with_dependencies=True,
+        version_id=vid or None,
+        project_type=ptype or "mod",
+        progress_cb=progress_cb,
+        mc_dir=mc_dir,
+    )
+
+
+def list_content(
+    version_name: str,
+    kind: Optional[str] = None,
+    *,
+    refresh: bool = False,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[List[Dict[str, Any]]]:
+    if not safe_version_dir(version_name, mc_dir):
+        return err("invalid version", "invalid_version")
+    if refresh:
+        content_index.scan_filesystem(version_name, kinds=[kind] if kind else None, mc_dir=mc_dir, compute_hash=False)
+    items = content_index.list_indexed(version_name, kind=kind, mc_dir=mc_dir)
+    # 附加 abs path
+    vdir = safe_version_dir(version_name, mc_dir)
+    for it in items:
+        rel = it.get("path") or ""
+        it["abs_path"] = os.path.join(vdir, rel.replace("/", os.sep)) if vdir and rel else ""
+    return ok(items)

--- a/modules/services/content_service.py
+++ b/modules/services/content_service.py
@@ -67,6 +67,18 @@ def list_mods(version_name: str) -> ServiceResult[List[Dict[str, Any]]]:
 
 
 def list_resourcepacks(version_name: str) -> ServiceResult[List[Dict[str, Any]]]:
+    return _list_folder_content(version_name, "resourcepacks")
+
+
+def list_shaderpacks(version_name: str) -> ServiceResult[List[Dict[str, Any]]]:
+    return _list_folder_content(version_name, "shaderpacks")
+
+
+def list_datapacks(version_name: str) -> ServiceResult[List[Dict[str, Any]]]:
+    return _list_folder_content(version_name, "datapacks")
+
+
+def _list_folder_content(version_name: str, folder: str) -> ServiceResult[List[Dict[str, Any]]]:
     if not version_name:
         return err("version required", "invalid_version")
     root = _versions_root()
@@ -75,15 +87,24 @@ def list_resourcepacks(version_name: str) -> ServiceResult[List[Dict[str, Any]]]
     version_dir = _safe_version_dir(version_name)
     if not version_dir:
         return err("invalid version path", "invalid_version")
-    rp_dir = os.path.join(version_dir, "resourcepacks")
-    if not os.path.isdir(rp_dir):
+    d = os.path.join(version_dir, folder)
+    if not os.path.isdir(d):
         return ok([])
     items: List[Dict[str, Any]] = []
     try:
-        for name in sorted(os.listdir(rp_dir)):
-            path = os.path.join(rp_dir, name)
+        for name in sorted(os.listdir(d)):
+            path = os.path.join(d, name)
             if os.path.isfile(path) or os.path.isdir(path):
-                items.append({"name": name, "path": path, "is_dir": os.path.isdir(path)})
+                enabled = not name.endswith(".disabled")
+                items.append(
+                    {
+                        "name": name,
+                        "path": path,
+                        "is_dir": os.path.isdir(path),
+                        "enabled": enabled,
+                        "kind": folder.rstrip("s") if folder.endswith("s") else folder,
+                    }
+                )
         return ok(items)
     except Exception as e:
-        return err(str(e), "resourcepacks_list_failed")
+        return err(str(e), f"{folder}_list_failed")

--- a/modules/services/content_service.py
+++ b/modules/services/content_service.py
@@ -108,3 +108,39 @@ def _list_folder_content(version_name: str, folder: str) -> ServiceResult[List[D
         return ok(items)
     except Exception as e:
         return err(str(e), f"{folder}_list_failed")
+
+
+def toggle_pack_enabled(path: str, enabled: bool) -> ServiceResult[Dict[str, Any]]:
+    """Enable/disable a content file via .disabled suffix."""
+    if not path or not os.path.exists(path):
+        return err("not found", "not_found")
+    dirname, filename = os.path.split(path)
+    try:
+        if enabled:
+            if filename.endswith(".disabled"):
+                new_path = os.path.join(dirname, filename[:-9])
+                os.rename(path, new_path)
+                return ok({"path": new_path, "enabled": True})
+            return ok({"path": path, "enabled": True})
+        if not filename.endswith(".disabled"):
+            new_path = os.path.join(dirname, filename + ".disabled")
+            os.rename(path, new_path)
+            return ok({"path": new_path, "enabled": False})
+        return ok({"path": path, "enabled": False})
+    except Exception as e:
+        return err(str(e), "toggle_failed")
+
+
+def delete_content_path(path: str) -> ServiceResult[bool]:
+    if not path or not os.path.exists(path):
+        return err("not found", "not_found")
+    try:
+        if os.path.isdir(path):
+            import shutil
+
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+        return ok(True)
+    except Exception as e:
+        return err(str(e), "delete_failed")

--- a/modules/services/feature_bridge.py
+++ b/modules/services/feature_bridge.py
@@ -1,0 +1,213 @@
+"""Backend 用的 P0–P2 能力桥接（避免把 Bloret-Launcher.py 再堆几千行）。"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+
+def install_mod_with_deps(
+    version_name: str,
+    project_id: str,
+    *,
+    project_type: str = "mod",
+    with_dependencies: bool = True,
+    progress_cb=None,
+) -> Dict[str, Any]:
+    from modules.services.content_lifecycle import install_project
+
+    res = install_project(
+        version_name,
+        project_id,
+        with_dependencies=with_dependencies,
+        project_type=project_type,
+        progress_cb=progress_cb,
+    )
+    return res.to_dict()
+
+
+def check_content_updates(version_name: str) -> Dict[str, Any]:
+    from modules.services.content_lifecycle import check_updates
+
+    return check_updates(version_name).to_dict()
+
+
+def update_all_content(version_name: str, progress_cb=None) -> Dict[str, Any]:
+    from modules.services.content_lifecycle import update_projects
+
+    return update_projects(version_name, progress_cb=progress_cb).to_dict()
+
+
+def update_selected_content(version_name: str, project_ids: List[str], progress_cb=None) -> Dict[str, Any]:
+    from modules.services.content_lifecycle import update_projects
+
+    return update_projects(version_name, project_ids, progress_cb=progress_cb).to_dict()
+
+
+def scan_and_enrich(version_name: str) -> Dict[str, Any]:
+    from modules.services.content_lifecycle import enrich_from_modrinth
+
+    return enrich_from_modrinth(version_name).to_dict()
+
+
+def list_indexed_content(version_name: str, kind: str = "") -> Dict[str, Any]:
+    from modules.services.content_lifecycle import list_content
+
+    return list_content(version_name, kind=kind or None, refresh=True).to_dict()
+
+
+def get_instance_settings(version_name: str) -> Dict[str, Any]:
+    from modules.services.instance_settings import get
+
+    return get(version_name).to_dict()
+
+
+def save_instance_settings(version_name: str, patch: Dict[str, Any]) -> Dict[str, Any]:
+    from modules.services.instance_settings import save
+
+    return save(version_name, patch or {}).to_dict()
+
+
+def list_worlds(version_name: str) -> Dict[str, Any]:
+    from modules.services.worlds_service import list_worlds as _lw
+
+    return _lw(version_name).to_dict()
+
+
+def set_quick_play_world(version_name: str, world: str) -> Dict[str, Any]:
+    from modules.services.worlds_service import set_quick_play_world as _s
+
+    return _s(version_name, world).to_dict()
+
+
+def set_quick_play_server(version_name: str, address: str, port: int = 0) -> Dict[str, Any]:
+    from modules.services.worlds_service import set_quick_play_server as _s
+
+    return _s(version_name, address, port=port or None).to_dict()
+
+
+def clear_quick_play(version_name: str) -> Dict[str, Any]:
+    from modules.services.worlds_service import clear_quick_play as _c
+
+    return _c(version_name).to_dict()
+
+
+def list_skins() -> Dict[str, Any]:
+    from modules.services.skins_service import list_skins as _ls
+
+    return _ls().to_dict()
+
+
+def import_skin(path: str, name: str = "", variant: str = "classic") -> Dict[str, Any]:
+    from modules.services.skins_service import import_skin_file
+
+    return import_skin_file(path, name=name, variant=variant).to_dict()
+
+
+def delete_skin(skin_id: str) -> Dict[str, Any]:
+    from modules.services.skins_service import delete_skin as _d
+
+    return _d(skin_id).to_dict()
+
+
+def equip_skin(skin_id: str, variant: str = "") -> Dict[str, Any]:
+    from modules.services.skins_service import equip_skin as _e
+
+    return _e(skin_id, variant=variant or None).to_dict()
+
+
+def list_crashes(version_name: str) -> Dict[str, Any]:
+    from modules.services.runtime_extras import list_crash_reports
+
+    return list_crash_reports(version_name).to_dict()
+
+
+def read_crash_log(path: str) -> Dict[str, Any]:
+    from modules.services.runtime_extras import read_log_file
+
+    return read_log_file(path).to_dict()
+
+
+def list_importable(base_path: str) -> Dict[str, Any]:
+    from modules.services.instance_import import list_importable_instances
+
+    return list_importable_instances(base_path).to_dict()
+
+
+def import_instance(path: str, target_name: str = "") -> Dict[str, Any]:
+    from modules.services.instance_import import import_mmc_instance
+
+    return import_mmc_instance(path, target_name=target_name or None).to_dict()
+
+
+def default_import_paths() -> Dict[str, Any]:
+    from modules.services.instance_import import default_multimc_path, default_prism_path
+
+    return {
+        "ok": True,
+        "prism": default_prism_path() or "",
+        "multimc": default_multimc_path() or "",
+    }
+
+
+def mrpack_export_candidates(instance_path: str) -> Dict[str, Any]:
+    from modules.mrpack_export import get_export_candidates
+
+    try:
+        return {"ok": True, "data": get_export_candidates(instance_path)}
+    except Exception as e:
+        return {"ok": False, "message": str(e)}
+
+
+def apply_pending_launch_side_effects(proc, launch_env: Optional[dict] = None):
+    """合并实例 env、post-exit hook、Discord RPC。返回最终 env。
+
+    - proc is None：只合并 env，不消费 pending
+    - proc 有值：挂 post-exit / Discord，并清空 pending
+    """
+    import modules.globals as BLglobals
+
+    pending = getattr(BLglobals, "_pending_launch_hooks", None) or {}
+    env = dict(launch_env) if launch_env else dict(os.environ)
+    for k, v in (pending.get("env_vars") or {}).items():
+        if k:
+            env[str(k)] = str(v)
+
+    if proc is None:
+        return env
+
+    post = str(pending.get("post_exit") or "").strip()
+    if post:
+        try:
+            from modules.services.runtime_extras import spawn_post_exit_hook
+
+            spawn_post_exit_hook(
+                post,
+                instance_name=str(pending.get("instance_name") or ""),
+                instance_dir=str(pending.get("instance_dir") or ""),
+                java_path=str(pending.get("java_path") or ""),
+                process_obj=proc,
+            )
+        except Exception:
+            pass
+
+    try:
+        from modules.services.runtime_extras import discord_set_playing, discord_is_enabled
+
+        if discord_is_enabled():
+            discord_set_playing(str(pending.get("instance_name") or "Minecraft"))
+    except Exception:
+        pass
+
+    try:
+        BLglobals._pending_launch_hooks = None
+    except Exception:
+        pass
+    return env
+
+
+def set_discord_rpc(enabled: bool) -> None:
+    from modules.services.runtime_extras import discord_set_enabled
+
+    discord_set_enabled(bool(enabled))

--- a/modules/services/instance_import.py
+++ b/modules/services/instance_import.py
@@ -1,0 +1,302 @@
+"""从 MultiMC / PrismLauncher 导入实例。"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from modules.services.base import ServiceResult, err, ok
+from modules.services.paths_util import minecraft_dir, safe_version_dir, versions_root
+
+
+def _read_text(path: Path) -> str:
+    for enc in ("utf-8", "utf-8-sig", "gbk", "latin-1"):
+        try:
+            return path.read_text(encoding=enc)
+        except Exception:
+            continue
+    return ""
+
+
+def _parse_cfg(path: Path) -> Dict[str, str]:
+    raw = _read_text(path)
+    # MultiMC instance.cfg 类似 ini 但常无 section
+    if raw and not re.search(r"^\s*\[", raw, re.M):
+        raw = "[instance]\n" + raw
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(raw)
+    except Exception:
+        return {}
+    out: Dict[str, str] = {}
+    for section in parser.sections():
+        for k, v in parser.items(section):
+            out[k] = v
+    return out
+
+
+def is_valid_mmc_instance(instance_path: str) -> bool:
+    p = Path(instance_path)
+    return (p / "instance.cfg").is_file() or (p / "mmc-pack.json").is_file()
+
+
+def list_importable_instances(base_path: str) -> ServiceResult[List[Dict[str, Any]]]:
+    base = Path(base_path)
+    if not base.is_dir():
+        return err("path not found", "not_found")
+    # 直接指向 instances 目录，或启动器根目录
+    candidates = []
+    if (base / "instances").is_dir():
+        root = base / "instances"
+    else:
+        root = base
+    try:
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            if is_valid_mmc_instance(str(child)):
+                cfg = _parse_cfg(child / "instance.cfg") if (child / "instance.cfg").is_file() else {}
+                name = cfg.get("name") or child.name
+                candidates.append(
+                    {
+                        "folder": child.name,
+                        "name": name,
+                        "path": str(child),
+                        "minecraft_version": cfg.get("ManagedVersion") or cfg.get("MinecraftVersion") or "",
+                    }
+                )
+    except Exception as e:
+        return err(str(e), "list_failed")
+    return ok(candidates)
+
+
+def _detect_components(instance_path: Path) -> Dict[str, str]:
+    """从 mmc-pack.json 解析 minecraft / fabric / forge / quilt 版本。"""
+    out = {"minecraft": "", "loader": "vanilla", "loader_version": ""}
+    pack = instance_path / "mmc-pack.json"
+    if not pack.is_file():
+        cfg = _parse_cfg(instance_path / "instance.cfg")
+        out["minecraft"] = cfg.get("ManagedVersion") or cfg.get("IntendedVersion") or ""
+        return out
+    try:
+        data = json.loads(_read_text(pack))
+    except Exception:
+        return out
+    for comp in data.get("components") or []:
+        if not isinstance(comp, dict):
+            continue
+        uid = str(comp.get("uid") or "").lower()
+        ver = str(comp.get("version") or "")
+        if uid in ("net.minecraft", "minecraft"):
+            out["minecraft"] = ver
+        elif "fabric" in uid and "loader" in uid:
+            out["loader"] = "fabric"
+            out["loader_version"] = ver
+        elif "quilt" in uid and "loader" in uid:
+            out["loader"] = "quilt"
+            out["loader_version"] = ver
+        elif "neoforge" in uid or "neoforged" in uid:
+            out["loader"] = "neoforge"
+            out["loader_version"] = ver
+        elif "minecraftforge" in uid or uid.endswith("forge"):
+            if "neoforge" not in out["loader"]:
+                out["loader"] = "forge"
+                out["loader_version"] = ver
+    return out
+
+
+def _copy_tree(src: Path, dst: Path, skip_names: Optional[set] = None) -> int:
+    skip = skip_names or set()
+    count = 0
+    if not src.exists():
+        return 0
+    if src.is_file():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        return 1
+    for root, dirs, files in os.walk(src):
+        rel_root = os.path.relpath(root, src)
+        # 过滤
+        dirs[:] = [d for d in dirs if d not in skip and not d.startswith(".")]
+        for name in files:
+            if name in skip or name.startswith("."):
+                continue
+            s = Path(root) / name
+            if rel_root in (".", ""):
+                d = dst / name
+            else:
+                d = dst / rel_path_safe(rel_root) / name
+            d.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(s, d)
+                count += 1
+            except Exception:
+                pass
+    return count
+
+
+def rel_path_safe(p: str) -> Path:
+    parts = [x for x in Path(p).parts if x not in (".", "..")]
+    return Path(*parts) if parts else Path()
+
+
+def import_mmc_instance(
+    instance_path: str,
+    *,
+    target_name: Optional[str] = None,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    """
+    导入 MultiMC/Prism 实例到 Bloret versions/<name>。
+
+    策略：复制 .minecraft 内容（mods/config/saves/...）到新 version 目录；
+    若已有完整 version JSON 则一并带上；否则只导入内容，用户需自行有对应 loader 版本，
+    或依赖后续安装流程。
+    """
+    src = Path(instance_path)
+    if not is_valid_mmc_instance(str(src)):
+        return err("不是有效的 MultiMC/Prism 实例", "invalid_instance")
+
+    cfg = _parse_cfg(src / "instance.cfg") if (src / "instance.cfg").is_file() else {}
+    components = _detect_components(src)
+    name = target_name or cfg.get("name") or src.name
+    # 清理非法文件夹名
+    name = re.sub(r'[<>:"/\\|?*]', "_", name).strip() or src.name
+
+    root = mc_dir or minecraft_dir()
+    if not root:
+        return err("minecraft_dir not set", "no_minecraft_dir")
+    vroot = versions_root(root)
+    dest = Path(vroot) / name
+    if dest.exists():
+        return err(f"目标版本已存在: {name}", "already_exists")
+
+    # MMC 的 .minecraft 可能在 instance/.minecraft 或 instance/minecraft
+    dot_mc = src / ".minecraft"
+    if not dot_mc.is_dir():
+        dot_mc = src / "minecraft"
+    if not dot_mc.is_dir():
+        # 有些把内容直接放实例根
+        dot_mc = src
+
+    try:
+        dest.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        return err(f"目标版本已存在: {name}", "already_exists")
+    except Exception as e:
+        return err(str(e), "mkdir_failed")
+
+    skip = {"cache", "libraries", "assets", "versions", "webcache2", "logs", ".cache"}
+    copied = _copy_tree(dot_mc, dest, skip_names=skip)
+
+    # 图标
+    for icon_name in ("minecraft.png", "icon.png", "instance.png"):
+        icon = src / icon_name
+        if icon.is_file():
+            try:
+                shutil.copy2(icon, dest / "icon.png")
+            except Exception:
+                pass
+            break
+
+    # 写 bl 侧车与 instance-settings 种子
+    mc_ver = components.get("minecraft") or cfg.get("ManagedVersion") or ""
+    loader = components.get("loader") or "vanilla"
+    try:
+        from modules.install import update_bl_json
+
+        update_bl_json(root, name, fabric_loader=(loader == "fabric"), icon_path=None)
+        # 补充 loader 字段
+        bl_path = os.path.join(root, "versions", ".BL.json")
+        if os.path.isfile(bl_path):
+            with open(bl_path, "r", encoding="utf-8") as f:
+                bl = json.load(f)
+            entry = (bl.get("versions") or {}).get(name) or {}
+            entry["version"] = mc_ver or entry.get("version") or name
+            entry["loader"] = loader
+            entry["Fabric"] = loader == "fabric"
+            entry["Quilt"] = loader == "quilt"
+            entry["Forge"] = loader == "forge"
+            entry["NeoForge"] = loader == "neoforge"
+            entry["imported_from"] = "prism" if "prism" in str(src).lower() else "multimc"
+            bl.setdefault("versions", {})[name] = entry
+            with open(bl_path, "w", encoding="utf-8") as f:
+                json.dump(bl, f, ensure_ascii=False, indent=4)
+    except Exception:
+        pass
+
+    # JVM 参数
+    jvm = cfg.get("JvmArgs") or cfg.get("jvmargs") or ""
+    if jvm:
+        try:
+            from modules.services import instance_settings
+
+            instance_settings.save(name, {"jvm_args": jvm}, mc_dir=root)
+        except Exception:
+            pass
+
+    # 扫描内容索引
+    try:
+        from modules.services import content_index
+
+        content_index.scan_filesystem(name, mc_dir=root, compute_hash=False)
+    except Exception:
+        pass
+
+    note = ""
+    if not any(dest.glob("*.json")):
+        note = (
+            "已导入 mods/config/saves 等内容，但未包含可启动的 version JSON。"
+            "请在下载页安装对应 MC + Loader，或把已有版本 JSON/JAR 拷入该目录后启动。"
+        )
+
+    return ok(
+        {
+            "name": name,
+            "path": str(dest),
+            "copied_files": copied,
+            "minecraft": mc_ver,
+            "loader": loader,
+            "loader_version": components.get("loader_version") or "",
+            "note": note,
+        }
+    )
+
+
+def default_prism_path() -> Optional[str]:
+    candidates = []
+    data = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    candidates.append(os.path.join(data, "PrismLauncher"))
+    home = os.path.expanduser("~")
+    candidates.append(os.path.join(home, "PrismLauncher"))
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA") or ""
+        if appdata:
+            candidates.append(os.path.join(appdata, "PrismLauncher"))
+    for c in candidates:
+        if os.path.isdir(c):
+            return c
+    return None
+
+
+def default_multimc_path() -> Optional[str]:
+    candidates = []
+    data = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    candidates += [os.path.join(data, "multimc"), os.path.join(data, "MultiMC")]
+    home = os.path.expanduser("~")
+    candidates += [os.path.join(home, "MultiMC"), os.path.join(home, "multimc")]
+    if os.name == "nt":
+        for base in filter(None, [os.environ.get("USERPROFILE"), "C:\\"]):
+            candidates += [
+                os.path.join(base, "MultiMC"),
+                os.path.join(base, "Desktop", "MultiMC"),
+            ]
+    for c in candidates:
+        if os.path.isfile(os.path.join(c, "multimc.cfg")) or os.path.isdir(os.path.join(c, "instances")):
+            return c
+    return None

--- a/modules/services/instance_import.py
+++ b/modules/services/instance_import.py
@@ -240,6 +240,25 @@ def import_mmc_instance(
         except Exception:
             pass
 
+    # 尝试从 MMC patches / 实例根复制 profile JSON
+    try:
+        patches = src / "patches"
+        if patches.is_dir():
+            for p in patches.glob("*.json"):
+                try:
+                    shutil.copy2(p, dest / p.name)
+                except Exception:
+                    pass
+        for p in src.glob("*.json"):
+            if p.name.lower() in ("mmc-pack.json",):
+                continue
+            try:
+                shutil.copy2(p, dest / p.name)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
     # 扫描内容索引
     try:
         from modules.services import content_index
@@ -248,12 +267,31 @@ def import_mmc_instance(
     except Exception:
         pass
 
+    has_launch_json = any(dest.glob(f"{name}.json")) or any(
+        p.name.endswith(".json") and p.stem.lower() not in ("mmc-pack", "bloret-import-meta")
+        for p in dest.glob("*.json")
+    )
+    needs_loader = not has_launch_json
     note = ""
-    if not any(dest.glob("*.json")):
+    if needs_loader:
         note = (
-            "已导入 mods/config/saves 等内容，但未包含可启动的 version JSON。"
-            "请在下载页安装对应 MC + Loader，或把已有版本 JSON/JAR 拷入该目录后启动。"
+            f"已导入内容，但缺少可启动 version JSON。"
+            f"检测到 MC={mc_ver or '?'} loader={loader}。"
+            f"请到下载页安装对应版本，或把 JSON/JAR 放入该版本目录后再启动。"
         )
+        try:
+            marker = {
+                "needs_loader_install": True,
+                "minecraft": mc_ver,
+                "loader": loader,
+                "loader_version": components.get("loader_version") or "",
+            }
+            (dest / "bloret-import-meta.json").write_text(
+                json.dumps(marker, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
 
     return ok(
         {
@@ -263,6 +301,12 @@ def import_mmc_instance(
             "minecraft": mc_ver,
             "loader": loader,
             "loader_version": components.get("loader_version") or "",
+            "needs_loader_install": needs_loader,
+            "suggested_install": {
+                "minecraft": mc_ver,
+                "loader": loader,
+                "loader_version": components.get("loader_version") or "",
+            },
             "note": note,
         }
     )

--- a/modules/services/instance_settings.py
+++ b/modules/services/instance_settings.py
@@ -1,0 +1,221 @@
+"""实例级设置 overrides（内存 / Java / JVM / 环境 / 窗口 / hooks）。
+
+存储：versions/<name>/instance-settings.json
+同时兼容 .BL.json 里的 jvmArgs 字段。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from modules.services.base import ServiceResult, err, ok
+from modules.services.paths_util import minecraft_dir, safe_version_dir
+
+SETTINGS_FILE = "instance-settings.json"
+SCHEMA_VERSION = 1
+
+DEFAULTS: Dict[str, Any] = {
+    "java_min_memory": None,  # None = 跟随全局
+    "java_max_memory": None,
+    "java_path": None,
+    "jvm_args": "",  # 额外 JVM 参数字符串
+    "env_vars": {},  # {KEY: VALUE}
+    "resolution_width": None,
+    "resolution_height": None,
+    "fullscreen": None,
+    "quick_play": {
+        "type": None,  # None | "singleplayer" | "multiplayer"
+        "world": None,
+        "server": None,
+        "port": None,
+    },
+    "hooks": {
+        "pre_launch": "",
+        "wrapper": "",
+        "post_exit": "",
+    },
+    "custom_game_args": "",
+}
+
+
+def settings_path(version_name: str, mc_dir: Optional[str] = None) -> str:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return ""
+    return os.path.join(vdir, SETTINGS_FILE)
+
+
+def _read_bl_jvm(version_name: str, mc_dir: Optional[str] = None) -> str:
+    root = mc_dir or minecraft_dir()
+    if not root:
+        return ""
+    bl = os.path.join(root, "versions", ".BL.json")
+    if not os.path.isfile(bl):
+        return ""
+    try:
+        with open(bl, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        entry = (data.get("versions") or {}).get(version_name) or {}
+        return str(entry.get("jvmArgs") or "")
+    except Exception:
+        return ""
+
+
+def _write_bl_jvm(version_name: str, jvm_args: str, mc_dir: Optional[str] = None) -> None:
+    root = mc_dir or minecraft_dir()
+    if not root:
+        return
+    bl = os.path.join(root, "versions", ".BL.json")
+    try:
+        data: Dict[str, Any] = {"versions": {}}
+        if os.path.isfile(bl):
+            with open(bl, "r", encoding="utf-8") as f:
+                data = json.load(f) or {"versions": {}}
+        versions = data.setdefault("versions", {})
+        entry = versions.get(version_name) or {}
+        entry["jvmArgs"] = jvm_args or ""
+        versions[version_name] = entry
+        os.makedirs(os.path.dirname(bl), exist_ok=True)
+        tmp = bl + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+        os.replace(tmp, bl)
+    except Exception:
+        pass
+
+
+def load(version_name: str, mc_dir: Optional[str] = None) -> Dict[str, Any]:
+    path = settings_path(version_name, mc_dir)
+    raw: Dict[str, Any] = {}
+    if path and os.path.isfile(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                raw = loaded
+        except Exception:
+            raw = {}
+    out = {**DEFAULTS, **{k: v for k, v in raw.items() if k in DEFAULTS or k in ("schema", "updated_at")}}
+    out["hooks"] = {**DEFAULTS["hooks"], **(raw.get("hooks") or {})}
+    out["quick_play"] = {**DEFAULTS["quick_play"], **(raw.get("quick_play") or {})}
+    out["env_vars"] = dict(raw.get("env_vars") or {})
+    # 兼容 .BL.json jvmArgs
+    if not out.get("jvm_args"):
+        legacy = _read_bl_jvm(version_name, mc_dir)
+        if legacy:
+            out["jvm_args"] = legacy
+    out["schema"] = SCHEMA_VERSION
+    return out
+
+
+def save(version_name: str, patch: Dict[str, Any], mc_dir: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    if not safe_version_dir(version_name, mc_dir):
+        return err("invalid version", "invalid_version")
+    current = load(version_name, mc_dir)
+    for key, value in (patch or {}).items():
+        if key in ("hooks", "quick_play", "env_vars") and isinstance(value, dict):
+            base = dict(current.get(key) or {})
+            base.update(value)
+            current[key] = base
+        elif key in DEFAULTS or key in current:
+            current[key] = value
+    current["schema"] = SCHEMA_VERSION
+    current["updated_at"] = int(time.time())
+    path = settings_path(version_name, mc_dir)
+    try:
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(current, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+        if "jvm_args" in (patch or {}):
+            _write_bl_jvm(version_name, str(current.get("jvm_args") or ""), mc_dir)
+        return ok(current)
+    except Exception as e:
+        return err(str(e), "settings_save_failed")
+
+
+def get(version_name: str, mc_dir: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    if not version_name:
+        return err("version required", "invalid_version")
+    if not safe_version_dir(version_name, mc_dir):
+        return err("invalid version", "invalid_version")
+    return ok(load(version_name, mc_dir))
+
+
+def resolve_launch_overrides(
+    version_name: str,
+    global_config: Optional[Dict[str, Any]] = None,
+    mc_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """合并全局配置与实例 overrides，供 launch.py 使用。"""
+    g = dict(global_config or {})
+    s = load(version_name, mc_dir)
+
+    min_mem = s.get("java_min_memory")
+    max_mem = s.get("java_max_memory")
+    if min_mem is None:
+        min_mem = g.get("java_min_memory", 512)
+    if max_mem is None:
+        max_mem = g.get("java_max_memory", 4096)
+
+    java_path = s.get("java_path") or g.get("java_path") or g.get("selected_java") or ""
+
+    extra_jvm: List[str] = []
+    jvm_str = str(s.get("jvm_args") or "").strip()
+    if jvm_str:
+        try:
+            extra_jvm = shlex.split(jvm_str, posix=(os.name != "nt"))
+        except ValueError:
+            extra_jvm = jvm_str.split()
+
+    env = {}
+    if isinstance(s.get("env_vars"), dict):
+        env = {str(k): str(v) for k, v in s["env_vars"].items() if k}
+
+    hooks = s.get("hooks") or {}
+    quick = s.get("quick_play") or {}
+
+    width = s.get("resolution_width")
+    height = s.get("resolution_height")
+    if width is None:
+        width = g.get("game_width")
+    if height is None:
+        height = g.get("game_height")
+
+    return {
+        "java_min_memory": int(min_mem or 512),
+        "java_max_memory": int(max_mem or 4096),
+        "java_path": java_path,
+        "extra_jvm_args": extra_jvm,
+        "env_vars": env,
+        "resolution": (int(width), int(height)) if width and height else None,
+        "fullscreen": s.get("fullscreen"),
+        "hooks": {
+            "pre_launch": str(hooks.get("pre_launch") or ""),
+            "wrapper": str(hooks.get("wrapper") or ""),
+            "post_exit": str(hooks.get("post_exit") or ""),
+        },
+        "quick_play": {
+            "type": quick.get("type"),
+            "world": quick.get("world"),
+            "server": quick.get("server"),
+            "port": quick.get("port"),
+        },
+        "custom_game_args": str(s.get("custom_game_args") or ""),
+        "raw": s,
+    }
+
+
+def split_jvm_args(s: str) -> List[str]:
+    s = (s or "").strip()
+    if not s:
+        return []
+    try:
+        return shlex.split(s, posix=(os.name != "nt"))
+    except ValueError:
+        return s.split()

--- a/modules/services/modrinth_content.py
+++ b/modules/services/modrinth_content.py
@@ -1,0 +1,269 @@
+"""Modrinth API 扩展：版本详情、依赖、hash 反查、更新检查。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from modules.log import log
+
+API = "https://api.modrinth.com/v2"
+USER_AGENT = "Bloret-Launcher/content (support@bloret.net)"
+
+
+def _session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(total=3, backoff_factor=0.8, status_forcelist=[429, 500, 502, 503, 504])
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.headers.update({"User-Agent": USER_AGENT})
+    return session
+
+
+def get_project_versions(
+    slug_or_id: str,
+    *,
+    loaders: Optional[Sequence[str]] = None,
+    game_versions: Optional[Sequence[str]] = None,
+) -> List[Dict[str, Any]]:
+    if not slug_or_id:
+        return []
+    url = f"{API}/project/{requests.utils.quote(str(slug_or_id), safe='')}/version"
+    parts = []
+    if loaders:
+        loaders_list = [loaders] if isinstance(loaders, str) else list(loaders)
+        parts.append(f"loaders={requests.utils.quote(json.dumps(loaders_list))}")
+    if game_versions:
+        gv = [game_versions] if isinstance(game_versions, str) else list(game_versions)
+        parts.append(f"game_versions={requests.utils.quote(json.dumps(gv))}")
+    if parts:
+        url += "?" + "&".join(parts)
+    try:
+        resp = _session().get(url, timeout=15)
+        if resp.status_code == 200:
+            data = resp.json()
+            return data if isinstance(data, list) else []
+        log(f"get_project_versions fail {slug_or_id}: {resp.status_code}", logging.WARNING)
+        return []
+    except Exception as e:
+        log(f"get_project_versions error {slug_or_id}: {e}", logging.ERROR)
+        return []
+
+
+def get_version(version_id: str) -> Optional[Dict[str, Any]]:
+    if not version_id:
+        return None
+    url = f"{API}/version/{requests.utils.quote(str(version_id), safe='')}"
+    try:
+        resp = _session().get(url, timeout=12)
+        if resp.status_code == 200:
+            data = resp.json()
+            return data if isinstance(data, dict) else None
+        return None
+    except Exception as e:
+        log(f"get_version error {version_id}: {e}", logging.ERROR)
+        return None
+
+
+def get_versions_by_hashes(
+    hashes: Sequence[str],
+    algorithm: str = "sha1",
+) -> Dict[str, Dict[str, Any]]:
+    """POST /version_files — 返回 {hash: version_object}。"""
+    cleaned = [h for h in hashes if h and isinstance(h, str)]
+    if not cleaned:
+        return {}
+    # API 单次建议别太大
+    out: Dict[str, Dict[str, Any]] = {}
+    session = _session()
+    for i in range(0, len(cleaned), 64):
+        chunk = cleaned[i : i + 64]
+        try:
+            resp = session.post(
+                f"{API}/version_files",
+                json={"hashes": chunk, "algorithm": algorithm},
+                timeout=20,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if isinstance(data, dict):
+                    for k, v in data.items():
+                        if isinstance(v, dict):
+                            out[k] = v
+            else:
+                log(f"version_files HTTP {resp.status_code}", logging.WARNING)
+        except Exception as e:
+            log(f"version_files error: {e}", logging.ERROR)
+    return out
+
+
+def primary_file(version_obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    files = version_obj.get("files") or []
+    if not files:
+        return None
+    primary = next((f for f in files if f.get("primary")), None)
+    if primary:
+        return primary
+    # 优先 jar
+    for f in files:
+        name = str(f.get("filename") or "")
+        if name.endswith(".jar"):
+            return f
+    return files[0]
+
+
+def pick_best_version(
+    versions: List[Dict[str, Any]],
+    *,
+    game_version: Optional[str] = None,
+    loaders: Optional[Sequence[str]] = None,
+) -> Optional[Dict[str, Any]]:
+    if not versions:
+        return None
+    loaders_l = {str(x).lower() for x in (loaders or [])}
+    ranked: List[Dict[str, Any]] = []
+    for v in versions:
+        if not isinstance(v, dict):
+            continue
+        gvs = [str(x) for x in (v.get("game_versions") or [])]
+        lds = [str(x).lower() for x in (v.get("loaders") or [])]
+        if game_version and gvs and game_version not in gvs:
+            continue
+        if loaders_l and lds and not (loaders_l & set(lds)):
+            continue
+        ranked.append(v)
+    pool = ranked or list(versions)
+    # 已按 API 时间倒序；取第一个 release 优先
+    for pref in ("release", "beta", "alpha"):
+        for v in pool:
+            if str(v.get("version_type") or "").lower() == pref:
+                return v
+    return pool[0] if pool else None
+
+
+def resolve_download_info(
+    slug_or_id: str,
+    *,
+    loaders: Optional[Sequence[str]] = None,
+    game_versions: Optional[Sequence[str]] = None,
+    version_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """
+    解析可下载文件信息。
+    返回: {
+      project_id, version_id, title, filename, url, sha1, sha512, size,
+      dependencies, loaders, game_versions, project_type?
+    }
+    """
+    version_obj = None
+    if version_id:
+        version_obj = get_version(version_id)
+    if not version_obj:
+        versions = get_project_versions(slug_or_id, loaders=loaders, game_versions=game_versions)
+        gv = None
+        if game_versions:
+            gv = game_versions[0] if not isinstance(game_versions, str) else game_versions
+        version_obj = pick_best_version(versions, game_version=gv, loaders=loaders)
+    if not version_obj:
+        return None
+    f = primary_file(version_obj)
+    if not f or not f.get("url"):
+        return None
+    hashes = f.get("hashes") or {}
+    return {
+        "project_id": version_obj.get("project_id") or "",
+        "version_id": version_obj.get("id") or "",
+        "title": version_obj.get("name") or slug_or_id,
+        "filename": f.get("filename") or f"{slug_or_id}.jar",
+        "url": f.get("url"),
+        "sha1": hashes.get("sha1") or "",
+        "sha512": hashes.get("sha512") or "",
+        "size": int(f.get("size") or 0),
+        "dependencies": version_obj.get("dependencies") or [],
+        "loaders": version_obj.get("loaders") or [],
+        "game_versions": version_obj.get("game_versions") or [],
+        "version_number": version_obj.get("version_number") or "",
+    }
+
+
+def collect_required_dependencies(
+    version_obj_or_deps: Any,
+    *,
+    loaders: Optional[Sequence[str]] = None,
+    game_versions: Optional[Sequence[str]] = None,
+    max_depth: int = 5,
+) -> List[Dict[str, Any]]:
+    """
+    递归收集 dependency_type == required 的依赖下载信息。
+    返回 resolve_download_info 风格的 list（已去重 project_id）。
+    """
+    if isinstance(version_obj_or_deps, dict) and "dependencies" in version_obj_or_deps:
+        deps = version_obj_or_deps.get("dependencies") or []
+    elif isinstance(version_obj_or_deps, list):
+        deps = version_obj_or_deps
+    else:
+        deps = []
+
+    seen: set = set()
+    result: List[Dict[str, Any]] = []
+
+    def walk(dep_list: List[Any], depth: int) -> None:
+        if depth > max_depth:
+            return
+        for dep in dep_list or []:
+            if not isinstance(dep, dict):
+                continue
+            # 只装 required；embedded 已打进主 jar，optional/incompatible 跳过
+            if str(dep.get("dependency_type") or "").lower() != "required":
+                continue
+            pid = dep.get("project_id") or ""
+            vid = dep.get("version_id") or ""
+            if not pid and not vid:
+                continue
+            key = pid or vid
+            if key in seen:
+                continue
+            seen.add(key)
+            info = resolve_download_info(
+                pid or vid,
+                loaders=loaders,
+                game_versions=game_versions,
+                version_id=vid or None,
+            )
+            if not info:
+                continue
+            # 再按实际 project_id 去重
+            real_pid = info.get("project_id") or key
+            if real_pid in {r.get("project_id") for r in result}:
+                continue
+            result.append(info)
+            walk(info.get("dependencies") or [], depth + 1)
+
+    walk(list(deps), 0)
+    return result
+
+
+def latest_for_project(
+    project_id: str,
+    *,
+    loaders: Optional[Sequence[str]] = None,
+    game_versions: Optional[Sequence[str]] = None,
+) -> Optional[Dict[str, Any]]:
+    return resolve_download_info(project_id, loaders=loaders, game_versions=game_versions)
+
+
+def meta_from_version_file(version_obj: Dict[str, Any]) -> Dict[str, Any]:
+    """把 version_files 返回的对象压成索引可用的 meta。"""
+    return {
+        "project_id": version_obj.get("project_id") or "",
+        "version_id": version_obj.get("id") or "",
+        "title": version_obj.get("name") or "",
+        "version_number": version_obj.get("version_number") or "",
+        "project_type": "",  # version 对象不含 project_type
+    }

--- a/modules/services/paths_util.py
+++ b/modules/services/paths_util.py
@@ -1,0 +1,178 @@
+"""版本目录路径工具（服务层共用）。"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+import modules.config as cfg
+
+
+def minecraft_dir() -> str:
+    data = cfg.read() or {}
+    return str(data.get("minecraft_dir") or "")
+
+
+def versions_root(mc_dir: Optional[str] = None) -> str:
+    root = mc_dir if mc_dir is not None else minecraft_dir()
+    if not root:
+        return ""
+    return os.path.join(root, "versions")
+
+
+def safe_version_dir(version_name: str, mc_dir: Optional[str] = None) -> str:
+    """返回 versions/<name> 的绝对路径；越界或不合法时返回空串。"""
+    if not version_name or ".." in version_name or "/" in version_name or "\\" in version_name:
+        return ""
+    root = versions_root(mc_dir)
+    if not root:
+        return ""
+    root_abs = os.path.abspath(root)
+    candidate = os.path.abspath(os.path.join(root_abs, version_name))
+    try:
+        if os.path.commonpath([candidate, root_abs]) != root_abs:
+            return ""
+    except ValueError:
+        return ""
+    return candidate
+
+
+def content_dir(version_name: str, kind: str, mc_dir: Optional[str] = None) -> str:
+    """kind: mods | resourcepacks | shaderpacks | datapacks | saves"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return ""
+    mapping = {
+        "mod": "mods",
+        "mods": "mods",
+        "resourcepack": "resourcepacks",
+        "resourcepacks": "resourcepacks",
+        "shader": "shaderpacks",
+        "shaderpack": "shaderpacks",
+        "shaderpacks": "shaderpacks",
+        "datapack": "datapacks",
+        "datapacks": "datapacks",
+        "saves": "saves",
+        "world": "saves",
+        "worlds": "saves",
+    }
+    sub = mapping.get((kind or "").lower())
+    if not sub:
+        return ""
+    return os.path.join(vdir, sub)
+
+
+def resolve_game_version(version_name: str, mc_dir: Optional[str] = None) -> str:
+    """从 .BL.json / 版本 JSON / 文件夹名解析 MC 版本号。"""
+    import json
+    import re
+
+    root = mc_dir if mc_dir is not None else minecraft_dir()
+    if root:
+        bl_path = os.path.join(root, "versions", ".BL.json")
+        if os.path.isfile(bl_path):
+            try:
+                with open(bl_path, "r", encoding="utf-8") as f:
+                    bl = json.load(f)
+                entry = (bl.get("versions") or {}).get(version_name) or {}
+                ver = entry.get("version")
+                if ver:
+                    return str(ver)
+            except Exception:
+                pass
+        vdir = safe_version_dir(version_name, root)
+        if vdir:
+            for candidate in (
+                os.path.join(vdir, f"{version_name}.json"),
+                os.path.join(vdir, "version.json"),
+            ):
+                if not os.path.isfile(candidate):
+                    continue
+                try:
+                    with open(candidate, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+                    # inheritsFrom 优先，否则 id
+                    inherited = data.get("inheritsFrom")
+                    if inherited:
+                        return str(inherited)
+                    vid = data.get("id") or ""
+                    m = re.match(r"^(\d+\.\d+(?:\.\d+)?)", str(vid))
+                    if m:
+                        return m.group(1)
+                    if vid and not any(x in vid.lower() for x in ("fabric", "forge", "quilt", "neoforge")):
+                        return str(vid)
+                except Exception:
+                    pass
+    m = re.match(r"^(\d+\.\d+(?:\.\d+)?)", version_name or "")
+    return m.group(1) if m else ""
+
+
+def detect_loader(version_name: str, mc_dir: Optional[str] = None) -> str:
+    """返回 fabric | forge | neoforge | quilt | vanilla。"""
+    import json
+
+    name_l = (version_name or "").lower()
+    if "quilt" in name_l:
+        return "quilt"
+    if "neoforge" in name_l:
+        return "neoforge"
+    if "forge" in name_l and "neoforge" not in name_l:
+        return "forge"
+    if "fabric" in name_l:
+        return "fabric"
+
+    root = mc_dir if mc_dir is not None else minecraft_dir()
+    if root:
+        bl_path = os.path.join(root, "versions", ".BL.json")
+        if os.path.isfile(bl_path):
+            try:
+                with open(bl_path, "r", encoding="utf-8") as f:
+                    bl = json.load(f)
+                entry = (bl.get("versions") or {}).get(version_name) or {}
+                if entry.get("Quilt"):
+                    return "quilt"
+                if entry.get("NeoForge"):
+                    return "neoforge"
+                if entry.get("Forge"):
+                    return "forge"
+                if entry.get("Fabric"):
+                    return "fabric"
+                loader = str(entry.get("loader") or "").lower()
+                if loader in ("fabric", "forge", "neoforge", "quilt"):
+                    return loader
+            except Exception:
+                pass
+        vdir = safe_version_dir(version_name, root)
+        if vdir:
+            jpath = os.path.join(vdir, f"{version_name}.json")
+            if os.path.isfile(jpath):
+                try:
+                    with open(jpath, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+                    main = str(data.get("mainClass") or "").lower()
+                    libs = " ".join(
+                        str(lib.get("name") or "").lower()
+                        for lib in (data.get("libraries") or [])
+                        if isinstance(lib, dict)
+                    )
+                    blob = main + " " + libs + " " + str(data.get("id") or "").lower()
+                    if "quilt" in blob:
+                        return "quilt"
+                    if "neoforge" in blob or "neoforged" in blob:
+                        return "neoforge"
+                    if "minecraftforge" in blob or "net.minecraftforge" in blob:
+                        return "forge"
+                    if "fabric" in blob:
+                        return "fabric"
+                except Exception:
+                    pass
+    return "vanilla"
+
+
+def pair_version_context(version_name: str, mc_dir: Optional[str] = None) -> Tuple[str, str, str]:
+    """(version_dir, game_version, loader)"""
+    return (
+        safe_version_dir(version_name, mc_dir),
+        resolve_game_version(version_name, mc_dir),
+        detect_loader(version_name, mc_dir),
+    )

--- a/modules/services/runtime_extras.py
+++ b/modules/services/runtime_extras.py
@@ -1,0 +1,298 @@
+"""启动 hooks、Discord RPC、崩溃报告浏览。"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from modules.services.base import ServiceResult, err, ok
+from modules.services.paths_util import safe_version_dir
+
+# ---------------- Hooks ----------------
+
+def _expand_hook(command: str, variables: Dict[str, str]) -> str:
+    out = command or ""
+    for k, v in variables.items():
+        out = out.replace(f"${k}", v).replace(f"%{k}%", v)
+    return out
+
+
+def run_pre_launch_hook(
+    command: str,
+    *,
+    instance_name: str,
+    instance_dir: str,
+    java_path: str,
+    cwd: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    command = (command or "").strip()
+    if not command:
+        return ok({"skipped": True})
+    variables = {
+        "INST_NAME": instance_name,
+        "INST_ID": instance_name,
+        "INST_DIR": instance_dir,
+        "INST_MC_DIR": instance_dir,
+        "INST_JAVA": java_path,
+    }
+    expanded = _expand_hook(command, variables)
+    try:
+        # shell 以支持用户写管道；工作目录实例目录
+        proc = subprocess.run(
+            expanded,
+            shell=True,
+            cwd=cwd or instance_dir or None,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if proc.returncode != 0:
+            return err(
+                f"pre-launch hook failed ({proc.returncode}): {(proc.stderr or proc.stdout or '')[:300]}",
+                "hook_failed",
+            )
+        return ok({"returncode": proc.returncode, "stdout": (proc.stdout or "")[:500]})
+    except Exception as e:
+        return err(str(e), "hook_failed")
+
+
+def wrap_launch_args(wrapper: str, launch_args: List[str], variables: Dict[str, str]) -> List[str]:
+    """把 wrapper 插到命令最前。支持 $INST_JAVA 等。"""
+    wrapper = (wrapper or "").strip()
+    if not wrapper:
+        return list(launch_args)
+    expanded = _expand_hook(wrapper, variables)
+    # 简单按空白拆（用户应写可执行路径）
+    import shlex
+
+    try:
+        parts = shlex.split(expanded, posix=(os.name != "nt"))
+    except ValueError:
+        parts = expanded.split()
+    return parts + list(launch_args)
+
+
+def spawn_post_exit_hook(
+    command: str,
+    *,
+    instance_name: str,
+    instance_dir: str,
+    java_path: str,
+    process_obj=None,
+) -> None:
+    """在游戏进程结束后异步跑 post-exit（不阻塞）。"""
+    command = (command or "").strip()
+    if not command:
+        return
+
+    def _runner():
+        try:
+            if process_obj is not None:
+                try:
+                    process_obj.wait()
+                except Exception:
+                    pass
+            variables = {
+                "INST_NAME": instance_name,
+                "INST_ID": instance_name,
+                "INST_DIR": instance_dir,
+                "INST_MC_DIR": instance_dir,
+                "INST_JAVA": java_path,
+            }
+            expanded = _expand_hook(command, variables)
+            subprocess.run(
+                expanded,
+                shell=True,
+                cwd=instance_dir or None,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except Exception:
+            pass
+
+    threading.Thread(target=_runner, daemon=True).start()
+
+
+# ---------------- Discord RPC ----------------
+
+class _DiscordRPC:
+    def __init__(self):
+        self._client = None
+        self._enabled = False
+        self._lock = threading.Lock()
+        self._app_id = "1123683254248148992"  # 可后续换成 Bloret 自己的
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = bool(enabled)
+        if not self._enabled:
+            self.clear()
+
+    def _ensure(self) -> bool:
+        if not self._enabled:
+            return False
+        if self._client is not None:
+            return True
+        try:
+            from pypresence import Presence  # type: ignore
+
+            self._client = Presence(self._app_id)
+            self._client.connect()
+            return True
+        except Exception:
+            self._client = None
+            return False
+
+    def set_activity(self, state: str, details: str = "Bloret Launcher") -> None:
+        with self._lock:
+            if not self._ensure():
+                return
+            try:
+                self._client.update(  # type: ignore
+                    state=state[:128],
+                    details=details[:128],
+                    large_image="minecraft",
+                    large_text="Bloret Launcher",
+                    start=int(time.time()),
+                )
+            except Exception:
+                try:
+                    self._client.close()  # type: ignore
+                except Exception:
+                    pass
+                self._client = None
+
+    def clear(self) -> None:
+        with self._lock:
+            if self._client is None:
+                return
+            try:
+                self._client.clear()
+            except Exception:
+                pass
+            try:
+                self._client.close()
+            except Exception:
+                pass
+            self._client = None
+
+
+_RPC = _DiscordRPC()
+
+
+def discord_set_enabled(enabled: bool) -> None:
+    _RPC.set_enabled(enabled)
+    try:
+        import modules.config as cfg
+
+        cfg.update_keys(discord_rpc=bool(enabled))
+    except Exception:
+        pass
+
+
+def discord_is_enabled() -> bool:
+    try:
+        import modules.config as cfg
+
+        return bool((cfg.read() or {}).get("discord_rpc"))
+    except Exception:
+        return False
+
+
+def discord_set_playing(version_name: str) -> None:
+    if not discord_is_enabled():
+        _RPC.set_enabled(False)
+        return
+    _RPC.set_enabled(True)
+    _RPC.set_activity(f"Playing {version_name}", "Minecraft via Bloret")
+
+
+def discord_clear() -> None:
+    _RPC.clear()
+
+
+# ---------------- Crash / Logs ----------------
+
+def list_crash_reports(version_name: str, mc_dir: Optional[str] = None, limit: int = 30) -> ServiceResult[List[Dict[str, Any]]]:
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return err("invalid version", "invalid_version")
+    crash_dir = os.path.join(vdir, "crash-reports")
+    logs_dir = os.path.join(vdir, "logs")
+    items: List[Dict[str, Any]] = []
+
+    def add_from(folder: str, log_type: str, pattern: str):
+        if not os.path.isdir(folder):
+            return
+        try:
+            for name in os.listdir(folder):
+                if not re.search(pattern, name, re.I):
+                    continue
+                path = os.path.join(folder, name)
+                if not os.path.isfile(path):
+                    continue
+                try:
+                    age = int(os.path.getmtime(path))
+                    size = os.path.getsize(path)
+                except OSError:
+                    age, size = 0, 0
+                items.append(
+                    {
+                        "name": name,
+                        "path": path,
+                        "type": log_type,
+                        "mtime": age,
+                        "size": size,
+                    }
+                )
+        except OSError:
+            pass
+
+    add_from(crash_dir, "crash", r"\.txt$")
+    add_from(logs_dir, "log", r"latest\.log$|\.log\.gz$|\.log$")
+    items.sort(key=lambda x: x.get("mtime") or 0, reverse=True)
+    return ok(items[: max(1, limit)])
+
+
+_TOKEN_RE = re.compile(
+    r"(access[_-]?token|session|password|authorization)\s*[:=]\s*([^\s\"']+)",
+    re.I,
+)
+_UUID_TOKENish = re.compile(r"\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b")
+
+
+def censor_log_text(text: str) -> str:
+    text = _TOKEN_RE.sub(r"\1: ***", text or "")
+    text = _UUID_TOKENish.sub("***jwt***", text)
+    return text
+
+
+def read_log_file(path: str, *, max_bytes: int = 256_000, censor: bool = True) -> ServiceResult[Dict[str, Any]]:
+    if not path or not os.path.isfile(path):
+        return err("file not found", "not_found")
+    # 只允许读 version 目录下
+    ap = os.path.abspath(path)
+    try:
+        size = os.path.getsize(ap)
+        with open(ap, "rb") as f:
+            if size > max_bytes:
+                f.seek(-max_bytes, os.SEEK_END)
+            raw = f.read()
+        # gzip?
+        text: str
+        if ap.endswith(".gz"):
+            import gzip
+
+            text = gzip.decompress(raw).decode("utf-8", errors="replace")
+        else:
+            text = raw.decode("utf-8", errors="replace")
+        if censor:
+            text = censor_log_text(text)
+        return ok({"path": ap, "size": size, "text": text, "censored": censor})
+    except Exception as e:
+        return err(str(e), "read_failed")

--- a/modules/services/skins_service.py
+++ b/modules/services/skins_service.py
@@ -1,0 +1,253 @@
+"""本地皮肤库（保存 / 列表 / 装备到微软账号）。"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from modules.services.base import ServiceResult, err, ok
+
+try:
+    import modules.globals as BLglobals
+except Exception:  # pragma: no cover
+    BLglobals = None  # type: ignore
+
+
+def _skins_root() -> str:
+    base = ""
+    if BLglobals is not None:
+        base = getattr(BLglobals, "datapath", "") or ""
+    if not base:
+        base = os.path.join(os.path.expanduser("~"), ".Bloret-Launcher")
+    path = os.path.join(base, "skins")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _index_path() -> str:
+    return os.path.join(_skins_root(), "index.json")
+
+
+def _load_index() -> Dict[str, Any]:
+    path = _index_path()
+    if not os.path.isfile(path):
+        return {"skins": [], "updated_at": 0}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"skins": [], "updated_at": 0}
+        data.setdefault("skins", [])
+        return data
+    except Exception:
+        return {"skins": [], "updated_at": 0}
+
+
+def _save_index(data: Dict[str, Any]) -> None:
+    data["updated_at"] = int(time.time())
+    path = _index_path()
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+def list_skins() -> ServiceResult[List[Dict[str, Any]]]:
+    data = _load_index()
+    skins = list(data.get("skins") or [])
+    # 校验文件还在
+    out = []
+    for s in skins:
+        if not isinstance(s, dict):
+            continue
+        p = s.get("path") or ""
+        if p and os.path.isfile(p):
+            out.append(s)
+    return ok(out)
+
+
+def import_skin_file(
+    file_path: str,
+    *,
+    name: str = "",
+    variant: str = "classic",  # classic | slim
+) -> ServiceResult[Dict[str, Any]]:
+    if not file_path or not os.path.isfile(file_path):
+        return err("file not found", "not_found")
+    if not str(file_path).lower().endswith(".png"):
+        return err("仅支持 PNG 皮肤", "invalid_format")
+    skin_id = uuid.uuid4().hex[:12]
+    dest_name = f"{skin_id}.png"
+    dest = os.path.join(_skins_root(), dest_name)
+    try:
+        with open(file_path, "rb") as src, open(dest, "wb") as dst:
+            dst.write(src.read())
+    except Exception as e:
+        return err(str(e), "copy_failed")
+    entry = {
+        "id": skin_id,
+        "name": name or Path(file_path).stem,
+        "path": dest,
+        "variant": variant if variant in ("classic", "slim") else "classic",
+        "created_at": int(time.time()),
+    }
+    data = _load_index()
+    skins = list(data.get("skins") or [])
+    skins.insert(0, entry)
+    data["skins"] = skins
+    _save_index(data)
+    return ok(entry)
+
+
+def delete_skin(skin_id: str) -> ServiceResult[bool]:
+    data = _load_index()
+    skins = list(data.get("skins") or [])
+    kept = []
+    removed = None
+    for s in skins:
+        if isinstance(s, dict) and s.get("id") == skin_id:
+            removed = s
+            continue
+        kept.append(s)
+    if not removed:
+        return err("not found", "not_found")
+    data["skins"] = kept
+    _save_index(data)
+    try:
+        p = removed.get("path")
+        if p and os.path.isfile(p):
+            os.remove(p)
+    except OSError:
+        pass
+    return ok(True)
+
+
+def _get_minecraft_access_token() -> Optional[str]:
+    """从 config / globals 尽量拿到 Minecraft 访问令牌。"""
+    try:
+        import modules.config as cfg
+
+        conf = cfg.read() or {}
+        # 常见字段
+        for key in ("mc_access_token", "minecraft_token", "access_token"):
+            if conf.get(key):
+                return str(conf.get(key))
+        accounts = conf.get("accounts") or conf.get("microsoft_accounts") or []
+        if isinstance(accounts, list):
+            for acc in accounts:
+                if not isinstance(acc, dict):
+                    continue
+                if acc.get("selected") or acc.get("active"):
+                    tok = acc.get("access_token") or acc.get("mc_token") or acc.get("token")
+                    if tok:
+                        return str(tok)
+            for acc in accounts:
+                if isinstance(acc, dict):
+                    tok = acc.get("access_token") or acc.get("mc_token") or acc.get("token")
+                    if tok:
+                        return str(tok)
+        # 单账号
+        acc = conf.get("account") or conf.get("microsoft_account") or {}
+        if isinstance(acc, dict):
+            tok = acc.get("access_token") or acc.get("mc_token") or acc.get("token")
+            if tok:
+                return str(tok)
+    except Exception:
+        pass
+    return None
+
+
+def equip_skin(skin_id: str, variant: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    """
+    通过 Mojang API 装备本地皮肤。
+    需要有效的 Minecraft access token；失败时仍保留本地库条目。
+    """
+    data = _load_index()
+    entry = next((s for s in (data.get("skins") or []) if isinstance(s, dict) and s.get("id") == skin_id), None)
+    if not entry:
+        return err("skin not found", "not_found")
+    path = entry.get("path") or ""
+    if not os.path.isfile(path):
+        return err("skin file missing", "not_found")
+    token = _get_minecraft_access_token()
+    if not token:
+        return err("未找到微软/Minecraft 登录令牌，请先登录正版账号", "no_token")
+
+    var = variant or entry.get("variant") or "classic"
+    if var not in ("classic", "slim"):
+        var = "classic"
+    try:
+        with open(path, "rb") as f:
+            png = f.read()
+        # POST https://api.minecraftservices.com/minecraft/profile/skins
+        files = {
+            "file": ("skin.png", png, "image/png"),
+        }
+        form = {"variant": var}
+        resp = requests.post(
+            "https://api.minecraftservices.com/minecraft/profile/skins",
+            headers={"Authorization": f"Bearer {token}"},
+            files=files,
+            data=form,
+            timeout=30,
+        )
+        if resp.status_code not in (200, 204):
+            return err(f"Mojang API HTTP {resp.status_code}: {resp.text[:200]}", "api_error")
+        entry["equipped_at"] = int(time.time())
+        entry["variant"] = var
+        # 写回
+        skins = []
+        for s in data.get("skins") or []:
+            if isinstance(s, dict) and s.get("id") == skin_id:
+                skins.append(entry)
+            else:
+                skins.append(s)
+        data["skins"] = skins
+        _save_index(data)
+        return ok({"id": skin_id, "variant": var, "status": "equipped"})
+    except Exception as e:
+        return err(str(e), "equip_failed")
+
+
+def query_player_textures(uuid_or_name: str) -> ServiceResult[Dict[str, Any]]:
+    """查询玩家皮肤/披风 URL（不装备）。"""
+    import re
+
+    session = requests.Session()
+    session.headers["User-Agent"] = "Bloret-Launcher/skins"
+    uid = uuid_or_name.strip().replace("-", "")
+    try:
+        if not re.fullmatch(r"[0-9a-fA-F]{32}", uid):
+            # name -> uuid
+            r = session.get(f"https://api.mojang.com/users/profiles/minecraft/{uuid_or_name.strip()}", timeout=10)
+            if r.status_code != 200:
+                return err("player not found", "not_found")
+            uid = r.json().get("id") or ""
+        if not uid:
+            return err("player not found", "not_found")
+        profile = session.get(
+            f"https://sessionserver.mojang.com/session/minecraft/profile/{uid}",
+            timeout=10,
+        )
+        if profile.status_code != 200:
+            return err("profile not found", "not_found")
+        props = profile.json().get("properties") or []
+        skin = cape = ""
+        for p in props:
+            if p.get("name") != "textures":
+                continue
+            raw = base64.b64decode(p.get("value") or "")
+            tex = json.loads(raw.decode("utf-8", errors="replace"))
+            textures = (tex.get("textures") or {})
+            skin = (textures.get("SKIN") or {}).get("url") or ""
+            cape = (textures.get("CAPE") or {}).get("url") or ""
+        return ok({"uuid": uid, "skin": skin, "cape": cape})
+    except Exception as e:
+        return err(str(e), "query_failed")

--- a/modules/services/worlds_service.py
+++ b/modules/services/worlds_service.py
@@ -1,0 +1,278 @@
+"""世界列表 / 服务器 / Quick Play 参数。"""
+
+from __future__ import annotations
+
+import os
+import struct
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from modules.services.base import ServiceResult, err, ok
+from modules.services.paths_util import content_dir, safe_version_dir
+
+
+# ---- 极简 NBT（改自 modules/versions.SimpleNBT，保持服务层独立） ----
+
+class _NBT:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+
+    def read_tag(self, include_name: bool = True):
+        if self.pos >= len(self.data):
+            return None, None, None
+        tag_type = self.data[self.pos]
+        self.pos += 1
+        if tag_type == 0:
+            return 0, None, None
+        name = self.read_string() if include_name else ""
+        payload = self.read_payload(tag_type)
+        return tag_type, name, payload
+
+    def read_payload(self, tag_type: int):
+        if tag_type == 1:
+            return self.read_byte()
+        if tag_type == 2:
+            return self.read_short()
+        if tag_type == 3:
+            return self.read_int()
+        if tag_type == 4:
+            return self.read_long()
+        if tag_type == 5:
+            return self.read_float()
+        if tag_type == 6:
+            return self.read_double()
+        if tag_type == 7:
+            length = self.read_int()
+            val = self.data[self.pos : self.pos + length]
+            self.pos += length
+            return val
+        if tag_type == 8:
+            return self.read_string()
+        if tag_type == 9:
+            return self.read_list()
+        if tag_type == 10:
+            return self.read_compound()
+        if tag_type == 11:
+            length = self.read_int()
+            val = [self.read_int() for _ in range(length)]
+            return val
+        if tag_type == 12:
+            length = self.read_int()
+            val = [self.read_long() for _ in range(length)]
+            return val
+        return None
+
+    def read_byte(self):
+        v = self.data[self.pos]
+        self.pos += 1
+        return v if v < 128 else v - 256
+
+    def read_short(self):
+        v = struct.unpack(">h", self.data[self.pos : self.pos + 2])[0]
+        self.pos += 2
+        return v
+
+    def read_int(self):
+        v = struct.unpack(">i", self.data[self.pos : self.pos + 4])[0]
+        self.pos += 4
+        return v
+
+    def read_long(self):
+        v = struct.unpack(">q", self.data[self.pos : self.pos + 8])[0]
+        self.pos += 8
+        return v
+
+    def read_float(self):
+        v = struct.unpack(">f", self.data[self.pos : self.pos + 4])[0]
+        self.pos += 4
+        return v
+
+    def read_double(self):
+        v = struct.unpack(">d", self.data[self.pos : self.pos + 8])[0]
+        self.pos += 8
+        return v
+
+    def read_string(self):
+        length = struct.unpack(">H", self.data[self.pos : self.pos + 2])[0]
+        self.pos += 2
+        s = self.data[self.pos : self.pos + length].decode("utf-8", errors="replace")
+        self.pos += length
+        return s
+
+    def read_list(self):
+        tag_type = self.read_byte()
+        if tag_type < 0:
+            tag_type += 256
+        length = self.read_int()
+        return [self.read_payload(tag_type) for _ in range(max(0, length))]
+
+    def read_compound(self):
+        result = {}
+        while True:
+            tag_type, name, payload = self.read_tag(True)
+            if tag_type == 0 or tag_type is None:
+                break
+            result[name] = payload
+        return result
+
+
+def _load_level_dat(path: Path) -> Dict[str, Any]:
+    import gzip
+
+    try:
+        raw = path.read_bytes()
+        try:
+            raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        nbt = _NBT(raw)
+        tag_type, name, payload = nbt.read_tag(True)
+        if isinstance(payload, dict):
+            data = payload.get("Data") or payload
+            if isinstance(data, dict):
+                return data
+        return {}
+    except Exception:
+        return {}
+
+
+def list_worlds(version_name: str, mc_dir: Optional[str] = None) -> ServiceResult[List[Dict[str, Any]]]:
+    saves = content_dir(version_name, "saves", mc_dir)
+    if not saves:
+        return err("invalid version", "invalid_version")
+    if not os.path.isdir(saves):
+        return ok([])
+    items: List[Dict[str, Any]] = []
+    try:
+        for name in sorted(os.listdir(saves)):
+            wdir = os.path.join(saves, name)
+            if not os.path.isdir(wdir):
+                continue
+            level = Path(wdir) / "level.dat"
+            meta = _load_level_dat(level) if level.is_file() else {}
+            last_played = meta.get("LastPlayed")
+            # LastPlayed 是毫秒
+            try:
+                last_played_s = int(last_played) / 1000.0 if last_played else os.path.getmtime(wdir)
+            except Exception:
+                last_played_s = os.path.getmtime(wdir)
+            icon = os.path.join(wdir, "icon.png")
+            items.append(
+                {
+                    "id": name,
+                    "name": str(meta.get("LevelName") or name),
+                    "folder": name,
+                    "path": wdir,
+                    "last_played": int(last_played_s),
+                    "gamemode": meta.get("GameType"),
+                    "hardcore": bool(meta.get("hardcore") or meta.get("Hardcore")),
+                    "difficulty": meta.get("Difficulty"),
+                    "icon": icon if os.path.isfile(icon) else "",
+                    "type": "singleplayer",
+                }
+            )
+        items.sort(key=lambda x: x.get("last_played") or 0, reverse=True)
+        return ok(items)
+    except Exception as e:
+        return err(str(e), "worlds_list_failed")
+
+
+def list_servers(version_name: str, mc_dir: Optional[str] = None) -> ServiceResult[List[Dict[str, Any]]]:
+    """读取 versions/<name>/servers.dat（若有）；否则空。"""
+    vdir = safe_version_dir(version_name, mc_dir)
+    if not vdir:
+        return err("invalid version", "invalid_version")
+    path = os.path.join(vdir, "servers.dat")
+    if not os.path.isfile(path):
+        return ok([])
+    try:
+        # 复用 versions.parse_servers_dat 若可用
+        try:
+            from modules.versions import parse_servers_dat
+
+            servers = parse_servers_dat(path) or []
+        except Exception:
+            servers = []
+        out = []
+        for s in servers:
+            if not isinstance(s, dict):
+                continue
+            out.append(
+                {
+                    "name": s.get("name") or s.get("Name") or "",
+                    "address": s.get("ip") or s.get("Ip") or s.get("address") or "",
+                    "icon": s.get("icon") or "",
+                    "type": "server",
+                }
+            )
+        return ok(out)
+    except Exception as e:
+        return err(str(e), "servers_list_failed")
+
+
+def quick_play_game_args(quick: Dict[str, Any]) -> List[str]:
+    """
+    生成 Minecraft Quick Play 游戏参数（1.20+ / 23w14a+）。
+    quick: {type, world, server, port}
+    """
+    if not quick or not quick.get("type"):
+        return []
+    qtype = str(quick.get("type") or "").lower()
+    args: List[str] = []
+    if qtype in ("singleplayer", "world"):
+        world = quick.get("world") or ""
+        if world:
+            args += ["--quickPlaySingleplayer", str(world)]
+    elif qtype in ("multiplayer", "server"):
+        server = quick.get("server") or ""
+        if server:
+            # 新版
+            args += ["--quickPlayMultiplayer", str(server)]
+            # 兼容旧 --server / --port
+            host = server
+            port = quick.get("port")
+            if ":" in server and not str(server).startswith("["):
+                host, _, p = server.rpartition(":")
+                if p.isdigit():
+                    port = port or int(p)
+            args += ["--server", host]
+            if port:
+                args += ["--port", str(port)]
+    return args
+
+
+def set_quick_play_world(version_name: str, world_folder: str, mc_dir: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    from modules.services import instance_settings
+
+    return instance_settings.save(
+        version_name,
+        {"quick_play": {"type": "singleplayer", "world": world_folder, "server": None, "port": None}},
+        mc_dir=mc_dir,
+    )
+
+
+def set_quick_play_server(
+    version_name: str,
+    address: str,
+    port: Optional[int] = None,
+    mc_dir: Optional[str] = None,
+) -> ServiceResult[Dict[str, Any]]:
+    from modules.services import instance_settings
+
+    return instance_settings.save(
+        version_name,
+        {"quick_play": {"type": "multiplayer", "world": None, "server": address, "port": port}},
+        mc_dir=mc_dir,
+    )
+
+
+def clear_quick_play(version_name: str, mc_dir: Optional[str] = None) -> ServiceResult[Dict[str, Any]]:
+    from modules.services import instance_settings
+
+    return instance_settings.save(
+        version_name,
+        {"quick_play": {"type": None, "world": None, "server": None, "port": None}},
+        mc_dir=mc_dir,
+    )

--- a/qml/components/CoreManagerDialog.qml
+++ b/qml/components/CoreManagerDialog.qml
@@ -19,6 +19,8 @@ Dialog {
     property var servers: []
     property var mods: []
     property var resourcePacks: []
+    property var shaderPacks: []
+    property var dataPacks: []
     property var worlds: []
     property var contentUpdates: []
     property var crashReports: []
@@ -90,6 +92,8 @@ Dialog {
                     { key: "server", text: Backend ? Backend.tr("服务器") : "服务器" },
                     { key: "resource", text: Backend ? Backend.tr("资源包") : "资源包" },
                     { key: "mod", text: Backend ? Backend.tr("Mod") : "Mod" },
+                    { key: "shader", text: Backend ? Backend.tr("光影") : "光影" },
+                    { key: "datapack", text: Backend ? Backend.tr("数据包") : "数据包" },
                     { key: "worlds", text: Backend ? Backend.tr("世界") : "世界" },
                     { key: "advanced", text: Backend ? Backend.tr("高级") : "高级" }
                 ]
@@ -103,7 +107,9 @@ Dialog {
                         if (index === 1) loadServers()
                         if (index === 2) loadResourcePacks()
                         if (index === 3) loadMods()
-                        if (index === 4) loadWorlds()
+                        if (index === 4) loadShaderPacks()
+                        if (index === 5) loadDataPacks()
+                        if (index === 6) loadWorlds()
                     }
                 }
             }
@@ -635,6 +641,160 @@ Dialog {
                 }
             }
 
+            // Shader packs
+            ColumnLayout {
+                spacing: 10
+                RowLayout {
+                    spacing: 10
+                    Label {
+                        text: Backend ? Backend.tr("光影包") : "光影包"
+                        font.weight: Font.DemiBold
+                        color: Theme.currentTheme.colors.textColor
+                    }
+                    Item { Layout.fillWidth: true }
+                    Button {
+                        icon.name: "ic_fluent_arrow_sync_20_regular"
+                        flat: true
+                        onClicked: loadShaderPacks()
+                    }
+                    Button {
+                        text: Backend ? Backend.tr("打开文件夹") : "打开文件夹"
+                        icon.name: "ic_fluent_folder_open_20_regular"
+                        onClicked: if (Backend) Backend.openSubFolder(versionName, "shaderpacks")
+                    }
+                }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    ColumnLayout {
+                        width: parent ? parent.width - 20 : 600
+                        spacing: 8
+                        Repeater {
+                            model: shaderPacks
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 52
+                                radius: 8
+                                color: Theme.currentTheme.colors.cardColor
+                                border.color: Theme.currentTheme.colors.cardBorderColor
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                    spacing: 10
+                                    Label {
+                                        text: modelData.name
+                                        font.weight: Font.DemiBold
+                                        color: Theme.currentTheme.colors.textColor
+                                        Layout.fillWidth: true
+                                        elide: Text.ElideRight
+                                    }
+                                    Switch {
+                                        checked: modelData.enabled !== false
+                                        onCheckedChanged: {
+                                            if (Backend && checked !== modelData.enabled) {
+                                                Backend.toggleContentPack(modelData.path, checked)
+                                                loadShaderPacks()
+                                            }
+                                        }
+                                    }
+                                    Button {
+                                        icon.name: "ic_fluent_delete_20_regular"
+                                        flat: true
+                                        onClicked: {
+                                            if (Backend && Backend.deleteContentPack(modelData.path))
+                                                loadShaderPacks()
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Label {
+                            visible: shaderPacks.length === 0
+                            text: Backend ? Backend.tr("暂无光影包") : "暂无光影包"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                    }
+                }
+            }
+
+            // Datapacks
+            ColumnLayout {
+                spacing: 10
+                RowLayout {
+                    spacing: 10
+                    Label {
+                        text: Backend ? Backend.tr("数据包") : "数据包"
+                        font.weight: Font.DemiBold
+                        color: Theme.currentTheme.colors.textColor
+                    }
+                    Item { Layout.fillWidth: true }
+                    Button {
+                        icon.name: "ic_fluent_arrow_sync_20_regular"
+                        flat: true
+                        onClicked: loadDataPacks()
+                    }
+                    Button {
+                        text: Backend ? Backend.tr("打开文件夹") : "打开文件夹"
+                        icon.name: "ic_fluent_folder_open_20_regular"
+                        onClicked: if (Backend) Backend.openSubFolder(versionName, "datapacks")
+                    }
+                }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    ColumnLayout {
+                        width: parent ? parent.width - 20 : 600
+                        spacing: 8
+                        Repeater {
+                            model: dataPacks
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 52
+                                radius: 8
+                                color: Theme.currentTheme.colors.cardColor
+                                border.color: Theme.currentTheme.colors.cardBorderColor
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                    spacing: 10
+                                    Label {
+                                        text: modelData.name
+                                        font.weight: Font.DemiBold
+                                        color: Theme.currentTheme.colors.textColor
+                                        Layout.fillWidth: true
+                                        elide: Text.ElideRight
+                                    }
+                                    Switch {
+                                        checked: modelData.enabled !== false
+                                        onCheckedChanged: {
+                                            if (Backend && checked !== modelData.enabled) {
+                                                Backend.toggleContentPack(modelData.path, checked)
+                                                loadDataPacks()
+                                            }
+                                        }
+                                    }
+                                    Button {
+                                        icon.name: "ic_fluent_delete_20_regular"
+                                        flat: true
+                                        onClicked: {
+                                            if (Backend && Backend.deleteContentPack(modelData.path))
+                                                loadDataPacks()
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Label {
+                            visible: dataPacks.length === 0
+                            text: Backend ? Backend.tr("暂无数据包") : "暂无数据包"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                    }
+                }
+            }
+
             // Worlds + Quick Play
             ColumnLayout {
                 spacing: 10
@@ -1034,6 +1194,24 @@ Dialog {
         Backend.requestWorlds(versionName)
     }
 
+    function loadShaderPacks() {
+        if (!Backend) return
+        try {
+            shaderPacks = Backend.listShaderpacks(versionName) || []
+        } catch (e) {
+            shaderPacks = []
+        }
+    }
+
+    function loadDataPacks() {
+        if (!Backend) return
+        try {
+            dataPacks = Backend.listDatapacks(versionName) || []
+        } catch (e) {
+            dataPacks = []
+        }
+    }
+
     function loadCrashReports() {
         if (!Backend) return
         crashLogText = ""
@@ -1104,6 +1282,8 @@ Dialog {
         servers = []
         mods = []
         resourcePacks = []
+        shaderPacks = []
+        dataPacks = []
         worlds = []
         contentUpdates = []
         crashReports = []

--- a/qml/components/CoreManagerDialog.qml
+++ b/qml/components/CoreManagerDialog.qml
@@ -19,13 +19,24 @@ Dialog {
     property var servers: []
     property var mods: []
     property var resourcePacks: []
+    property var worlds: []
+    property var contentUpdates: []
+    property var crashReports: []
+    property string crashLogText: ""
     property bool isOpening: false
     property bool modsLoading: false
     property bool resourcePacksLoading: false
+    property bool worldsLoading: false
     property int modsRequestSerial: 0
     property int resourcePacksRequestSerial: 0
     property string activeModsRequestId: ""
     property string activeResourcePacksRequestId: ""
+    property int minMemMb: 512
+    property int maxMemMb: 4096
+    property string extraJvmArgs: ""
+    property string preLaunchHook: ""
+    property string wrapperHook: ""
+    property string postExitHook: ""
 
     Connections {
         target: Backend
@@ -40,6 +51,23 @@ Dialog {
             resourcePacksLoading = false
             if (!errorMessage) resourcePacks = items
             else console.error("[CoreManager] resource pack scan failed:", errorMessage)
+        }
+        function onWorldsListReady(loadedVersion, items) {
+            if (loadedVersion !== versionName) return
+            worldsLoading = false
+            worlds = items || []
+        }
+        function onContentUpdatesReady(loadedVersion, items) {
+            if (loadedVersion !== versionName) return
+            contentUpdates = items || []
+        }
+        function onContentActionFinished(action, loadedVersion, ok, message) {
+            if (loadedVersion !== versionName) return
+            if (action === "update_all" || action === "enrich") loadMods()
+        }
+        function onCrashReportsReady(loadedVersion, items) {
+            if (loadedVersion !== versionName) return
+            crashReports = items || []
         }
     }
 
@@ -62,6 +90,7 @@ Dialog {
                     { key: "server", text: Backend ? Backend.tr("服务器") : "服务器" },
                     { key: "resource", text: Backend ? Backend.tr("资源包") : "资源包" },
                     { key: "mod", text: Backend ? Backend.tr("Mod") : "Mod" },
+                    { key: "worlds", text: Backend ? Backend.tr("世界") : "世界" },
                     { key: "advanced", text: Backend ? Backend.tr("高级") : "高级" }
                 ]
                 
@@ -74,6 +103,7 @@ Dialog {
                         if (index === 1) loadServers()
                         if (index === 2) loadResourcePacks()
                         if (index === 3) loadMods()
+                        if (index === 4) loadWorlds()
                     }
                 }
             }
@@ -475,15 +505,35 @@ Dialog {
                     }
                     Item { Layout.fillWidth: true }
                     Button {
+                        text: Backend ? Backend.tr("检查更新") : "检查更新"
+                        flat: true
+                        onClicked: if (Backend) Backend.checkContentUpdates(versionName)
+                    }
+                    Button {
+                        text: Backend ? Backend.tr("全部更新") : "全部更新"
+                        highlighted: contentUpdates.length > 0
+                        onClicked: if (Backend) Backend.updateAllContent(versionName)
+                    }
+                    Button {
                         icon.name: "ic_fluent_arrow_sync_20_regular"
                         flat: true
-                        onClicked: loadMods()
+                        onClicked: {
+                            if (Backend) Backend.enrichContentIndex(versionName)
+                            loadMods()
+                        }
                     }
                     Button {
                         text: Backend ? Backend.tr("打开文件夹") : "打开文件夹"
                         icon.name: "ic_fluent_folder_open_20_regular"
                         onClicked: if (Backend) Backend.openSubFolder(versionName, "mods")
                     }
+                }
+
+                Label {
+                    visible: contentUpdates.length > 0
+                    text: (Backend ? Backend.tr("可更新") : "可更新") + ": " + contentUpdates.length
+                    color: Theme.currentTheme.colors.primaryColor
+                    font.pixelSize: 12
                 }
                 
                 ScrollView {
@@ -584,6 +634,154 @@ Dialog {
                     }
                 }
             }
+
+            // Worlds + Quick Play
+            ColumnLayout {
+                spacing: 10
+                RowLayout {
+                    spacing: 10
+                    Label {
+                        text: Backend ? Backend.tr("单人世界") : "单人世界"
+                        font.weight: Font.DemiBold
+                        color: Theme.currentTheme.colors.textColor
+                    }
+                    Item { Layout.fillWidth: true }
+                    Button {
+                        text: Backend ? Backend.tr("刷新") : "刷新"
+                        flat: true
+                        onClicked: loadWorlds()
+                    }
+                    Button {
+                        text: Backend ? Backend.tr("清除 Quick Play") : "清除 Quick Play"
+                        flat: true
+                        onClicked: if (Backend) Backend.clearQuickPlay(versionName)
+                    }
+                }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    ColumnLayout {
+                        width: parent.width - 20
+                        spacing: 8
+                        Repeater {
+                            model: worlds
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 56
+                                radius: 8
+                                color: Theme.currentTheme.colors.cardColor
+                                border.color: Theme.currentTheme.colors.cardBorderColor
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                    spacing: 12
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 2
+                                        Label {
+                                            text: modelData.name || modelData.folder
+                                            font.weight: Font.DemiBold
+                                            color: Theme.currentTheme.colors.textColor
+                                        }
+                                        Label {
+                                            text: modelData.folder || ""
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            font.pixelSize: 11
+                                        }
+                                    }
+                                    Button {
+                                        text: Backend ? Backend.tr("设为直进") : "设为直进"
+                                        onClicked: {
+                                            if (Backend) Backend.setQuickPlayWorld(versionName, modelData.folder)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Label {
+                            visible: worlds.length === 0
+                            text: worldsLoading
+                                  ? (Backend ? Backend.tr("加载中...") : "加载中...")
+                                  : (Backend ? Backend.tr("暂无世界") : "暂无世界")
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+
+                        // Crash reports
+                        Label {
+                            text: Backend ? Backend.tr("崩溃 / 日志") : "崩溃 / 日志"
+                            font.weight: Font.DemiBold
+                            color: Theme.currentTheme.colors.textColor
+                            Layout.topMargin: 12
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Button {
+                                text: Backend ? Backend.tr("刷新日志列表") : "刷新日志列表"
+                                flat: true
+                                onClicked: loadCrashReports()
+                            }
+                            Item { Layout.fillWidth: true }
+                        }
+                        Repeater {
+                            model: crashReports
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 48
+                                radius: 8
+                                color: Theme.currentTheme.colors.cardColor
+                                border.color: Theme.currentTheme.colors.cardBorderColor
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 8
+                                    spacing: 8
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 1
+                                        Label {
+                                            text: modelData.name || ""
+                                            font.weight: Font.DemiBold
+                                            color: Theme.currentTheme.colors.textColor
+                                            elide: Text.ElideRight
+                                            Layout.fillWidth: true
+                                        }
+                                        Label {
+                                            text: (modelData.type || "") + (modelData.size ? (" · " + Math.round(modelData.size / 1024) + " KB") : "")
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            font.pixelSize: 11
+                                        }
+                                    }
+                                    Button {
+                                        text: Backend ? Backend.tr("查看") : "查看"
+                                        onClicked: openCrashLog(modelData.path)
+                                    }
+                                }
+                            }
+                        }
+                        Label {
+                            visible: crashReports.length === 0
+                            text: Backend ? Backend.tr("暂无崩溃报告 / 日志") : "暂无崩溃报告 / 日志"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignHCenter
+                        }
+                        ScrollView {
+                            visible: crashLogText.length > 0
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 160
+                            TextArea {
+                                width: parent.width - 16
+                                readOnly: true
+                                wrapMode: TextEdit.Wrap
+                                text: crashLogText
+                                color: Theme.currentTheme.colors.textSecondaryColor
+                                font.family: "monospace"
+                                font.pixelSize: 11
+                                selectByMouse: true
+                            }
+                        }
+                    }
+                }
+            }
             
             ScrollView {
                 id: advancedScroll
@@ -622,6 +820,80 @@ Dialog {
                                 id: fabricSwitch
                                 checked: coreData.Fabric || false
                             }
+                        }
+                    }
+
+                    ColumnLayout {
+                        spacing: 10
+                        Layout.fillWidth: true
+                        Label {
+                            text: Backend ? Backend.tr("实例设置") : "实例设置"
+                            font.weight: Font.DemiBold
+                            color: Theme.currentTheme.colors.textColor
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("最小内存 (MB，空=全局)") : "最小内存 (MB，空=全局)"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: minMemEdit
+                            Layout.fillWidth: true
+                            placeholderText: "512"
+                            text: minMemMb > 0 ? String(minMemMb) : ""
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("最大内存 (MB，空=全局)") : "最大内存 (MB，空=全局)"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: maxMemEdit
+                            Layout.fillWidth: true
+                            placeholderText: "4096"
+                            text: maxMemMb > 0 ? String(maxMemMb) : ""
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("额外 JVM 参数") : "额外 JVM 参数"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: jvmArgsEdit
+                            Layout.fillWidth: true
+                            placeholderText: "-XX:+UseG1GC"
+                            text: extraJvmArgs
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("Pre-launch hook") : "Pre-launch hook"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: preHookEdit
+                            Layout.fillWidth: true
+                            placeholderText: "echo $INST_NAME"
+                            text: preLaunchHook
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("Wrapper") : "Wrapper"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: wrapperHookEdit
+                            Layout.fillWidth: true
+                            text: wrapperHook
+                        }
+                        Label {
+                            text: Backend ? Backend.tr("Post-exit hook") : "Post-exit hook"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                        }
+                        TextField {
+                            id: postHookEdit
+                            Layout.fillWidth: true
+                            text: postExitHook
+                        }
+                        Button {
+                            text: Backend ? Backend.tr("保存实例设置") : "保存实例设置"
+                            highlighted: true
+                            Layout.fillWidth: true
+                            onClicked: saveInstanceSettings()
                         }
                     }
                     
@@ -755,6 +1027,62 @@ Dialog {
         if (!Backend.requestResourcePacks(versionName, activeResourcePacksRequestId))
             resourcePacksLoading = false
     }
+
+    function loadWorlds() {
+        if (!Backend) return
+        worldsLoading = true
+        Backend.requestWorlds(versionName)
+    }
+
+    function loadCrashReports() {
+        if (!Backend) return
+        crashLogText = ""
+        Backend.requestCrashReports(versionName)
+    }
+
+    function openCrashLog(path) {
+        if (!Backend || !path) return
+        var res = Backend.readCrashLog(path)
+        if (res && res.ok && res.data)
+            crashLogText = res.data.text || ""
+        else
+            crashLogText = (res && res.message) || "read failed"
+    }
+
+    function loadInstanceSettings() {
+        if (!Backend) return
+        var s = Backend.getInstanceSettings(versionName) || {}
+        minMemMb = s.java_min_memory || 0
+        maxMemMb = s.java_max_memory || 0
+        extraJvmArgs = s.jvm_args || ""
+        var hooks = s.hooks || {}
+        preLaunchHook = hooks.pre_launch || ""
+        wrapperHook = hooks.wrapper || ""
+        postExitHook = hooks.post_exit || ""
+        minMemEdit.text = minMemMb > 0 ? String(minMemMb) : ""
+        maxMemEdit.text = maxMemMb > 0 ? String(maxMemMb) : ""
+        jvmArgsEdit.text = extraJvmArgs
+        preHookEdit.text = preLaunchHook
+        wrapperHookEdit.text = wrapperHook
+        postHookEdit.text = postExitHook
+    }
+
+    function saveInstanceSettings() {
+        if (!Backend) return
+        var patch = {
+            jvm_args: jvmArgsEdit.text,
+            hooks: {
+                pre_launch: preHookEdit.text,
+                wrapper: wrapperHookEdit.text,
+                post_exit: postHookEdit.text
+            }
+        }
+        var minT = minMemEdit.text.trim()
+        var maxT = maxMemEdit.text.trim()
+        patch.java_min_memory = minT === "" ? null : parseInt(minT)
+        patch.java_max_memory = maxT === "" ? null : parseInt(maxT)
+        Backend.saveInstanceSettings(versionName, patch)
+    }
     
     function openWithVersion(name) {
         // 防止重复打开
@@ -776,6 +1104,11 @@ Dialog {
         servers = []
         mods = []
         resourcePacks = []
+        worlds = []
+        contentUpdates = []
+        crashReports = []
+        crashLogText = ""
+        loadInstanceSettings()
         
         stackedWidget.currentIndex = 0
         open()

--- a/qml/components/ExportMrpackDialog.qml
+++ b/qml/components/ExportMrpackDialog.qml
@@ -8,12 +8,15 @@ Dialog {
 
     title: (Backend ? Backend.tr("导出 Modrinth 整合包") : "导出 Modrinth 整合包")
     modal: true
-    width: 450
-    implicitHeight: 480
+    width: 520
+    implicitHeight: 560
+    height: Math.min(640, Overlay.overlay ? Overlay.overlay.height - 40 : 560)
     standardButtons: Dialog.NoButton
 
     property string versionName: ""
     property var instanceInfo: ({})
+    property var exportCandidates: []
+    property var selectedPaths: ({})
 
     property bool exporting: false
     property bool exportDone: false
@@ -35,6 +38,31 @@ Dialog {
         }
     }
 
+    function loadCandidates() {
+        exportCandidates = []
+        selectedPaths = ({})
+        if (!Backend || !versionName) return
+        var res = Backend.getMrpackExportCandidates(versionName) || {}
+        var list = (res && res.ok) ? (res.data || []) : []
+        exportCandidates = list
+        var sel = ({})
+        for (var i = 0; i < list.length; i++) {
+            var c = list[i]
+            if (c && c.path && c.default_selected)
+                sel[c.path] = true
+        }
+        selectedPaths = sel
+    }
+
+    function selectedPathList() {
+        var out = []
+        var keys = Object.keys(selectedPaths)
+        for (var i = 0; i < keys.length; i++) {
+            if (selectedPaths[keys[i]]) out.push(keys[i])
+        }
+        return out
+    }
+
     function openForVersion(name) {
         versionName = name
         exporting = false
@@ -43,18 +71,18 @@ Dialog {
         outputPath = ""
         exportError = ""
         if (Backend) {
-            instanceInfo = Backend.getMrpackInstanceInfo(name)
+            instanceInfo = Backend.getMrpackInstanceInfo(name) || {}
         }
         packNameField.text = instanceInfo.name || name
         packVersionField.text = "1.0.0"
+        loadCandidates()
         open()
     }
 
     ColumnLayout {
         Layout.fillWidth: true
-        spacing: 16
+        spacing: 12
 
-        // 实例信息
         Rectangle {
             Layout.fillWidth: true
             implicitHeight: infoLayout.implicitHeight + 16
@@ -88,17 +116,17 @@ Dialog {
                     visible: instanceInfo.loader && instanceInfo.loader !== "unknown"
                 }
                 Label {
-                    text: (Backend ? Backend.tr("文件数: %1").arg(instanceInfo.file_count || 0) : "文件数: " + (instanceInfo.file_count || 0))
+                    text: (Backend ? Backend.tr("候选文件: %1 / 已选 %2").arg(exportCandidates.length).arg(selectedPathList().length)
+                                   : ("候选: " + exportCandidates.length + " 已选: " + selectedPathList().length))
                     font.pixelSize: 12
                     color: Theme.currentTheme.colors.textColor
                 }
             }
         }
 
-        // 输入区域
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 12
+            spacing: 10
             visible: !exporting && !exportDone
 
             ColumnLayout {
@@ -139,7 +167,6 @@ Dialog {
                 RowLayout {
                     Layout.fillWidth: true
                     spacing: 8
-
                     TextField {
                         id: savePathField
                         Layout.fillWidth: true
@@ -147,7 +174,6 @@ Dialog {
                         placeholderText: (Backend ? Backend.tr("点击浏览选择保存位置") : "点击浏览选择保存位置")
                         text: exportDialog.outputPath
                     }
-
                     Button {
                         text: (Backend ? Backend.tr("浏览...") : "浏览...")
                         onClicked: {
@@ -158,27 +184,69 @@ Dialog {
                                     defaultName,
                                     "Modrinth Modpack Files (*.mrpack)"
                                 )
-                                if (path && path.length > 0) {
+                                if (path && path.length > 0)
                                     exportDialog.outputPath = path
+                            }
+                        }
+                    }
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 6
+                RowLayout {
+                    Layout.fillWidth: true
+                    Label {
+                        text: (Backend ? Backend.tr("导出内容") : "导出内容")
+                        font.weight: Font.DemiBold
+                        color: Theme.currentTheme.colors.textColor
+                    }
+                    Item { Layout.fillWidth: true }
+                    Button {
+                        text: (Backend ? Backend.tr("全选默认") : "全选默认")
+                        flat: true
+                        onClicked: loadCandidates()
+                    }
+                }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 160
+                    clip: true
+                    ColumnLayout {
+                        width: parent.width - 12
+                        spacing: 4
+                        Repeater {
+                            model: exportCandidates
+                            CheckBox {
+                                text: {
+                                    var sz = modelData.size ? (" · " + Math.round(modelData.size / 1024) + "KB") : ""
+                                    return (modelData.path || "") + sz
+                                }
+                                checked: !!(selectedPaths[modelData.path])
+                                onCheckedChanged: {
+                                    var s = Object.assign({}, selectedPaths)
+                                    if (checked) s[modelData.path] = true
+                                    else delete s[modelData.path]
+                                    selectedPaths = s
                                 }
                             }
+                        }
+                        Label {
+                            visible: exportCandidates.length === 0
+                            text: (Backend ? Backend.tr("无可导出文件（或未扫描到）") : "无可导出文件")
+                            color: Theme.currentTheme.colors.textSecondaryColor
                         }
                     }
                 }
             }
         }
 
-        // 导出中
         ColumnLayout {
             Layout.fillWidth: true
             spacing: 12
             visible: exporting
-
-            ProgressBar {
-                Layout.fillWidth: true
-                indeterminate: true
-            }
-
+            ProgressBar { Layout.fillWidth: true; indeterminate: true }
             Label {
                 text: (Backend ? Backend.tr("正在导出整合包...") : "正在导出整合包...")
                 Layout.alignment: Qt.AlignHCenter
@@ -186,12 +254,10 @@ Dialog {
             }
         }
 
-        // 导出结果
         ColumnLayout {
             Layout.fillWidth: true
             spacing: 12
             visible: exportDone
-
             Label {
                 text: exportDialog.exportSuccess
                     ? (Backend ? Backend.tr("整合包已成功导出到:") : "整合包已成功导出到:")
@@ -200,7 +266,6 @@ Dialog {
                 Layout.fillWidth: true
                 color: Theme.currentTheme.colors.textColor
             }
-
             Label {
                 text: exportDialog.outputPath
                 wrapMode: Text.WrapAnywhere
@@ -211,19 +276,15 @@ Dialog {
             }
         }
 
-        // 按钮区域
         RowLayout {
             Layout.fillWidth: true
             spacing: 8
             visible: !exporting
-
             Item { Layout.fillWidth: true }
-
             Button {
                 text: (Backend ? Backend.tr("取消") : "取消")
                 onClicked: exportDialog.close()
             }
-
             Button {
                 text: exportDialog.exportDone
                     ? (Backend ? Backend.tr("关闭") : "关闭")
@@ -234,27 +295,39 @@ Dialog {
                 onClicked: {
                     if (exportDialog.exportDone) {
                         exportDialog.close()
-                    } else {
-                        exportDialog.exporting = true
-                        exportDialog.exportRequestSerial++
-                        exportDialog.activeExportRequestId = "export:" + exportDialog.exportRequestSerial
-                        var submitted = Backend && Backend.requestMrpackExport(
+                        return
+                    }
+                    exportDialog.exporting = true
+                    exportDialog.exportRequestSerial++
+                    exportDialog.activeExportRequestId = "export:" + exportDialog.exportRequestSerial
+                    var paths = selectedPathList()
+                    var submitted = false
+                    if (Backend && Backend.requestMrpackExportWithSelection) {
+                        submitted = Backend.requestMrpackExportWithSelection(
+                            exportDialog.versionName,
+                            packNameField.text.trim(),
+                            packVersionField.text.trim(),
+                            exportDialog.outputPath,
+                            exportDialog.activeExportRequestId,
+                            paths
+                        )
+                    } else if (Backend) {
+                        submitted = Backend.requestMrpackExport(
                             exportDialog.versionName,
                             packNameField.text.trim(),
                             packVersionField.text.trim(),
                             exportDialog.outputPath,
                             exportDialog.activeExportRequestId
                         )
-                        if (!submitted) {
-                            exportDialog.exporting = false
-                            exportDialog.exportDone = true
-                            exportDialog.exportSuccess = false
-                            exportDialog.exportError = Backend ? Backend.tr("相同路径已有导出任务") : "An export is already running for this path"
-                        }
+                    }
+                    if (!submitted) {
+                        exportDialog.exporting = false
+                        exportDialog.exportDone = true
+                        exportDialog.exportSuccess = false
+                        exportDialog.exportError = Backend ? Backend.tr("相同路径已有导出任务") : "An export is already running for this path"
                     }
                 }
             }
         }
     }
-
 }

--- a/qml/components/VersionNameDialog.qml
+++ b/qml/components/VersionNameDialog.qml
@@ -20,6 +20,8 @@ Dialog {
             return Backend ? Backend.tr("安装 Forge 版本 %1").arg(version) : ("安装 Forge 版本 " + version)
         if (loaderType === "neoforge")
             return Backend ? Backend.tr("安装 NeoForge 版本 %1").arg(version) : ("安装 NeoForge 版本 " + version)
+        if (loaderType === "quilt")
+            return Backend ? Backend.tr("安装 Quilt 版本 %1").arg(version) : ("安装 Quilt 版本 " + version)
         return Backend ? Backend.tr("安装 Minecraft 版本 %1").arg(version) : ("安装 Minecraft 版本 " + version)
     }
 

--- a/qml/pages/Download.qml
+++ b/qml/pages/Download.qml
@@ -52,7 +52,25 @@ FluentPage {
                 _currentSource = Backend.getDownloadSource()
             }
         }
+        function onImportInstancesReady(items) {
+            importableInstances = items || []
+            importStatusText = importableInstances.length
+                ? ((Backend ? Backend.tr("找到实例") : "找到实例") + ": " + importableInstances.length)
+                : (Backend ? Backend.tr("未找到可导入实例") : "未找到可导入实例")
+        }
+        function onImportInstanceFinished(ok, name, message) {
+            importStatusText = ok
+                ? ((Backend ? Backend.tr("导入成功") : "导入成功") + ": " + name + (message ? (" — " + message) : ""))
+                : ((Backend ? Backend.tr("导入失败") : "导入失败") + ": " + (message || name || ""))
+            if (ok && Backend && Backend.invalidateLaunchItemsCache)
+                Backend.invalidateLaunchItemsCache()
+        }
     }
+
+    property var importableInstances: []
+    property string importBasePath: ""
+    property string importStatusText: ""
+    property string importTargetName: ""
 
     // ── 下载任务状态（稳定 ListModel，避免每秒销毁重建）──
     property int _dlActive: 0
@@ -182,6 +200,7 @@ FluentPage {
     property var fabricVersionList: []
     property var forgeVersionList: []
     property var neoForgeVersionList: []
+    property var quiltVersionList: []
     property string currentSelectionTarget: ""
     property bool _ignoreIndexChange: false
 
@@ -205,6 +224,11 @@ FluentPage {
         neoForgeVersionList = bloretVersions.slice()
         neoForgeVersionList.push(Backend.tr("其他版本..."))
         neoForgeCombo.model = neoForgeVersionList
+
+        quiltVersionList = bloretVersions.slice()
+        quiltVersionList.push(Backend.tr("其他版本..."))
+        if (typeof quiltCombo !== "undefined" && quiltCombo)
+            quiltCombo.model = quiltVersionList
     }
 
     Component.onCompleted: {
@@ -215,6 +239,8 @@ FluentPage {
             versionDialog.confirmed.connect(function(name) {
                 if (versionDialog.loaderType === "fabric") {
                     Backend.downloadFabric(fabricCombo.currentText, name)
+                } else if (versionDialog.loaderType === "quilt") {
+                    Backend.downloadQuilt(quiltCombo.currentText, name)
                 } else if (versionDialog.loaderType === "forge") {
                     Backend.downloadForge(forgeCombo.currentText, name)
                 } else if (versionDialog.loaderType === "neoforge") {
@@ -259,6 +285,13 @@ FluentPage {
                 neoForgeCombo.model = neoForgeVersionList
             }
             neoForgeCombo.currentIndex = neoForgeVersionList.indexOf(version)
+        } else if (currentSelectionTarget === "quilt") {
+            let index = quiltVersionList.indexOf(version)
+            if (index === -1) {
+                quiltVersionList.splice(quiltVersionList.length - 1, 0, version)
+                quiltCombo.model = quiltVersionList
+            }
+            quiltCombo.currentIndex = quiltVersionList.indexOf(version)
         }
         _ignoreIndexChange = false
     }
@@ -640,6 +673,74 @@ FluentPage {
             }
         }
 
+        // Quilt
+        DownloadCard {
+            RowLayout {
+                width: parent.width
+                spacing: 16
+
+                CardIcon {
+                    source: Qt.resolvedUrl("../../icon/fabric.png")
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 120
+                    spacing: 2
+
+                    Label {
+                        font.weight: Font.DemiBold
+                        text: "Quilt Loader"
+                        color: downloadPage._cText
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+
+                    Label {
+                        text: (Backend ? Backend.tr("安装 Quilt 加载器（Fabric 兼容生态）") : "安装 Quilt 加载器（Fabric 兼容生态）")
+                        color: downloadPage._cTextSecondary
+                        font.pixelSize: 12
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                        maximumLineCount: 2
+                    }
+                }
+
+                ComboBox {
+                    id: quiltCombo
+                    Layout.preferredWidth: 160
+                    Layout.minimumWidth: 120
+                    onCurrentIndexChanged: {
+                        if (_ignoreIndexChange) return
+                        if (model[currentIndex] === (Backend ? Backend.tr("其他版本...") : "其他版本...")) {
+                            currentSelectionTarget = "quilt"
+                            selectVersionDialog.open()
+                        }
+                    }
+                }
+
+                Button {
+                    text: (Backend ? Backend.tr("下载并安装") : "下载并安装")
+                    highlighted: true
+                    Layout.alignment: Qt.AlignVCenter
+                    onClicked: {
+                        if (!Backend) return
+                        let ver = quiltCombo.currentText
+                        if (ver === (Backend ? Backend.tr("其他版本...") : "其他版本...")) {
+                            currentSelectionTarget = "quilt"
+                            selectVersionDialog.open()
+                            return
+                        }
+                        versionDialog.version = ver
+                        versionDialog.fabric = false
+                        versionDialog.loaderType = "quilt"
+                        versionDialog.open()
+                    }
+                }
+            }
+        }
+
         // Forge
         DownloadCard {
             RowLayout {
@@ -936,6 +1037,139 @@ FluentPage {
                     Layout.alignment: Qt.AlignVCenter
                     onClicked: {
                         if (Backend) Backend.importMrpack()
+                    }
+                }
+            }
+        }
+
+        DownloadCard {
+            ColumnLayout {
+                width: parent.width
+                spacing: 12
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 16
+
+                    CardIcon {
+                        source: Qt.resolvedUrl("../../icon/exeapps.png")
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+                        Label {
+                            font.weight: Font.DemiBold
+                            text: (Backend ? Backend.tr("从 Prism / MultiMC 导入") : "从 Prism / MultiMC 导入")
+                            color: downloadPage._cText
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                        }
+                        Label {
+                            text: (Backend ? Backend.tr("选择启动器根目录或 instances 目录，导入 mods/config/saves") : "选择启动器根目录或 instances 目录，导入 mods/config/saves")
+                            color: downloadPage._cTextSecondary
+                            font.pixelSize: 12
+                            Layout.fillWidth: true
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+                    TextField {
+                        id: importPathField
+                        Layout.fillWidth: true
+                        text: importBasePath
+                        placeholderText: (Backend ? Backend.tr("PrismLauncher / MultiMC 路径") : "PrismLauncher / MultiMC 路径")
+                        onTextChanged: importBasePath = text
+                    }
+                    Button {
+                        text: (Backend ? Backend.tr("浏览") : "浏览")
+                        onClicked: {
+                            if (!Backend) return
+                            var p = Backend.selectImportLauncherFolder()
+                            if (p) {
+                                importBasePath = p
+                                importPathField.text = p
+                            }
+                        }
+                    }
+                    Button {
+                        text: (Backend ? Backend.tr("自动检测") : "自动检测")
+                        onClicked: {
+                            if (!Backend) return
+                            var paths = Backend.getDefaultImportPaths() || {}
+                            var p = paths.prism || paths.multimc || ""
+                            if (p) {
+                                importBasePath = p
+                                importPathField.text = p
+                                importStatusText = (Backend.tr("已定位") + ": " + p)
+                            } else {
+                                importStatusText = Backend.tr("未找到默认路径，请手动浏览")
+                            }
+                        }
+                    }
+                    Button {
+                        text: (Backend ? Backend.tr("扫描") : "扫描")
+                        highlighted: true
+                        onClicked: {
+                            if (!Backend || !importBasePath) return
+                            importStatusText = Backend.tr("扫描中...")
+                            Backend.requestImportableInstances(importBasePath)
+                        }
+                    }
+                }
+
+                Label {
+                    Layout.fillWidth: true
+                    text: importStatusText
+                    color: downloadPage._cTextSecondary
+                    font.pixelSize: 12
+                    wrapMode: Text.WordWrap
+                }
+
+                Repeater {
+                    model: importableInstances
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        height: 52
+                        radius: 8
+                        color: downloadPage._cCard
+                        border.color: downloadPage._cCardBorder
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 10
+                            spacing: 10
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 2
+                                Label {
+                                    text: modelData.name || modelData.folder || ""
+                                    font.weight: Font.DemiBold
+                                    color: downloadPage._cText
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+                                Label {
+                                    text: (modelData.minecraft_version || "") + (modelData.path ? (" · " + modelData.path) : "")
+                                    color: downloadPage._cTextSecondary
+                                    font.pixelSize: 11
+                                    elide: Text.ElideMiddle
+                                    Layout.fillWidth: true
+                                }
+                            }
+                            Button {
+                                text: (Backend ? Backend.tr("导入") : "导入")
+                                onClicked: {
+                                    if (!Backend) return
+                                    importStatusText = (Backend.tr("正在导入") + ": " + (modelData.name || modelData.folder))
+                                    Backend.importExternalInstance(modelData.path, "")
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/qml/pages/Download.qml
+++ b/qml/pages/Download.qml
@@ -64,6 +64,10 @@ FluentPage {
                 : ((Backend ? Backend.tr("导入失败") : "导入失败") + ": " + (message || name || ""))
             if (ok && Backend && Backend.invalidateLaunchItemsCache)
                 Backend.invalidateLaunchItemsCache()
+            // 若提示缺 loader，引导用户到版本安装区
+            if (ok && message && (String(message).indexOf("version JSON") >= 0 || String(message).indexOf("缺少可启动") >= 0)) {
+                importStatusText += "\n" + (Backend ? Backend.tr("提示：请在上方安装对应 MC + Loader，再启动该实例。") : "请安装对应 MC+Loader 后再启动")
+            }
         }
     }
 

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -1482,6 +1482,20 @@ FluentPage {
                     onClicked: systemRestartDialog.open()
                 }
             }
+
+            SettingCard {
+                Layout.fillWidth: true
+                title: Backend ? Backend.tr("Discord 状态") : "Discord 状态"
+                description: Backend ? Backend.tr("启动游戏时在 Discord 显示正在游玩（需安装 pypresence）") : "启动游戏时在 Discord 显示正在游玩（需安装 pypresence）"
+                icon.name: "ic_fluent_chat_20_regular"
+                Switch {
+                    checked: Backend && Backend.isDiscordRpcEnabled ? Backend.isDiscordRpcEnabled() : false
+                    onCheckedChanged: {
+                        if (Backend && Backend.setDiscordRpcEnabled)
+                            Backend.setDiscordRpcEnabled(checked)
+                    }
+                }
+            }
         }
 
         // ── System confirmation dialogs ──

--- a/qml/pages/Tools.qml
+++ b/qml/pages/Tools.qml
@@ -8,6 +8,7 @@ FluentPage {
     title: (Backend ? Backend.tr("小工具") : "小工具")
 
     property var pluginToolCards: []
+    property var skinLibrary: []
 
     function loadPluginToolCards() {
         pluginToolCards = []
@@ -25,7 +26,14 @@ FluentPage {
         }
     }
 
-    Component.onCompleted: loadPluginToolCards()
+    function reloadSkins() {
+        if (Backend) Backend.requestSkins()
+    }
+
+    Component.onCompleted: {
+        loadPluginToolCards()
+        reloadSkins()
+    }
 
     Connections {
         target: (typeof PluginHost !== "undefined") ? PluginHost : null
@@ -60,6 +68,9 @@ FluentPage {
         function onLogsCleared() {
             logClearedInfoBar.visible = true
             logClearedTimer.start()
+        }
+        function onSkinsListReady(items) {
+            skinLibrary = items || []
         }
     }
 
@@ -421,5 +432,144 @@ FluentPage {
             }
         }
 
+        // --- 本地皮肤库 ---
+        Label {
+            font.pixelSize: 20
+            font.weight: Font.DemiBold
+            text: (Backend ? Backend.tr("皮肤库") : "皮肤库")
+            Layout.topMargin: 10
+            color: Theme.currentTheme.colors.textColor
+        }
+
+        Frame {
+            Layout.fillWidth: true
+            padding: 15
+            background: Rectangle {
+                color: Theme.currentTheme.colors.cardColor
+                radius: 8
+                border.color: Theme.currentTheme.colors.controlBorderColor
+            }
+
+            ColumnLayout {
+                width: parent.width
+                spacing: 12
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+                    Label {
+                        text: (Backend ? Backend.tr("本地保存的皮肤，可装备到已登录的微软账号") : "本地保存的皮肤，可装备到已登录的微软账号")
+                        color: Theme.currentTheme.colors.textSecondaryColor
+                        Layout.fillWidth: true
+                        wrapMode: Text.WordWrap
+                    }
+                    ComboBox {
+                        id: skinVariantCombo
+                        model: ["classic", "slim"]
+                        currentIndex: 0
+                        Layout.preferredWidth: 110
+                    }
+                    Button {
+                        text: (Backend ? Backend.tr("导入 PNG") : "导入 PNG")
+                        highlighted: true
+                        onClicked: {
+                            if (!Backend) return
+                            var path = Backend.selectSkinPng()
+                            if (!path) return
+                            var name = path.split(/[\\/]/).pop().replace(/\.png$/i, "")
+                            var res = Backend.importSkinFile(path, name, skinVariantCombo.currentText)
+                            skinLibStatus.text = res && res.ok
+                                ? (Backend.tr("已导入") + ": " + name)
+                                : (Backend.tr("导入失败") + ": " + ((res && res.message) || ""))
+                            reloadSkins()
+                        }
+                    }
+                    Button {
+                        text: (Backend ? Backend.tr("刷新") : "刷新")
+                        flat: true
+                        onClicked: reloadSkins()
+                    }
+                }
+
+                Label {
+                    id: skinLibStatus
+                    Layout.fillWidth: true
+                    color: Theme.currentTheme.colors.textSecondaryColor
+                    font.pixelSize: 12
+                    text: ""
+                }
+
+                Repeater {
+                    model: skinLibrary
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        height: 64
+                        radius: 8
+                        color: Theme.currentTheme.colors.cardColor
+                        border.color: Theme.currentTheme.colors.controlBorderColor
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 10
+                            spacing: 12
+
+                            Image {
+                                source: modelData.path ? ("file:///" + String(modelData.path).replace(/\\/g, "/")) : ""
+                                sourceSize.width: 40
+                                sourceSize.height: 40
+                                fillMode: Image.PreserveAspectFit
+                                Layout.preferredWidth: 40
+                                Layout.preferredHeight: 40
+                            }
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 2
+                                Label {
+                                    text: modelData.name || modelData.id || ""
+                                    font.weight: Font.DemiBold
+                                    color: Theme.currentTheme.colors.textColor
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+                                Label {
+                                    text: (modelData.variant || "classic") + (modelData.equipped_at ? " · equipped" : "")
+                                    color: Theme.currentTheme.colors.textSecondaryColor
+                                    font.pixelSize: 11
+                                }
+                            }
+                            Button {
+                                text: (Backend ? Backend.tr("装备") : "装备")
+                                onClicked: {
+                                    if (!Backend) return
+                                    var res = Backend.equipSkin(modelData.id, modelData.variant || skinVariantCombo.currentText)
+                                    skinLibStatus.text = res && res.ok
+                                        ? (Backend.tr("已装备") + ": " + (modelData.name || modelData.id))
+                                        : (Backend.tr("装备失败") + ": " + ((res && res.message) || ""))
+                                    reloadSkins()
+                                }
+                            }
+                            Button {
+                                icon.name: "ic_fluent_delete_20_regular"
+                                flat: true
+                                onClicked: {
+                                    if (!Backend) return
+                                    if (Backend.deleteSkin(modelData.id)) {
+                                        skinLibStatus.text = Backend.tr("已删除")
+                                        reloadSkins()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Label {
+                    visible: skinLibrary.length === 0
+                    text: (Backend ? Backend.tr("暂无本地皮肤，点击「导入 PNG」添加") : "暂无本地皮肤，点击「导入 PNG」添加")
+                    color: Theme.currentTheme.colors.textSecondaryColor
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+        }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ Send2Trash
 winsdk; sys_platform == 'win32'
 toml
 psutil
+# Optional: Discord Rich Presence (Settings → System). Missing package = silent no-op.
+pypresence
 dulwich
 # WeChat QR code generation (optional)
 qrcode[pil]

--- a/test_p0_p2_features.py
+++ b/test_p0_p2_features.py
@@ -1,0 +1,246 @@
+"""P0–P2 feature unit tests (no network, no GUI)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _ensure_stubs():
+    if "modules" not in sys.modules:
+        m = type(sys)("modules")
+        m.__path__ = [str(ROOT / "modules")]  # type: ignore
+        sys.modules["modules"] = m
+    if "modules.services" not in sys.modules:
+        m = type(sys)("modules.services")
+        m.__path__ = [str(ROOT / "modules" / "services")]  # type: ignore
+        sys.modules["modules.services"] = m
+    if "modules.log" not in sys.modules:
+        log_mod = type(sys)("modules.log")
+
+        def log(msg, *a, **k):
+            pass
+
+        log_mod.log = log  # type: ignore
+        sys.modules["modules.log"] = log_mod
+    if "modules.config" not in sys.modules:
+        cfg = type(sys)("modules.config")
+        cfg.read = lambda: {}  # type: ignore
+        cfg.update_keys = lambda **k: None  # type: ignore
+        sys.modules["modules.config"] = cfg
+    if "modules.globals" not in sys.modules:
+        g = type(sys)("modules.globals")
+        g.datapath = tempfile.gettempdir()
+        g._pending_launch_hooks = None
+        sys.modules["modules.globals"] = g
+    if "modules.i18n" not in sys.modules:
+        i18n = type(sys)("modules.i18n")
+        i18n.i18nText = lambda x: x  # type: ignore
+        sys.modules["modules.i18n"] = i18n
+
+
+def _import_service(mod_file: str, qualname: str):
+    _ensure_stubs()
+    # base first
+    if "modules.services.base" not in sys.modules:
+        base_path = ROOT / "modules" / "services" / "base.py"
+        spec = importlib.util.spec_from_file_location("modules.services.base", base_path)
+        assert spec and spec.loader
+        base = importlib.util.module_from_spec(spec)
+        sys.modules["modules.services.base"] = base
+        spec.loader.exec_module(base)
+    if "modules.services.paths_util" not in sys.modules and mod_file != "paths_util.py":
+        pu_path = ROOT / "modules" / "services" / "paths_util.py"
+        if pu_path.exists():
+            spec = importlib.util.spec_from_file_location("modules.services.paths_util", pu_path)
+            assert spec and spec.loader
+            pu = importlib.util.module_from_spec(spec)
+            sys.modules["modules.services.paths_util"] = pu
+            spec.loader.exec_module(pu)
+
+    path = ROOT / "modules" / "services" / mod_file
+    name = f"modules.services.{qualname}"
+    if name in sys.modules and getattr(sys.modules[name], "__file__", None):
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestContentIndex(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.mc = self.tmp.name
+        self.version = "1.21.1-Fabric"
+        self.vdir = Path(self.mc) / "versions" / self.version
+        self.mods = self.vdir / "mods"
+        self.mods.mkdir(parents=True)
+        (self.mods / "demo.jar").write_bytes(b"hello-mod-bytes")
+        self.ci = _import_service("content_index.py", "content_index")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_scan_and_upsert(self):
+        with mock.patch.object(self.ci, "safe_version_dir", return_value=str(self.vdir)):
+            with mock.patch.object(self.ci, "minecraft_dir", return_value=self.mc):
+                idx = self.ci.scan_filesystem(self.version, mc_dir=self.mc, compute_hash=True)
+                self.assertIn("items", idx)
+                items = self.ci.list_indexed(self.version, kind="mod", mc_dir=self.mc)
+                self.assertTrue(any(i["filename"] == "demo.jar" for i in items))
+                row = self.ci.upsert_item(
+                    self.version,
+                    path=str(self.mods / "demo.jar"),
+                    kind="mod",
+                    project_id="AABB",
+                    version_id="VV11",
+                    source="modrinth",
+                    title="Demo",
+                    mc_dir=self.mc,
+                )
+                self.assertEqual(row["project_id"], "AABB")
+                found = self.ci.get_by_project(self.version, "AABB", mc_dir=self.mc)
+                self.assertIsNotNone(found)
+                assert found is not None
+                self.assertEqual(found["version_id"], "VV11")
+                self.assertTrue((self.vdir / "content-index.json").is_file())
+
+
+class TestInstanceSettings(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.mc = self.tmp.name
+        self.version = "TestInst"
+        self.vdir = Path(self.mc) / "versions" / self.version
+        self.vdir.mkdir(parents=True)
+        self.mod = _import_service("instance_settings.py", "instance_settings")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_save_load_overrides(self):
+        with mock.patch.object(self.mod, "safe_version_dir", return_value=str(self.vdir)):
+            with mock.patch.object(self.mod, "minecraft_dir", return_value=self.mc):
+                res = self.mod.save(
+                    self.version,
+                    {
+                        "java_max_memory": 8192,
+                        "jvm_args": "-XX:+UseG1GC",
+                        "hooks": {"pre_launch": "echo hi"},
+                        "quick_play": {"type": "singleplayer", "world": "New World"},
+                    },
+                    mc_dir=self.mc,
+                )
+                self.assertTrue(res.ok)
+                loaded = self.mod.load(self.version, mc_dir=self.mc)
+                self.assertEqual(loaded["java_max_memory"], 8192)
+                self.assertIn("UseG1GC", loaded["jvm_args"])
+                self.assertEqual(loaded["hooks"]["pre_launch"], "echo hi")
+                merged = self.mod.resolve_launch_overrides(
+                    self.version,
+                    {"java_min_memory": 512, "java_max_memory": 2048},
+                    mc_dir=self.mc,
+                )
+                self.assertEqual(merged["java_max_memory"], 8192)
+                self.assertTrue(any("UseG1GC" in a for a in merged["extra_jvm_args"]))
+                self.assertEqual(merged["quick_play"]["world"], "New World")
+
+
+class TestQuickPlayArgs(unittest.TestCase):
+    def test_args(self):
+        mod = _import_service("worlds_service.py", "worlds_service")
+        args = mod.quick_play_game_args({"type": "singleplayer", "world": "MyWorld"})
+        self.assertIn("--quickPlaySingleplayer", args)
+        self.assertIn("MyWorld", args)
+        args2 = mod.quick_play_game_args({"type": "multiplayer", "server": "play.example.com:25565"})
+        self.assertIn("--quickPlayMultiplayer", args2)
+        self.assertIn("--server", args2)
+
+
+class TestMrpackCandidates(unittest.TestCase):
+    def test_candidates_and_collect(self):
+        _ensure_stubs()
+        path = ROOT / "modules" / "mrpack_export.py"
+        name = "modules.mrpack_export"
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            inst = Path(tmp)
+            (inst / "mods").mkdir()
+            (inst / "mods" / "a.jar").write_bytes(b"jar")
+            (inst / "logs").mkdir()
+            (inst / "logs" / "latest.log").write_text("x")
+            (inst / "config").mkdir()
+            (inst / "config" / "x.toml").write_text("a=1")
+            cands = mod.get_export_candidates(str(inst))
+            paths = {c["path"] for c in cands}
+            self.assertIn("mods/a.jar", paths)
+            self.assertIn("config/x.toml", paths)
+            self.assertNotIn("logs/latest.log", paths)
+            files = mod.collect_files(str(inst), selected_paths=["mods/a.jar"])
+            self.assertEqual(len(files), 1)
+
+
+class TestSkinsLocal(unittest.TestCase):
+    def test_import_list_delete(self):
+        mod = _import_service("skins_service.py", "skins_service")
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(mod, "_skins_root", return_value=tmp):
+                png = Path(tmp) / "src.png"
+                png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\0" * 32)
+                res = mod.import_skin_file(str(png), name="test", variant="slim")
+                self.assertTrue(res.ok)
+                listed = mod.list_skins()
+                self.assertTrue(listed.ok)
+                data = listed.data or []
+                self.assertEqual(len(data), 1)
+                sid = data[0]["id"]
+                self.assertTrue(mod.delete_skin(sid).ok)
+                self.assertEqual(len(mod.list_skins().data or []), 0)
+
+
+class TestLogCensor(unittest.TestCase):
+    def test_censor(self):
+        mod = _import_service("runtime_extras.py", "runtime_extras")
+        text = "accessToken: supersecrettoken123 and Authorization: Bearer abc"
+        out = mod.censor_log_text(text)
+        self.assertNotIn("supersecrettoken123", out)
+        self.assertIn("***", out)
+
+
+class TestModrinthDepFilter(unittest.TestCase):
+    def test_only_required(self):
+        mod = _import_service("modrinth_content.py", "modrinth_content")
+        with mock.patch.object(mod, "resolve_download_info") as m:
+            m.side_effect = lambda pid, **kw: {
+                "project_id": pid,
+                "version_id": "v1",
+                "filename": f"{pid}.jar",
+                "url": "http://x",
+                "dependencies": [],
+            }
+            deps = [
+                {"project_id": "req1", "dependency_type": "required"},
+                {"project_id": "opt1", "dependency_type": "optional"},
+                {"project_id": "emb1", "dependency_type": "embedded"},
+            ]
+            out = mod.collect_required_dependencies(deps)
+            ids = {x["project_id"] for x in out}
+            self.assertEqual(ids, {"req1"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Close major gaps vs Modrinth App for **P0–P2**: content index, dependency install/update, instance settings, Quilt, Prism/MMC import, worlds/Quick Play, skins, hooks, Discord RPC, crash logs, stronger mrpack export.
- Service-first design under `modules/services/*` with Backend/QML wiring (Download / Tools / Settings / Core Manager).
- Analysis doc: `docs/modrinth-feature-gap-analysis.md`
- Offline tests: `test_p0_p2_features.py` (7 passed)

## What’s included
| Area | Notes |
|------|--------|
| Content index | `versions/<name>/content-index.json` (hash/project/version) |
| Mods | install with required deps; check/update all |
| Instance settings | memory/JVM/hooks/Quick Play overrides → launch |
| Quilt | install path + Download page card |
| Import | Prism/MultiMC scan + import UI on Download page |
| Worlds | Core Manager tab + Quick Play direct join |
| Skins | local library on Tools page (import/equip/delete) |
| Discord RPC | Settings → System switch |
| Crash logs | Core Manager worlds tab, censored read |
| mrpack export | candidate tree + selected paths + skip caches |

## Intentionally not in this PR (remaining / later)
- Shared Instance cloud sync / Friends / Hosting (need Modrinth backend)
- Full CurseForge content source + ATL/GDL importers
- Dedicated Skins page (library is on Tools for now)
- pypresence packaging guarantee / official Discord app id for Bloret
- True SQLite instance model migration (still version-dir adapter)
- Full GUI e2e (this environment has no PySide6 for app launch tests)

## Test plan
- [x] `python3 test_p0_p2_features.py -v` → 7 passed
- [ ] Manual: install mod with deps → content-index written
- [ ] Manual: Core Manager → check updates / update all
- [ ] Manual: instance memory/JVM/hooks saved and applied on launch
- [ ] Manual: Download → Quilt install
- [ ] Manual: Prism/MultiMC import scan + import
- [ ] Manual: Tools skin import/equip (needs MS account for equip)
- [ ] Manual: Settings Discord toggle
- [ ] Manual: crash log list/view under Core Manager → 世界