### PR TITLE
feat: align mrpack import/export with Modrinth App format

### DIFF
--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -2692,30 +2692,66 @@ class Backend(QObject):
         """导入 Modrinth .mrpack 整合包（内置实现，弹出文件选择）。"""
         try:
             from PySide6.QtWidgets import QFileDialog
-            from modules.mrpack_import import import_mrpack
 
             file_path, _ = QFileDialog.getOpenFileName(
                 None,
-                self.tr("选择 .mrpack 文件") if hasattr(self, "tr") else "选择 .mrpack 文件",
+                self.tr("选择 .mrpack 文件"),
                 "",
                 "Modrinth Modpack Files (*.mrpack)",
             )
             if not file_path:
-                print("Requested import Modrinth mrpack: cancelled")
+                log("Requested import Modrinth mrpack: cancelled")
                 return
-            self.requestMrpackImport(file_path, "", f"import:{int(time.time() * 1000)}")
+
+            request_id = f"import:{int(time.time() * 1000)}"
+            log(f"Requested import Modrinth mrpack: {file_path}")
+            # 立即反馈，避免「选完文件无反应」
+            try:
+                self.downloadNotify.emit(
+                    self.tr("正在导入整合包"),
+                    os.path.basename(file_path),
+                    True,
+                )
+            except Exception:
+                pass
+            try:
+                self.openDownloadManager()
+            except Exception:
+                pass
+            ok = self.requestMrpackImport(file_path, "", request_id)
+            if not ok:
+                self.downloadNotify.emit(
+                    self.tr("导入失败"),
+                    self.tr("无法启动导入任务"),
+                    False,
+                )
         except Exception as e:
-            print(f"导入 Modrinth 整合包失败: {e}")
+            log(f"导入 Modrinth 整合包失败: {e}", logging.ERROR)
             import traceback
             traceback.print_exc()
+            try:
+                self.downloadNotify.emit(self.tr("导入失败"), str(e), False)
+            except Exception:
+                pass
 
     @Slot(str, str, str, result=bool)
     def requestMrpackImport(self, filePath, instanceName, requestId):
         """异步导入 .mrpack；进度经 mrpackImportProgress，结果经 mrpackImportFinished。"""
         if not filePath:
             return False
+        if getattr(self, "_mrpack_import_busy", False):
+            try:
+                self.downloadNotify.emit(
+                    self.tr("请稍候"),
+                    self.tr("已有整合包导入任务进行中"),
+                    False,
+                )
+            except Exception:
+                pass
+            return False
 
         def _run():
+            self._mrpack_import_busy = True
             ok = False
             name = ""
             message = ""
@@ -2732,10 +2768,20 @@ class Backend(QObject):
                         )
                     except Exception:
                         pass
+                    # 内容下载阶段也刷一下通知文案（InfoBar）
+                    try:
+                        if phase in ("read", "download", "extract", "install") and msg:
+                            title = self.tr("正在导入整合包")
+                            detail = f"[{phase}] {msg}"
+                            if total:
+                                detail = f"[{phase} {current}/{total}] {msg}"
+                            self.downloadNotify.emit(title, detail[:120], True)
+                    except Exception:
+                        pass
 
                 result = import_mrpack(
                     filePath,
-                    instance_name=(instanceName or None),
+                    instance_name=(instanceName or None) or None,
                     backend=self,
                     progress=on_progress,
                 )
@@ -2747,6 +2793,7 @@ class Backend(QObject):
                 message = str(exc)
                 log(f"导入 mrpack 失败: {exc}", logging.ERROR)
             finally:
+                self._mrpack_import_busy = False
                 try:
                     self.mrpackImportFinished.emit(
                         str(requestId or ""),
@@ -2756,8 +2803,23 @@ class Backend(QObject):
                     )
                 except Exception:
                     pass
+                try:
+                    if ok:
+                        self.downloadNotify.emit(
+                            self.tr("整合包导入成功"),
+                            name or message,
+                            True,
+                        )
+                        self.invalidateLaunchItemsCache()
+                    else:
+                        self.downloadNotify.emit(
+                            self.tr("整合包导入失败"),
+                            message or self.tr("未知错误"),
+                            False,
+                        )
+                except Exception:
+                    pass
                 if ok:
-                    # 通知 UI 刷新版本列表（若存在对应信号/方法）
                     for attr in ("versionsListChanged", "localVersionsChanged", "versionsChanged"):
                         sig = getattr(self, attr, None)
                         if sig is not None and hasattr(sig, "emit"):
@@ -2766,6 +2828,15 @@ class Backend(QObject):
                             except Exception:
                                 pass
                             break
+                try:
+                    from modules.notification import send_notification
+                    send_notification(
+                        self.tr("整合包导入成功") if ok else self.tr("整合包导入失败"),
+                        name or message,
+                        category="install",
+                    )
+                except Exception:
+                    pass
 
         threading.Thread(target=_run, daemon=True, name="MrpackImport").start()
         return True

--- a/Bloret-Launcher.py
+++ b/Bloret-Launcher.py
@@ -262,6 +262,10 @@ class Backend(QObject):
     modsLoadFinished = Signal(str, str, list, str)
     resourcePacksLoadFinished = Signal(str, str, list, str)
     mrpackExportFinished = Signal(str, bool, str, str)
+    # phase, current, total, message
+    mrpackImportProgress = Signal(str, int, int, str)
+    # requestId, ok, instanceName, message
+    mrpackImportFinished = Signal(str, bool, str, str)
     activityInfoChanged = Signal(dict)
     downloadNotify = Signal(str, str, bool)
     launchDialogRequested = Signal(str)
@@ -1529,7 +1533,7 @@ class Backend(QObject):
             print(f"获取实例信息失败：{e}")
             return {}
 
-    def _export_mrpack_sync(self, versionName, packName, packVersion, outputPath):
+    def _export_mrpack_sync(self, versionName, packName, packVersion, outputPath, selected_paths=None):
         from modules.mrpack_export import export_to_mrpack
         config_data = cfg.read()
         minecraft_dir = config_data.get('minecraft_dir', BLglobals.minecraft_dir)
@@ -1538,7 +1542,14 @@ class Backend(QObject):
         summary = f"从 {versionName} 导出的整合包"
         temp_path = actual_path + f".{threading.get_ident()}.part"
         try:
-            success = export_to_mrpack(instance_path, temp_path, packName, packVersion, summary)
+            success = export_to_mrpack(
+                instance_path,
+                temp_path,
+                packName,
+                packVersion,
+                summary,
+                selected_paths=selected_paths,
+            )
             if success:
                 os.replace(temp_path, actual_path)
             return bool(success), actual_path, "" if success else "导出失败"
@@ -1560,6 +1571,12 @@ class Backend(QObject):
 
     @Slot(str, str, str, str, str, result=bool)
     def requestMrpackExport(self, versionName, packName, packVersion, outputPath, requestId):
+        return self.requestMrpackExportWithSelection(
+            versionName, packName, packVersion, outputPath, requestId, []
+        )
+
+    @Slot(str, str, str, str, str, "QVariantList", result=bool)
+    def requestMrpackExportWithSelection(self, versionName, packName, packVersion, outputPath, requestId, selectedPaths):
         actual_path = outputPath if outputPath.lower().endswith('.mrpack') else outputPath + '.mrpack'
         path_key = os.path.normcase(os.path.abspath(actual_path))
         with self._export_paths_lock:
@@ -1567,12 +1584,19 @@ class Backend(QObject):
                 return False
             self._active_export_paths.add(path_key)
 
+        selected = None
+        try:
+            cleaned = [str(x) for x in (list(selectedPaths) if selectedPaths is not None else []) if x]
+            selected = cleaned if cleaned else None
+        except Exception:
+            selected = None
+
         def _run():
             success = False
             error = ""
             try:
                 success, _, error = self._export_mrpack_sync(
-                    versionName, packName, packVersion, outputPath
+                    versionName, packName, packVersion, outputPath, selected_paths=selected
                 )
             except Exception as exc:
                 error = str(exc)
@@ -1584,6 +1608,20 @@ class Backend(QObject):
 
         threading.Thread(target=_run, daemon=True, name="MrpackExport").start()
         return True
+
+    @Slot(str, result="QVariant")
+    def getMrpackExportCandidates(self, versionName):
+        """返回可导出候选文件列表（供导出对话框勾选）。"""
+        try:
+            from modules.mrpack_export import get_export_candidates
+            config_data = cfg.read()
+            mc_dir = config_data.get("minecraft_dir", BLglobals.minecraft_dir)
+            path = os.path.join(mc_dir, "versions", versionName)
+            if not os.path.isdir(path):
+                return {"ok": False, "message": "实例不存在", "data": []}
+            return {"ok": True, "data": get_export_candidates(path)}
+        except Exception as e:
+            return {"ok": False, "message": str(e), "data": []}
 
     @Slot(str, str, str, result=str)
     def selectSaveFile(self, caption, defaultName, fileFilter):
@@ -2651,15 +2689,86 @@ class Backend(QObject):
 
     @Slot()
     def importMrpack(self):
-        """导入 Modrinth .mrpack 整合包"""
+        """导入 Modrinth .mrpack 整合包（内置实现，弹出文件选择）。"""
         try:
-            from modules.modrinth import add_mrpack
-            print("Requested import Modrinth mrpack")
-            add_mrpack(None)
+            from PySide6.QtWidgets import QFileDialog
+            from modules.mrpack_import import import_mrpack
+
+            file_path, _ = QFileDialog.getOpenFileName(
+                None,
+                self.tr("选择 .mrpack 文件") if hasattr(self, "tr") else "选择 .mrpack 文件",
+                "",
+                "Modrinth Modpack Files (*.mrpack)",
+            )
+            if not file_path:
+                print("Requested import Modrinth mrpack: cancelled")
+                return
+            self.requestMrpackImport(file_path, "", f"import:{int(time.time() * 1000)}")
         except Exception as e:
             print(f"导入 Modrinth 整合包失败: {e}")
             import traceback
             traceback.print_exc()
+
+    @Slot(str, str, str, result=bool)
+    def requestMrpackImport(self, filePath, instanceName, requestId):
+        """异步导入 .mrpack；进度经 mrpackImportProgress，结果经 mrpackImportFinished。"""
+        if not filePath:
+            return False
+
+        def _run():
+            ok = False
+            name = ""
+            message = ""
+            try:
+                from modules.mrpack_import import import_mrpack
+
+                def on_progress(phase, current, total, msg):
+                    try:
+                        self.mrpackImportProgress.emit(
+                            str(phase or ""),
+                            int(current or 0),
+                            int(total or 0),
+                            str(msg or ""),
+                        )
+                    except Exception:
+                        pass
+
+                result = import_mrpack(
+                    filePath,
+                    instance_name=(instanceName or None),
+                    backend=self,
+                    progress=on_progress,
+                )
+                ok = bool(result.get("ok"))
+                name = str(result.get("instance_name") or "")
+                message = str(result.get("message") or "")
+            except Exception as exc:
+                ok = False
+                message = str(exc)
+                log(f"导入 mrpack 失败: {exc}", logging.ERROR)
+            finally:
+                try:
+                    self.mrpackImportFinished.emit(
+                        str(requestId or ""),
+                        ok,
+                        name,
+                        message,
+                    )
+                except Exception:
+                    pass
+                if ok:
+                    # 通知 UI 刷新版本列表（若存在对应信号/方法）
+                    for attr in ("versionsListChanged", "localVersionsChanged", "versionsChanged"):
+                        sig = getattr(self, attr, None)
+                        if sig is not None and hasattr(sig, "emit"):
+                            try:
+                                sig.emit()
+                            except Exception:
+                                pass
+                            break
+
+        threading.Thread(target=_run, daemon=True, name="MrpackImport").start()
+        return True
 
     @Slot(result=str)
     def getBloretVersion(self):

--- a/MRPACK_FORMAT_RESEARCH.md
+++ b/MRPACK_FORMAT_RESEARCH.md
@@ -1,29 +1,40 @@
 # Modrinth Modpack Format (.mrpack) 研究文档
 
+> 权威实现参考：`/data/modrinth-code`（Modrinth App）  
+> - 导出：`packages/app-lib/src/api/instance/export_mrpack.rs`  
+> - 导入：`packages/app-lib/src/api/pack/install_mrpack.rs`  
+> - 格式：`packages/app-lib/src/api/pack/install_from.rs`  
+>
+> Bloret 实现：`modules/mrpack_export.py`、`modules/mrpack_import.py`
+
 ## 概述
 
-`.mrpack` 是 Modrinth 平台的整合包文件格式，用于分发 Minecraft 模组整合包。
+`.mrpack` 是 Modrinth 平台的整合包文件格式，本质是 **ZIP**，用于分发 Minecraft 模组整合包。
 
-## 文件结构
-
-`.mrpack` 文件本质上是一个 **ZIP 压缩包**，包含以下结构：
+## 文件结构（官方）
 
 ```
-example.mrpack (ZIP 文件)
-├── modrinth.index.json    # 必需的索引文件（位于根目录）
-└── files/                 # 可选的文件目录
-    ├── config/            # 配置文件
-    ├── mods/              # 模组文件
-    ├── resourcepacks/     # 资源包
-    ├── shaderpacks/       # 光影包
-    └── ...                # 其他需要覆盖的文件
+example.mrpack (ZIP)
+├── modrinth.index.json       # 必需：清单
+├── overrides/                # 本地覆盖文件 → 解压到实例根目录
+│   ├── config/...
+│   ├── mods/本地未上架.jar
+│   └── ...
+├── client-overrides/         # 仅客户端覆盖
+└── server-overrides/         # 仅服务端（App 哈希会扫；客户端导入主路径用 overrides + client-overrides）
 ```
 
-## modrinth.index.json 格式
+### 重要更正
 
-这是整合包的核心配置文件，必须位于 ZIP 文件的根目录。
+| 错误（旧文档 / 旧 Bloret 导出） | 正确（Modrinth App） |
+|--------------------------------|----------------------|
+| ZIP 内使用 `files/{path}` 嵌入全部内容 | **不使用** `files/` 目录 |
+| index 中文件可不带 `downloads` | 远程内容必须有 `downloads` + 哈希；本地内容进 `overrides/` |
+| 所有文件既进 index 又进 ZIP | **有 CDN 的只进 index；无 CDN 的只进 overrides** |
 
-### 完整结构示例
+旧版 Bloret 导出的 `files/` 包与官方 App **不兼容**。新实现已改为 `overrides/` + 可选 `downloads` 分流。
+
+## modrinth.index.json（PackFormat）
 
 ```json
 {
@@ -31,317 +42,91 @@ example.mrpack (ZIP 文件)
   "game": "minecraft",
   "versionId": "1.0.0",
   "name": "我的整合包",
-  "summary": "一个很棒的整合包",
+  "summary": "简介（可选）",
   "files": [
     {
       "path": "mods/example-mod.jar",
       "hashes": {
-        "sha512": "abcdef1234567890...",
-        "sha1": "1234567890abcdef..."
+        "sha1": "...",
+        "sha512": "..."
       },
       "env": {
         "client": "required",
         "server": "required"
       },
       "downloads": [
-        "https://cdn.modrinth.com/mod/xxx/version/yyy/file.jar"
+        "https://cdn.modrinth.com/data/.../....jar"
       ],
       "fileSize": 123456
-    },
-    {
-      "path": "config/mod-config.toml",
-      "hashes": {
-        "sha512": "fedcba0987654321..."
-      }
     }
   ],
   "dependencies": {
     "minecraft": "1.20.1",
-    "fabric-loader": ">=0.14.0",
-    "quilt-loader": "*",
-    "minecraft-resourcepacks": "*"
+    "fabric-loader": "0.15.0"
   }
 }
 ```
 
-### 字段详解
+### 顶层字段
 
-#### 顶层字段
-
-| 字段名 | 类型 | 必需 | 说明 |
-|--------|------|------|------|
-| `formatVersion` | integer | ✓ | 格式版本号，当前为 `1` |
-| `game` | string | ✓ | 游戏标识，通常是 `"minecraft"` |
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `formatVersion` | int | ✓ | 当前为 `1` |
+| `game` | string | ✓ | 必须为 `"minecraft"`，否则官方导入失败 |
 | `versionId` | string | ✓ | 整合包版本号 |
-| `name` | string | ✓ | 整合包名称 |
-| `summary` | string | ✗ | 整合包简介 |
-| `files` | array | ✓ | 文件列表 |
-| `dependencies` | object | ✓ | 依赖项（游戏版本、加载器等） |
+| `name` | string | ✓ | 名称 |
+| `summary` | string | ✗ | 简介 |
+| `files` | array | ✓ | **可远程下载**的内容清单 |
+| `dependencies` | object | ✓ | 游戏 / 加载器依赖 |
 
-#### files 数组中的对象字段
+### files[] 字段
 
-| 字段名 | 类型 | 必需 | 说明 |
-|--------|------|------|------|
-| `path` | string | ✓ | 文件在实例目录中的相对路径 |
-| `hashes` | object | ✓ | 文件哈希值（至少包含 sha512 或 sha1） |
-| `hashes.sha512` | string | △ | SHA-512 哈希（推荐） |
-| `hashes.sha1` | string | △ | SHA-1 哈希 |
-| `env` | object | ✗ | 环境要求 |
-| `env.client` | string | ✗ | 客户端要求：`"required"`, `"optional"`, `"unsupported"`, `"enforced"` |
-| `env.server` | string | ✗ | 服务器要求：同上 |
-| `downloads` | array | ✗ | 下载 URL 列表 |
-| `fileSize` | integer | ✗ | 文件大小（字节） |
+| 字段 | 说明 |
+|------|------|
+| `path` | 相对实例根路径（如 `mods/foo.jar`） |
+| `hashes.sha1` | 官方下载校验主要用 sha1 |
+| `hashes.sha512` | 推荐一并写出 |
+| `downloads` | URL 列表（多镜像回退） |
+| `fileSize` | 字节数 |
+| `env.client` / `env.server` | `required` \| `optional` \| `unsupported` |
 
-**env 字段说明：**
-- `"required"`: 必须安装此文件
-- `"optional"`: 可选文件
-- `"unsupported"`: 不支持此环境（不会安装）
-- `"enforced"`: 强制要求（类似 required，但更严格）
+客户端安装时：`env.client == "unsupported"` 的文件会跳过。
 
-#### dependencies 对象字段
+### dependencies 常见键
 
-键值对形式，键为依赖项 ID，值为版本范围字符串。
+- `minecraft`
+- `fabric-loader` / `quilt-loader` / `forge` / `neoforge`
 
-常见依赖项：
-- `"minecraft"`: Minecraft 游戏版本（如 `"1.20.1"`, `"~1.20.1"`）
-- `"fabric-loader"`: Fabric 加载器版本
-- `"quilt-loader"`: Quilt 加载器版本
-- `"forge"`: Forge 加载器版本
-- `"neoforge"`: NeoForge 加载器版本
-- `"minecraft-resourcepacks"`: 资源包支持
-- `"minecraft-shaders"`: 光影包支持
+## 导出流程（对齐 App）
 
-**版本范围语法：**
-- `"1.20.1"`: 精确匹配
-- `">=1.20"`: 大于等于
-- `"~1.20.1"`: 兼容版本（小版本可变动）
-- `"*"`: 任意版本
+1. 扫描候选路径；默认勾选：`mods`、`datapacks`、`resourcepacks`、`shaderpacks`、`config`
+2. 黑名单跳过：日志、`.fabric`、`natives`、缓存等
+3. 对能反查到 Modrinth CDN 的文件：只写入 `files[]`（hashes + downloads），**不打进 ZIP**
+4. 其余选中文件：写入 `overrides/{相对路径}`
+5. 写入 `modrinth.index.json`
 
-## 创建 .mrpack 的步骤
+反查失败时降级为 overrides 内嵌（包可变大，但保证可装）。
 
-### Python 实现示例
+## 导入流程（对齐 App）
 
-```python
-import zipfile
-import json
-import hashlib
-from pathlib import Path
+1. 打开 ZIP，定位 `modrinth.index.json`
+2. 校验 `game == "minecraft"`
+3. 按 `dependencies` 安装 Minecraft + 加载器到目标版本目录
+4. 并发/串行下载 `files[]`（多 URL、sha1 校验；跳过 client unsupported）
+5. 解压 `overrides/` 与 `client-overrides/` 到实例根
+6. （可选）兼容旧 Bloret 错误格式：若存在 ZIP 内 `files/` 也解压
 
-def calculate_hash(file_path, algorithm='sha512'):
-    """计算文件的哈希值"""
-    hash_func = hashlib.new(algorithm)
-    with open(file_path, 'rb') as f:
-        for chunk in iter(lambda: f.read(8192), b''):
-            hash_func.update(chunk)
-    return hash_func.hexdigest()
+## Bloret 代码入口
 
-def create_mrpack(output_path, name, version, game_version, files_list, summary=""):
-    """
-    创建 .mrpack 文件
-    
-    Args:
-        output_path: 输出的 .mrpack 文件路径
-        name: 整合包名称
-        version: 整合包版本号
-        game_version: Minecraft 版本
-        files_list: 文件列表，每个元素包含：
-            - path: 文件在实例中的路径
-            - source: 源文件路径
-            - env: 环境要求（可选）
-            - downloads: 下载链接列表（可选）
-    """
-    
-    # 构建 index 文件
-    index = {
-        "formatVersion": 1,
-        "game": "minecraft",
-        "versionId": version,
-        "name": name,
-        "summary": summary,
-        "files": [],
-        "dependencies": {
-            "minecraft": game_version
-        }
-    }
-    
-    # 创建 ZIP 文件
-    with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-        # 处理每个文件
-        for file_info in files_list:
-            source_path = Path(file_info['source'])
-            target_path = file_info['path']
-            
-            # 计算哈希
-            sha512_hash = calculate_hash(source_path, 'sha512')
-            sha1_hash = calculate_hash(source_path, 'sha1')
-            
-            # 构建文件条目
-            file_entry = {
-                "path": target_path,
-                "hashes": {
-                    "sha512": sha512_hash,
-                    "sha1": sha1_hash
-                },
-                "fileSize": source_path.stat().st_size
-            }
-            
-            # 添加环境要求
-            if 'env' in file_info:
-                file_entry['env'] = file_info['env']
-            
-            # 添加下载链接
-            if 'downloads' in file_info:
-                file_entry['downloads'] = file_info['downloads']
-            
-            index['files'].append(file_entry)
-            
-            # 将文件添加到 ZIP
-            zipf.write(source_path, f"files/{target_path}")
-        
-        # 写入 index 文件
-        zipf.writestr('modrinth.index.json', json.dumps(index, indent=2))
-    
-    print(f"已创建整合包：{output_path}")
+| 能力 | 模块 / 槽 |
+|------|-----------|
+| 导出 | `modules/mrpack_export.py` → `Backend.requestMrpackExport*` |
+| 导入 | `modules/mrpack_import.py` → `Backend.importMrpack` / `add_mrpack` |
+| UI | `qml/components/ExportMrpackDialog.qml`、`qml/pages/Download.qml` |
 
-# 使用示例
-if __name__ == "__main__":
-    files = [
-        {
-            "path": "mods/fabric-api.jar",
-            "source": "/path/to/fabric-api.jar",
-            "env": {"client": "required", "server": "required"},
-            "downloads": ["https://cdn.modrinth.com/..."]
-        },
-        {
-            "path": "config/my-mod.toml",
-            "source": "/path/to/config.toml"
-        }
-    ]
-    
-    create_mrpack(
-        output_path="my-pack.mrpack",
-        name="我的整合包",
-        version="1.0.0",
-        game_version="1.20.1",
-        files_list=files,
-        summary="这是一个测试整合包"
-    )
-```
+## 验收
 
-## 从现有实例导出 .mrpack
-
-如果你要从现有的 Minecraft 实例导出整合包：
-
-```python
-import os
-import json
-import zipfile
-import hashlib
-from pathlib import Path
-
-def export_instance_to_mrpack(instance_path, output_path, name, version):
-    """
-    从现有实例导出 .mrpack
-    
-    Args:
-        instance_path: 实例目录路径
-        output_path: 输出的 .mrpack 路径
-        name: 整合包名称
-        version: 整合包版本
-    """
-    
-    instance = Path(instance_path)
-    files_list = []
-    
-    # 检测游戏版本和加载器
-    game_version = detect_game_version(instance)
-    loader = detect_loader(instance)
-    
-    dependencies = {"minecraft": game_version}
-    if loader:
-        dependencies[loader['name']] = loader['version']
-    
-    # 收集 mods 目录
-    mods_dir = instance / "mods"
-    if mods_dir.exists():
-        for mod_file in mods_dir.glob("*.jar"):
-            rel_path = f"mods/{mod_file.name}"
-            files_list.append({
-                "path": rel_path,
-                "source": str(mod_file),
-                "env": {"client": "required", "server": "required"}
-            })
-    
-    # 收集 config 目录
-    config_dir = instance / "config"
-    if config_dir.exists():
-        for config_file in config_dir.rglob("*"):
-            if config_file.is_file():
-                rel_path = f"config/{config_file.relative_to(config_dir)}"
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(config_file)
-                })
-    
-    # 收集 resourcepacks
-    rp_dir = instance / "resourcepacks"
-    if rp_dir.exists():
-        for rp_file in rp_dir.rglob("*"):
-            if rp_file.is_file():
-                rel_path = f"resourcepacks/{rp_file.relative_to(rp_dir)}"
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(rp_file)
-                })
-    
-    # 创建 mrpack
-    create_mrpack_with_deps(
-        output_path=output_path,
-        name=name,
-        version=version,
-        game_version=game_version,
-        dependencies=dependencies,
-        files_list=files_list
-    )
-
-def detect_game_version(instance_path):
-    """检测游戏版本（从 version.json 或其他文件）"""
-    # 实现版本检测逻辑
-    version_file = instance_path / "version.json"
-    if version_file.exists():
-        with open(version_file) as f:
-            data = json.load(f)
-            return data.get('id', '1.20.1')
-    return "1.20.1"  # 默认值
-
-def detect_loader(instance_path):
-    """检测加载器类型和版本"""
-    # Fabric: 检查 fabric-loader-*.jar
-    # Forge: 检查 forge-*.jar 或 .minecraft/forgeVersion.txt
-    # 实现检测逻辑
-    return None
-```
-
-## 注意事项
-
-1. **哈希算法**: 推荐使用 SHA-512，但也应该提供 SHA-1 以兼容旧客户端
-2. **路径规范**: 使用正斜杠 `/`，即使是在 Windows 上
-3. **文件大小**: `fileSize` 字段是可选的，但建议提供以便客户端验证
-4. **环境变量**: 合理使用 `env` 字段来区分客户端专用和服务端专用的文件
-5. **下载链接**: 对于来自 Modrinth 的模组，提供官方下载链接可以让客户端直接下载而不是从包内提取
-
-## 参考资源
-
-- Modrinth API 文档: https://docs.modrinth.com/
-- Modrinth 整合包规范: https://support.modrinth.com/en/articles/8792413-modrinth-modpack-format-mrpack
-- Knossos (Modrinth 官方启动器) 源码: https://github.com/modrinth/knossos
-
-## 在 Bloret Launcher 中实现导出功能
-
-基于你现有的代码结构，建议在以下位置添加功能：
-
-1. **新增模块**: `modules/mrpack_export.py` - 导出逻辑
-2. **UI 集成**: 在实例管理界面添加"导出为 .mrpack"按钮
-3. **API 扩展**: 在 `modules/modrinth.py` 中添加相关函数
-
-这样可以保持代码的组织性和可维护性。
+1. 导出包结构：`modrinth.index.json` + `overrides/`，无错误 `files/` 根目录
+2. 带 downloads 的条目不在 ZIP 中重复嵌入
+3. Bloret 可导入标准 `.mrpack`（无需 `mrpack-install`）
+4. 往返：Bloret 导出 → Bloret 导入，关键 mods/config 一致

--- a/modules/bloriko_agent/agent_loop.py
+++ b/modules/bloriko_agent/agent_loop.py
@@ -184,7 +184,8 @@ class BlorikoAgentLoop:
     def cancel(self):
         self._cancelled = True
 
-    def run(self, user_message: str, history: list = None):
+    def run(self, user_message, history: list = None):
+        """user_message 可为 str，或 OpenAI 多模态 content list。"""
         log.info(f"[AgentLoop] run 开始, 模型={self.model}, 角色={self.role}")
         try:
             self._run_internal(user_message, history)
@@ -224,12 +225,69 @@ class BlorikoAgentLoop:
         return self._cached_system_prompt
 
     # ================================================================
+    # 多模态 / content 工具
+    # ================================================================
+
+    @staticmethod
+    def _content_to_text(content) -> str:
+        """从 str 或 OpenAI 多模态 content list 提取纯文本。"""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        parts.append(str(part.get("text", "")))
+                    elif part.get("type") == "image_url":
+                        parts.append("[图片]")
+                elif isinstance(part, str):
+                    parts.append(part)
+            return "\n".join(p for p in parts if p)
+        return str(content)
+
+    @staticmethod
+    def _content_for_token_estimate(content) -> str:
+        """估算 token 时忽略 base64 图片数据。"""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        parts.append(str(part.get("text", "")))
+                    elif part.get("type") == "image_url":
+                        # 视觉 token 粗估：固定开销，不计入完整 base64
+                        parts.append("[image~1000tokens]")
+                elif isinstance(part, str):
+                    parts.append(part)
+            return "\n".join(parts)
+        return str(content)
+
+    # ================================================================
     # 上下文压缩
     # ================================================================
 
     @staticmethod
     def _estimate_tokens(messages: list) -> int:
-        return len(str(messages)) // 4
+        total = 0
+        for msg in messages:
+            content = msg.get("content", "")
+            total += len(BlorikoAgentLoop._content_for_token_estimate(content))
+            if msg.get("tool_calls"):
+                total += len(str(msg.get("tool_calls")))
+            if msg.get("toolName"):
+                total += (
+                    len(str(msg.get("toolName", "")))
+                    + len(str(msg.get("toolArgs", "")))
+                    + len(str(msg.get("toolResult", "")))
+                )
+        return total // 4
 
     def _compact_messages(self, messages: list) -> list:
         if len(messages) <= 1:
@@ -251,15 +309,31 @@ class BlorikoAgentLoop:
                 if tc_id in recent_tool_ids:
                     result.append(msg)
                 else:
-                    original_len = len(msg.get("content", ""))
+                    content = msg.get("content", "")
+                    original_len = len(content) if isinstance(content, str) else len(str(content))
                     compacted = dict(msg)
                     compacted["content"] = f"[结果已压缩: 原始长度 {original_len} 字符]"
                     result.append(compacted)
             elif role == "assistant":
                 content = msg.get("content", "")
-                if len(content) > 2000:
+                if isinstance(content, str) and len(content) > 2000:
                     compacted = dict(msg)
                     compacted["content"] = content[:500] + "...[已压缩]"
+                    result.append(compacted)
+                else:
+                    result.append(msg)
+            elif role == "user":
+                # 多模态历史：压缩时去掉 image base64，只保留文本与占位
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    compacted = dict(msg)
+                    new_parts = []
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "image_url":
+                            new_parts.append({"type": "text", "text": "[图片已压缩]"})
+                        else:
+                            new_parts.append(part)
+                    compacted["content"] = new_parts
                     result.append(compacted)
                 else:
                     result.append(msg)
@@ -285,7 +359,9 @@ class BlorikoAgentLoop:
             role = msg.get("role", "")
             content = msg.get("content", "")
             if content and role in ("user", "assistant"):
-                discadable.append(f"[{role}]: {content[:500]}")
+                text = self._content_to_text(content)
+                if text:
+                    discadable.append(f"[{role}]: {text[:500]}")
 
         if not discadable:
             return
@@ -503,11 +579,20 @@ class BlorikoAgentLoop:
                     "tool_call_id": tc_id,
                     "content": tool_result
                 })
+            elif role in ("user", "assistant", "system"):
+                # 仅保留 API 合法字段，去掉 image_paths 等内部字段
+                entry = {"role": role, "content": msg.get("content", "")}
+                if msg.get("tool_calls"):
+                    entry["tool_calls"] = msg["tool_calls"]
+                if msg.get("name"):
+                    entry["name"] = msg["name"]
+                result.append(entry)
             else:
-                result.append(msg)
+                # 未知角色尽量透传 content
+                result.append({"role": role or "user", "content": msg.get("content", "")})
         return result
 
-    def _run_internal(self, user_message: str, history: list = None):
+    def _run_internal(self, user_message, history: list = None):
         log.info("[AgentLoop] 构建系统提示词...")
         system_prompt = self._build_system_prompt()
         log.info(f"[AgentLoop] 系统提示词长度: {len(system_prompt)} 字符")
@@ -518,8 +603,10 @@ class BlorikoAgentLoop:
             messages.extend(converted)
             log.info(f"[AgentLoop] 历史消息数: {len(history)} (转换后 {len(converted)} 条)")
 
+        # user_message: str 或 OpenAI 多模态 content list
         messages.append({"role": "user", "content": user_message})
-        log.info(f"[AgentLoop] 总消息数: {len(messages)} (含系统提示)")
+        preview = self._content_to_text(user_message)[:80]
+        log.info(f"[AgentLoop] 总消息数: {len(messages)} (含系统提示), user_preview='{preview}'")
 
         for iteration in range(MAX_ITERATIONS):
             if self._cancelled:
@@ -902,7 +989,7 @@ def run_agent_async(
     working_dir: str,
     api_url: str,
     auth_header: str,
-    user_message: str,
+    user_message,
     history: list = None,
     on_text_chunk: Optional[Callable[[str], None]] = None,
     on_tool_call_start: Optional[Callable[[str, str], None]] = None,
@@ -963,7 +1050,9 @@ def _sanitize_conversation_title(raw: str, fallback: str = "") -> str:
     return title
 
 
-def generate_title(api_url: str, auth_header: str, user_message: str, model: str = "Bloriko") -> str:
+def generate_title(api_url: str, auth_header: str, user_message, model: str = "Bloriko") -> str:
+    if not isinstance(user_message, str):
+        user_message = BlorikoAgentLoop._content_to_text(user_message)
     """生成简短的对话标题"""
     log.info(f"[Title] 开始生成标题, model='{model}'")
     headers = {"Content-Type": "application/json"}

--- a/modules/bloriko_agent/backend.py
+++ b/modules/bloriko_agent/backend.py
@@ -13,16 +13,20 @@
 - 多平台连接器（微信、Telegram、QQ、Discord 等）
 """
 
+import base64
+import io
 import json
 import os
+import tempfile
 import time
 import logging
 import threading
+import wave
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import requests
-from PySide6.QtCore import QObject, Signal, Slot, Property
+from PySide6.QtCore import QObject, Signal, Slot, Property, QIODevice, QByteArray, QBuffer, QTimer
 from PySide6.QtGui import QGuiApplication
 
 from .agent_loop import BlorikoAgentLoop, run_agent_async, AGENT_ROLES
@@ -45,6 +49,12 @@ from .wechat_connector import (
 )
 
 log = logging.getLogger(__name__)
+
+# 图片附件限制
+_MAX_IMAGE_COUNT = 4
+_MAX_IMAGE_FILE_BYTES = 5 * 1024 * 1024  # 5MB 原始文件
+_MAX_IMAGE_EDGE = 1280
+_MAX_VOICE_SECONDS = 60
 
 
 def _send_os_notification(title: str, body: str):
@@ -75,6 +85,90 @@ _TOOL_CN = {
     "memory": "管理记忆",
     "set_emotion": "更新情感",
 }
+
+
+def _encode_image_for_api(path: str) -> Optional[dict]:
+    """读取本地图片，压缩后返回 OpenAI image_url part；失败返回 None。"""
+    if not path or not os.path.isfile(path):
+        log.warning(f"[Bloriko] 图片不存在: {path}")
+        return None
+    try:
+        size = os.path.getsize(path)
+        if size > _MAX_IMAGE_FILE_BYTES:
+            log.warning(f"[Bloriko] 图片过大: {path} ({size} bytes)")
+            return None
+
+        from PIL import Image
+
+        with Image.open(path) as img:
+            img = img.convert("RGB") if img.mode not in ("RGB", "L") else img
+            if img.mode == "L":
+                img = img.convert("RGB")
+            w, h = img.size
+            scale = min(1.0, _MAX_IMAGE_EDGE / max(w, h))
+            if scale < 1.0:
+                img = img.resize((max(1, int(w * scale)), max(1, int(h * scale))), Image.Resampling.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=85, optimize=True)
+            b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+        return {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+        }
+    except Exception as e:
+        log.warning(f"[Bloriko] 编码图片失败 {path}: {e}")
+        return None
+
+
+def _build_user_content(text: str, image_paths: list) -> Union[str, list]:
+    """构建 user message content：无图为 str，有图为多模态 list。"""
+    text = (text or "").strip()
+    parts = []
+    if text:
+        parts.append({"type": "text", "text": text})
+    for p in image_paths or []:
+        part = _encode_image_for_api(p)
+        if part:
+            parts.append(part)
+    if not parts:
+        return text or ""
+    if len(parts) == 1 and parts[0].get("type") == "text":
+        return parts[0]["text"]
+    if not text and any(p.get("type") == "image_url" for p in parts):
+        parts.insert(0, {"type": "text", "text": "请查看图片"})
+    return parts
+
+
+def _content_text_preview(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                texts.append(str(part.get("text", "")))
+        return "\n".join(texts)
+    return str(content or "")
+
+
+def _transcriptions_url_from_chat_api(api_url: str) -> Optional[str]:
+    if not api_url:
+        return None
+    if "/chat/completions" in api_url:
+        return api_url.replace("/chat/completions", "/audio/transcriptions")
+    if api_url.rstrip("/").endswith("/v1"):
+        return api_url.rstrip("/") + "/audio/transcriptions"
+    return None
+
+
+def _pcm_to_wav_bytes(pcm: bytes, sample_rate: int = 16000, channels: int = 1, sample_width: int = 2) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
 
 
 def _summarize_agent_result(text: str, tool_calls: list) -> str:
@@ -389,6 +483,11 @@ class BlorikoBackend(QObject):
     # 情感信号
     emotionChanged = Signal(str)
 
+    # 语音 STT
+    voiceStateChanged = Signal(str)          # idle | recording | transcribing
+    transcriptionReady = Signal(str)
+    transcriptionFailed = Signal(str)
+
     # ========== 连接器信号（通用） ==========
     connectorStatusChanged = Signal(str, str)       # platform_id, status
     connectorMessageReceived = Signal(str, str, str) # platform_id, sender_id, text
@@ -443,6 +542,14 @@ class BlorikoBackend(QObject):
         # 情感状态
         self._current_emotion = "neutral"
 
+        # 语音录音 / STT
+        self._voice_state = "idle"
+        self._audio_source = None
+        self._audio_buffer = None
+        self._audio_io = None
+        self._audio_sample_rate = 16000
+        self._voice_max_timer = None
+
         # ========== 多平台连接器 ==========
         self._connectors: dict[str, BaseConnector] = {}
         self._connectors_lock = threading.Lock()
@@ -476,6 +583,15 @@ class BlorikoBackend(QObject):
     @Property(bool, notify=busyChanged)
     def busy(self):
         return self._busy
+
+    @Property(str, notify=voiceStateChanged)
+    def voiceState(self):
+        return self._voice_state
+
+    def _set_voice_state(self, state: str):
+        if self._voice_state != state:
+            self._voice_state = state
+            self.voiceStateChanged.emit(state)
 
     @Property(str, notify=roleChanged)
     def agentRole(self):
@@ -666,11 +782,70 @@ class BlorikoBackend(QObject):
 
     # ========== 对话 ==========
 
+    def _resolve_auth(self, provider: dict) -> Optional[str]:
+        """返回 Authorization 头值（含 Bearer 前缀），失败时 emit 错误并返回 None。"""
+        if not provider.get("needs_auth", False):
+            log.info("[Bloriko] 无需认证（内置供应商）")
+            return ""
+        api_key = provider.get("api_key", "")
+        if not api_key:
+            if self._current_provider == "bloret_passport":
+                auth_header = _build_bloret_passport_auth()
+                if not auth_header:
+                    log.error("[Bloriko] Bloret PassPort 认证信息未配置：未找到 API Key 且用户未登录")
+                    self.errorOccurred.emit(
+                        "请先在 Bloret PassPort 的 /ai 页面创建 API Key，并在设置中配置；或确认已登录 Bloret PassPort"
+                    )
+                    return None
+                log.info("[Bloriko] 使用 Bloret PassPort 认证")
+                return auth_header
+            self.errorOccurred.emit(f"供应商 {provider.get('name', '')} 需要 API 密钥")
+            return None
+        return f"Bearer {api_key}"
+
     @Slot(str)
-    def sendMessage(self, text):
+    @Slot(str, str)
+    def sendMessage(self, text, images_json="[]"):
         log.info(f"[Bloriko] sendMessage 调用, busy={self._busy}")
         if self._busy:
             log.warning("[Bloriko] sendMessage 被拒绝: 正忙")
+            return
+
+        text = (text or "").strip()
+        try:
+            image_paths = json.loads(images_json) if images_json else []
+            if not isinstance(image_paths, list):
+                image_paths = []
+        except Exception:
+            image_paths = []
+
+        # 过滤有效路径并限制数量
+        valid_paths = []
+        for p in image_paths:
+            if not isinstance(p, str):
+                continue
+            path = p
+            if path.startswith("file://"):
+                path = path[7:] if not path.startswith("file:///") else path[7:]
+                # Windows file:///C:/... → /C:/... handled below
+                if os.name == "nt" and path.startswith("/") and len(path) > 2 and path[2] == ":":
+                    path = path[1:]
+            if os.path.isfile(path):
+                valid_paths.append(path)
+        if len(valid_paths) > _MAX_IMAGE_COUNT:
+            self.errorOccurred.emit(f"最多只能附加 {_MAX_IMAGE_COUNT} 张图片")
+            return
+        for path in valid_paths:
+            try:
+                if os.path.getsize(path) > _MAX_IMAGE_FILE_BYTES:
+                    self.errorOccurred.emit(f"图片过大（超过 5MB）: {os.path.basename(path)}")
+                    return
+            except OSError:
+                self.errorOccurred.emit(f"无法读取图片: {os.path.basename(path)}")
+                return
+
+        if not text and not valid_paths:
+            log.warning("[Bloriko] sendMessage 被拒绝: 空消息")
             return
 
         # 获取 API 配置
@@ -688,26 +863,16 @@ class BlorikoBackend(QObject):
             self.errorOccurred.emit("供应商配置不完整")
             return
 
-        # 认证
-        auth_header = ""
-        if provider.get("needs_auth", False):
-            api_key = provider.get("api_key", "")
-            if not api_key:
-                # 内置 Bloret PassPort：从 config.json 自动构建 OAuth 三段式 Token
-                if self._current_provider == "bloret_passport":
-                    auth_header = _build_bloret_passport_auth()
-                    if not auth_header:
-                        log.error("[Bloriko] Bloret PassPort 认证信息未配置：未找到 API Key 且用户未登录")
-                        self.errorOccurred.emit("请先在 Bloret PassPort 的 /ai 页面创建 API Key，并在设置中配置；或确认已登录 Bloret PassPort")
-                        return
-                    log.info("[Bloriko] 使用 Bloret PassPort 认证")
-                else:
-                    self.errorOccurred.emit(f"供应商 {provider.get('name', '')} 需要 API 密钥")
-                    return
-            else:
-                auth_header = f"Bearer {api_key}"
-        else:
-            log.info("[Bloriko] 无需认证（内置供应商）")
+        auth_header = self._resolve_auth(provider)
+        if auth_header is None:
+            return
+
+        user_content = _build_user_content(text, valid_paths)
+        if not user_content:
+            self.errorOccurred.emit("无法处理图片附件")
+            return
+
+        title_source = text or _content_text_preview(user_content) or "图片消息"
 
         # 第一条消息时自动生成对话标题
         if not self._title and len(self._history) == 0:
@@ -716,19 +881,25 @@ class BlorikoBackend(QObject):
             def _gen_title():
                 try:
                     from .agent_loop import generate_title, _sanitize_conversation_title
-                    title = generate_title(api_url, auth_header, text, model)
-                    self._title = _sanitize_conversation_title(title, fallback=text)
+                    title = generate_title(api_url, auth_header, title_source, model)
+                    self._title = _sanitize_conversation_title(title, fallback=title_source)
                     self.titleChanged.emit(self._title)
                 except Exception as e:
                     log.warning(f"[Bloriko] 标题生成失败: {e}")
                     from .agent_loop import _sanitize_conversation_title
-                    self._title = _sanitize_conversation_title(text)
+                    self._title = _sanitize_conversation_title(title_source)
                     self.titleChanged.emit(self._title)
 
             threading.Thread(target=_gen_title, daemon=True).start()
 
-        log.info(f"[Bloriko] 启动 Agent, 消息: '{text[:50]}...'")
-        self._history.append({"role": "user", "content": text})
+        preview = title_source[:50]
+        log.info(f"[Bloriko] 启动 Agent, 消息: '{preview}...', images={len(valid_paths)}")
+        history_entry = {
+            "role": "user",
+            "content": user_content,
+            "image_paths": valid_paths,
+        }
+        self._history.append(history_entry)
         self._current_text = ""
         self._current_tool_calls = []
         self._had_error = False
@@ -739,7 +910,7 @@ class BlorikoBackend(QObject):
             working_dir=self._working_dir,
             api_url=api_url,
             auth_header=auth_header,
-            user_message=text,
+            user_message=user_content,
             history=self._history[:-1],
             on_text_chunk=self._on_text_chunk,
             on_tool_call_start=self._on_tool_call_start,
@@ -754,6 +925,218 @@ class BlorikoBackend(QObject):
             memory_store=self._memory_store,
         )
         log.info("[Bloriko] Agent 线程已启动")
+
+    # ========== 语音 STT ==========
+
+    @Slot()
+    def startVoiceCapture(self):
+        """开始麦克风录音。再次调用 stopVoiceCaptureAndTranscribe 结束并转写。"""
+        if self._voice_state != "idle":
+            log.warning(f"[Bloriko] startVoiceCapture 忽略, state={self._voice_state}")
+            return
+        try:
+            from PySide6.QtMultimedia import QAudioFormat, QAudioSource, QMediaDevices
+        except Exception as e:
+            self.transcriptionFailed.emit(f"语音模块不可用: {e}")
+            return
+
+        device = QMediaDevices.defaultAudioInput()
+        if device.isNull():
+            self.transcriptionFailed.emit("未检测到麦克风设备")
+            return
+
+        fmt = QAudioFormat()
+        fmt.setSampleRate(16000)
+        fmt.setChannelCount(1)
+        fmt.setSampleFormat(QAudioFormat.SampleFormat.Int16)
+        if not device.isFormatSupported(fmt):
+            preferred = device.preferredFormat()
+            fmt = preferred
+            log.info(
+                f"[Bloriko] 使用设备首选音频格式: rate={fmt.sampleRate()}, "
+                f"ch={fmt.channelCount()}, sample={fmt.sampleFormat()}"
+            )
+
+        try:
+            self._audio_buffer = QByteArray()
+            self._audio_io = QBuffer(self._audio_buffer)
+            self._audio_io.open(QIODevice.OpenModeFlag.WriteOnly)
+            self._audio_source = QAudioSource(device, fmt, self)
+            self._audio_sample_rate = fmt.sampleRate() or 16000
+            self._audio_channels = fmt.channelCount() or 1
+            self._audio_sample_width = 2
+            if fmt.sampleFormat() == QAudioFormat.SampleFormat.UInt8:
+                self._audio_sample_width = 1
+            elif fmt.sampleFormat() == QAudioFormat.SampleFormat.Int16:
+                self._audio_sample_width = 2
+            elif fmt.sampleFormat() == QAudioFormat.SampleFormat.Int32:
+                self._audio_sample_width = 4
+            elif fmt.sampleFormat() == QAudioFormat.SampleFormat.Float:
+                self._audio_sample_width = 4
+            self._audio_source.start(self._audio_io)
+            self._set_voice_state("recording")
+            log.info("[Bloriko] 开始录音")
+
+            if self._voice_max_timer is None:
+                self._voice_max_timer = QTimer(self)
+                self._voice_max_timer.setSingleShot(True)
+                self._voice_max_timer.timeout.connect(self.stopVoiceCaptureAndTranscribe)
+            self._voice_max_timer.start(_MAX_VOICE_SECONDS * 1000)
+        except Exception as e:
+            log.error(f"[Bloriko] 启动录音失败: {e}", exc_info=True)
+            self._cleanup_audio_capture()
+            self.transcriptionFailed.emit(f"无法开始录音: {e}")
+
+    @Slot()
+    def stopVoiceCaptureAndTranscribe(self):
+        """停止录音并异步转写为文字。"""
+        if self._voice_state != "recording":
+            return
+
+        if self._voice_max_timer and self._voice_max_timer.isActive():
+            self._voice_max_timer.stop()
+
+        pcm = b""
+        sample_rate = getattr(self, "_audio_sample_rate", 16000)
+        channels = getattr(self, "_audio_channels", 1)
+        sample_width = getattr(self, "_audio_sample_width", 2)
+        try:
+            if self._audio_source:
+                self._audio_source.stop()
+            if self._audio_io:
+                self._audio_io.close()
+            if self._audio_buffer is not None:
+                pcm = bytes(self._audio_buffer.data())
+        except Exception as e:
+            log.warning(f"[Bloriko] 停止录音时出错: {e}")
+        finally:
+            self._cleanup_audio_capture(keep_state=True)
+
+        if len(pcm) < sample_rate * sample_width * channels * 0.2:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit("录音太短，请重试")
+            return
+
+        try:
+            if sample_width in (1, 2):
+                wav_bytes = _pcm_to_wav_bytes(
+                    pcm, sample_rate=sample_rate, channels=channels, sample_width=sample_width
+                )
+            else:
+                # Int32 / Float：按 16-bit 截断重打包，避免 wave 不支持
+                import array
+                if sample_width == 4:
+                    # 优先按 little-endian int32 再缩放到 int16
+                    try:
+                        ints = array.array("i")
+                        ints.frombytes(pcm[: len(pcm) - (len(pcm) % 4)])
+                        scaled = array.array("h", (max(-32768, min(32767, v >> 16)) for v in ints))
+                        pcm16 = scaled.tobytes()
+                    except Exception:
+                        pcm16 = pcm[::2]  # 粗暴降采样字节
+                        pcm16 = pcm16[: len(pcm16) - (len(pcm16) % 2)]
+                    wav_bytes = _pcm_to_wav_bytes(pcm16, sample_rate=sample_rate, channels=channels, sample_width=2)
+                else:
+                    wav_bytes = _pcm_to_wav_bytes(pcm, sample_rate=sample_rate, channels=channels, sample_width=2)
+        except Exception as e:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit(f"音频编码失败: {e}")
+            return
+
+        self._set_voice_state("transcribing")
+        auth_header = ""
+        provider = BUILTIN_PROVIDERS.get(self._current_provider) or self._custom_providers.get(self._current_provider)
+        api_url = (provider or {}).get("api", "")
+        stt_url = _transcriptions_url_from_chat_api(api_url)
+        if not stt_url:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit("当前供应商不支持语音识别（无法推导 transcriptions 地址）")
+            return
+        if provider:
+            auth_header = self._resolve_auth(provider)
+            if auth_header is None:
+                self._set_voice_state("idle")
+                return
+
+        def _worker():
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(suffix=".wav", prefix="bloriko_stt_")
+                os.write(fd, wav_bytes)
+                os.close(fd)
+                headers = {}
+                if auth_header:
+                    headers["Authorization"] = auth_header
+                with open(tmp_path, "rb") as f:
+                    files = {"file": ("audio.wav", f, "audio/wav")}
+                    data = {"model": "whisper-1"}
+                    resp = requests.post(stt_url, headers=headers, files=files, data=data, timeout=60)
+                if resp.status_code >= 400:
+                    detail = (resp.text or "")[:300]
+                    log.warning(f"[Bloriko] STT HTTP {resp.status_code}: {detail}")
+                    msg = (
+                        "当前供应商不支持语音识别，请配置支持 Whisper /audio/transcriptions 的供应商"
+                        if resp.status_code in (404, 405, 501)
+                        else f"语音识别失败 (HTTP {resp.status_code})"
+                    )
+                    self.transcriptionFailed.emit(msg)
+                    return
+                try:
+                    payload = resp.json()
+                    text = (payload.get("text") or "").strip()
+                except Exception:
+                    text = (resp.text or "").strip()
+                if not text:
+                    self.transcriptionFailed.emit("未识别到有效语音")
+                    return
+                self.transcriptionReady.emit(text)
+            except Exception as e:
+                log.error(f"[Bloriko] STT 失败: {e}", exc_info=True)
+                self.transcriptionFailed.emit(f"语音识别失败: {e}")
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
+                self._set_voice_state("idle")
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    @Slot()
+    def cancelVoiceCapture(self):
+        """取消录音，不转写。"""
+        if self._voice_max_timer and self._voice_max_timer.isActive():
+            self._voice_max_timer.stop()
+        if self._voice_state == "recording":
+            try:
+                if self._audio_source:
+                    self._audio_source.stop()
+            except Exception:
+                pass
+            self._cleanup_audio_capture()
+            self._set_voice_state("idle")
+
+    def _cleanup_audio_capture(self, keep_state: bool = False):
+        try:
+            if self._audio_source:
+                try:
+                    self._audio_source.stop()
+                except Exception:
+                    pass
+                self._audio_source.deleteLater()
+        except Exception:
+            pass
+        self._audio_source = None
+        try:
+            if self._audio_io:
+                self._audio_io.close()
+        except Exception:
+            pass
+        self._audio_io = None
+        self._audio_buffer = None
+        if not keep_state and self._voice_state == "recording":
+            self._set_voice_state("idle")
 
     @Slot()
     def cancelAgent(self):
@@ -936,26 +1319,55 @@ class BlorikoBackend(QObject):
         for msg in self._history:
             role = msg.get("role", "")
             if role == "user":
+                content = msg.get("content", "")
+                text = _content_text_preview(content)
+                image_paths = list(msg.get("image_paths") or [])
+                # 兼容仅有多模态 content、无 image_paths 的旧/外部数据：不还原 base64 大图
+                if not image_paths and isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "image_url":
+                            # 仅标记有图，UI 可用占位
+                            image_paths.append("")
                 messages.append({
                     "role": "user",
-                    "content": msg.get("content", ""),
+                    "content": text,
+                    "images": [p for p in image_paths if p],
+                    "imagesJson": json.dumps([p for p in image_paths if p], ensure_ascii=False),
                     "toolName": "", "toolArgs": "", "toolResult": "",
                 })
             elif role == "assistant":
                 messages.append({
                     "role": "assistant",
-                    "content": msg.get("content", ""),
+                    "content": msg.get("content", "") if isinstance(msg.get("content", ""), str) else _content_text_preview(msg.get("content", "")),
+                    "images": [],
+                    "imagesJson": "[]",
                     "toolName": "", "toolArgs": "", "toolResult": "",
                 })
             elif role == "tool_call":
                 messages.append({
                     "role": "tool_call",
                     "content": "",
+                    "images": [],
+                    "imagesJson": "[]",
                     "toolName": msg.get("toolName", ""),
                     "toolArgs": msg.get("toolArgs", ""),
                     "toolResult": msg.get("toolResult", ""),
                 })
         return json.dumps(messages, ensure_ascii=False)
+
+    @Slot(result=str)
+    def getCurrentModelName(self):
+        """返回当前模型显示名（供输入区胶囊使用）。"""
+        try:
+            models = json.loads(self._getModelsByKey(self._current_provider))
+            for m in models:
+                if m.get("id") == self._current_model:
+                    return m.get("name") or m.get("id") or ""
+            if models:
+                return models[0].get("name") or models[0].get("id") or ""
+        except Exception:
+            pass
+        return self._current_model or ""
 
     # ========== 记忆查看 ==========
 

--- a/modules/download_manager.py
+++ b/modules/download_manager.py
@@ -23,10 +23,11 @@ class DownloadTask:
         "downloaded", "total", "error_message",
         "cancel_event", "pause_event", "backend",
         "thread", "result", "finished_at",
+        "completed_event", "minecraft_dir",
         "_last_emit_ts", "_last_emit_progress",
     )
 
-    def __init__(self, task_id, version, version_name, loader, backend):
+    def __init__(self, task_id, version, version_name, loader, backend, minecraft_dir=None):
         self.task_id = task_id
         self.version = version
         self.version_name = version_name
@@ -45,6 +46,8 @@ class DownloadTask:
         self.thread = None
         self.result = None
         self.finished_at = 0.0
+        self.completed_event = threading.Event()
+        self.minecraft_dir = minecraft_dir
         self._last_emit_ts = 0.0
         self._last_emit_progress = -1.0
 
@@ -90,11 +93,16 @@ class DownloadManager:
 
     # ── task lifecycle ──
 
-    def start_download(self, version, version_name, loader, backend) -> str:
-        """Start a new download task. Returns task_id."""
+    def start_download(self, version, version_name, loader, backend, minecraft_dir=None) -> str:
+        """Start a new download task. Returns task_id.
+
+        minecraft_dir: optional override for install target root (e.g. mrpack import).
+        """
         self._init()
         task_id = uuid.uuid4().hex[:12]
-        task = DownloadTask(task_id, version, version_name, loader, backend)
+        task = DownloadTask(
+            task_id, version, version_name, loader, backend, minecraft_dir=minecraft_dir
+        )
         with self.tasks_lock:
             self.tasks[task_id] = task
 
@@ -111,8 +119,6 @@ class DownloadManager:
                 if backend:
                     backend.downloadTaskAdded.emit(task_id)
 
-                # Build task_state dict for backward compat with install.py
-                completed_ev = threading.Event()
                 task_state = {
                     "task_id": task_id,
                     "cancel_event": task.cancel_event,
@@ -121,7 +127,7 @@ class DownloadManager:
                     "cancelled": False,
                     "is_paused": False,
                     "downloader": None,
-                    "completed_event": completed_ev,
+                    "completed_event": task.completed_event,
                     "result": None,
                     "cleanup_on_fail": True,
                     "version_dir": None,
@@ -131,7 +137,7 @@ class DownloadManager:
                 result = bool(
                     _install_minecraft_version_threaded(
                         version,
-                        minecraft_dir=None,
+                        minecraft_dir=task.minecraft_dir,
                         Fabric_Loader=(loader == "fabric"),
                         VersionName=version_name,
                         backend=backend,
@@ -153,18 +159,25 @@ class DownloadManager:
                 log(f"[DownloadManager] task {task_id} exception: {exc}", exc_info=True)
             finally:
                 if task.status == "failed" and backend:
-                    backend.downloadErrorOccurred.emit(
-                        "Minecraft 下载失败",
-                        task.error_message or "下载任务未完成",
-                        version,
-                        version_name,
-                        loader,
-                    )
-                completed_ev.set()
+                    try:
+                        backend.downloadErrorOccurred.emit(
+                            "Minecraft 下载失败",
+                            task.error_message or "下载任务未完成",
+                            version,
+                            version_name,
+                            loader,
+                        )
+                    except Exception:
+                        pass
+                task.completed_event.set()
                 if backend:
-                    backend.downloadTaskRemoved.emit(task_id)
+                    try:
+                        backend.downloadTaskRemoved.emit(task_id)
+                    except Exception:
+                        pass
                 task.finished_at = time.monotonic()
                 task.thread = None
+                # 保留 backend 引用到任务被 prune 前，便于失败通知；此处清空避免泄漏
                 task.backend = None
                 self._prune_finished_tasks()
                 log(f"[DownloadManager] task {task_id} finished, status={task.status}")
@@ -174,6 +187,13 @@ class DownloadManager:
         thread.start()
         log(f"[DownloadManager] started task {task_id}: {version} ({loader})")
         return task_id
+
+    def wait_task(self, task_id, timeout: float | None = None) -> bool:
+        """Block until task finishes. Returns True if completed within timeout."""
+        task = self.get_task(task_id)
+        if task is None:
+            return False
+        return task.completed_event.wait(timeout=timeout)
 
     def cancel_task(self, task_id):
         """Cancel a task by ID."""

--- a/modules/modrinth.py
+++ b/modules/modrinth.py
@@ -1,4 +1,5 @@
 import requests, logging, json
+import os
 import sys
 from modules.log import log
 from requests.adapters import HTTPAdapter
@@ -220,77 +221,67 @@ def Get_Mod_File_Download_Url(slug, loaders=None, game_versions=None):
         return None
 
 
-def add_mrpack(parent_widget: QWidget = None):
+def add_mrpack(parent_widget: QWidget = None, backend=None):
+    """导入 .mrpack（内置实现；可选 BLORET_MRPACK_INSTALL_BIN 外挂回退）。"""
     log(i18nText("添加 Modrinth Modpack"), logging.INFO)
 
-    # 弹出文件选择对话框
     file_path, _ = QFileDialog.getOpenFileName(
         parent_widget,
         i18nText("选择 .mrpack 文件"),
         "",
-        "Modrinth Modpack Files (*.mrpack)"
+        "Modrinth Modpack Files (*.mrpack)",
     )
-
-    # 如果用户选择了文件
-    if file_path:
-        # 创建信息栏
-        if parent_widget:
-            info_bar = InfoBar(parent=parent_widget)
-            info_bar.show()
-        
-        def run_install():
-            try:
-                # 运行 mrpack-install 命令
-                executable = "mrpack-install.exe" if sys.platform == "win32" else "mrpack-install"
-                process = subprocess.Popen(
-                    [executable, file_path],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    bufsize=1,
-                    universal_newlines=True,
-                    **hidden_process_kwargs(),
-                )
-                
-                # 实时输出日志
-                last_line = ""
-                for line in process.stdout:
-                    print(line, end='')
-                    last_line = line
-                    # 更新信息栏
-                    if parent_widget:
-                        # 这里可以根据需要更新信息栏的状态
-                        # 例如，可以根据输出内容更新信息栏的文本
-                        info_bar.setMessage(last_line.strip()[:50])  # 限制文本长度
-                
-                # 等待进程结束
-                process.wait()
-                
-                # 检查最后一条日志
-                if "Done :) Have a nice day" in last_line.strip():
-                        log(i18nText("Modpack 安装成功!"))
-                        if parent_widget:
-                            info_bar.setMessage(i18nText("安装成功!"))
-                            info_bar.setSuccess()
-                else:
-                        log(i18nText("Modpack 安装失败!"))
-                        if parent_widget:
-                            info_bar.setMessage(i18nText("安装失败!"))
-                            info_bar.setError()
-                    
-            except Exception as e:
-                    log(f"安装过程中发生错误: {str(e)}", logging.ERROR)
-                    if parent_widget:
-                        info_bar.setMessage(f"错误: {str(e)}")
-                        info_bar.setError()
-            finally:
-                    # 关闭信息栏
-                    if parent_widget:
-                        info_bar.close()
-        
-        # 在单独线程中运行安装过程
-        thread = threading.Thread(target=run_install)
-        thread.daemon = True
-        thread.start()
-    else:
+    if not file_path:
         log(i18nText("未选择文件"))
+        return
+
+    fallback_bin = os.environ.get("BLORET_MRPACK_INSTALL_BIN", "").strip()
+    if fallback_bin:
+        _add_mrpack_via_external(file_path, parent_widget, fallback_bin)
+        return
+
+    def run_install():
+        try:
+            from modules.mrpack_import import import_mrpack
+
+            def on_progress(phase, current, total, message):
+                log(f"[mrpack] {phase} {current}/{total} {message}")
+
+            result = import_mrpack(file_path, backend=backend, progress=on_progress)
+            if result.get("ok"):
+                log(i18nText("Modpack 安装成功!"))
+            else:
+                log(f"{i18nText('Modpack 安装失败!')}: {result.get('message')}", logging.ERROR)
+        except Exception as e:
+            log(f"安装过程中发生错误: {str(e)}", logging.ERROR)
+
+    thread = threading.Thread(target=run_install, daemon=True)
+    thread.start()
+
+
+def _add_mrpack_via_external(file_path, parent_widget, executable):
+    """可选外挂 mrpack-install 回退（环境变量 BLORET_MRPACK_INSTALL_BIN）。"""
+    def run_install():
+        try:
+            process = subprocess.Popen(
+                [executable, file_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                universal_newlines=True,
+                **hidden_process_kwargs(),
+            )
+            last_line = ""
+            for line in process.stdout:
+                print(line, end="")
+                last_line = line
+            process.wait()
+            if "Done :) Have a nice day" in last_line.strip() or process.returncode == 0:
+                log(i18nText("Modpack 安装成功!"))
+            else:
+                log(i18nText("Modpack 安装失败!"), logging.ERROR)
+        except Exception as e:
+            log(f"安装过程中发生错误: {str(e)}", logging.ERROR)
+
+    threading.Thread(target=run_install, daemon=True).start()

--- a/modules/mrpack_export.py
+++ b/modules/mrpack_export.py
@@ -1,24 +1,93 @@
 """
 Modrinth Modpack Export Module
-用于将 Minecraft 实例导出为 .mrpack 格式
+
+对齐官方 Modrinth App（theseus）行为：
+- 远程可下载内容 → modrinth.index.json 的 files[]（含 downloads）
+- 本地文件 → ZIP 内 overrides/{path}
+- 不再使用错误的 ZIP files/ 目录
 """
 
-import zipfile
-import json
+from __future__ import annotations
+
 import hashlib
-import os
+import json
 import logging
+import os
+import re
+import zipfile
 from pathlib import Path
-from modules.log import log
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 from modules.i18n import i18nText
+from modules.log import log
+
+NEVER_EXPORT_PREFIXES = (
+    "modrinth_logs",
+    "logs",
+    "crash-reports",
+    ".fabric",
+    ".quilt",
+    "natives",
+    "versions",
+    "libraries",
+    "assets",
+    "__MACOSX",
+    "content-index.json",
+    "instance-settings.json",
+    "profile.json",
+    "saves",
+    "screenshots",
+    "resourcepacks/.cache",
+)
+
+DEFAULT_SELECTED_PREFIXES = (
+    "mods",
+    "datapacks",
+    "resourcepacks",
+    "shaderpacks",
+    "config",
+)
+
+# 仅对这些路径尝试 Modrinth hash 反查（减少 API 调用）
+CDN_LOOKUP_PREFIXES = ("mods/", "resourcepacks/", "shaderpacks/", "datapacks/")
+
+_MODRINTH_SESSION: Optional[requests.Session] = None
+_HASH_LOOKUP_CACHE: Dict[str, Optional[Dict[str, Any]]] = {}
 
 
-def calculate_hash(file_path, algorithm='sha512'):
-    """计算文件的哈希值"""
+def _session() -> requests.Session:
+    global _MODRINTH_SESSION
+    if _MODRINTH_SESSION is None:
+        s = requests.Session()
+        s.headers.update(
+            {
+                "User-Agent": "Bloret-Launcher/mrpack-export (https://github.com/Bloret-Crew/Bloret-Launcher)",
+                "Accept": "application/json",
+            }
+        )
+        retry = Retry(
+            total=2,
+            backoff_factor=0.4,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        _MODRINTH_SESSION = s
+    return _MODRINTH_SESSION
+
+
+def calculate_hash(file_path, algorithm="sha512"):
+    """计算文件的哈希值。"""
     hash_func = hashlib.new(algorithm)
     try:
-        with open(file_path, 'rb') as f:
-            for chunk in iter(lambda: f.read(8192), b''):
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
                 hash_func.update(chunk)
         return hash_func.hexdigest()
     except Exception as e:
@@ -26,249 +95,476 @@ def calculate_hash(file_path, algorithm='sha512'):
         return None
 
 
-def detect_game_version(instance_path):
-    """检测游戏版本"""
+def calculate_hashes(file_path) -> Optional[Dict[str, str]]:
+    """一次读取同时算 sha1 + sha512。"""
+    h1 = hashlib.sha1()
+    h512 = hashlib.sha512()
     try:
-        # 尝试从 version.json 读取
-        version_file = Path(instance_path) / "version.json"
-        if version_file.exists():
-            with open(version_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                return data.get('id', '1.20.1')
-        
-        # 尝试从实例名称解析
-        instance_name = Path(instance_path).name
-        # 简单的版本提取逻辑
-        import re
-        match = re.search(r'(\d+\.\d+(\.\d+)?)', instance_name)
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h1.update(chunk)
+                h512.update(chunk)
+        return {"sha1": h1.hexdigest(), "sha512": h512.hexdigest()}
+    except Exception as e:
+        log(f"计算文件哈希失败 {file_path}: {str(e)}", logging.ERROR)
+        return None
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def detect_game_version(instance_path) -> str:
+    """检测游戏版本：优先 version JSON / .BL.json，其次目录名。"""
+    instance = Path(instance_path)
+    try:
+        for name in (
+            f"{instance.name}.json",
+            "version.json",
+        ):
+            data = _read_json(instance / name)
+            if not data:
+                continue
+            # 继承链：优先 id，再尝试从 inheritsFrom
+            for key in ("id", "inheritsFrom", "jar"):
+                val = data.get(key)
+                if isinstance(val, str) and re.match(r"^\d+\.\d+", val):
+                    return val
+            # fabric/forge 版本 id 常含加载器前缀，尝试解析
+            vid = data.get("id")
+            if isinstance(vid, str):
+                m = re.search(r"(\d+\.\d+(?:\.\d+)?)", vid)
+                if m:
+                    return m.group(1)
+
+        bl = _read_json(instance / ".BL.json")
+        if bl:
+            for key in ("minecraft", "game_version", "version", "id"):
+                val = bl.get(key)
+                if isinstance(val, str) and re.match(r"^\d+\.\d+", val):
+                    return val
+
+        match = re.search(r"(\d+\.\d+(?:\.\d+)?)", instance.name)
         if match:
             return match.group(1)
-            
     except Exception as e:
         log(f"检测游戏版本失败：{str(e)}", logging.WARNING)
-    
+
     return "1.20.1"
 
 
-def detect_loader(instance_path):
-    """检测加载器类型和版本"""
+def detect_loader(instance_path) -> Optional[Dict[str, str]]:
+    """检测加载器类型和版本。返回 {"name": "fabric-loader", "version": "..."}。"""
+    instance = Path(instance_path)
     try:
-        mods_dir = Path(instance_path) / "mods"
-        if not mods_dir.exists():
-            return None
-        
-        # 检测 Fabric
-        fabric_loader_jars = list(mods_dir.glob("fabric-loader-*.jar"))
-        if fabric_loader_jars:
-            # 从文件名提取版本
-            name = fabric_loader_jars[0].name
-            import re
-            match = re.search(r'fabric-loader-(\d+\.\d+\.\d+)', name)
-            if match:
-                return {"name": "fabric-loader", "version": match.group(1)}
-            return {"name": "fabric-loader", "version": "*"}
-        
-        # 检测 Forge
-        forge_jars = list(mods_dir.glob("forge-*.jar")) + list(mods_dir.glob("*forge-*.jar"))
-        if forge_jars:
-            name = forge_jars[0].name
-            import re
-            match = re.search(r'forge[-_](\d+\.\d+\.\d+)', name, re.IGNORECASE)
-            if match:
-                return {"name": "forge", "version": match.group(1)}
-            return {"name": "forge", "version": "*"}
-        
-        # 检测 NeoForge
-        neoforge_jars = list(mods_dir.glob("neoforge-*.jar"))
-        if neoforge_jars:
-            name = neoforge_jars[0].name
-            import re
-            match = re.search(r'neoforge[-_](\d+\.\d+\.\d+)', name, re.IGNORECASE)
-            if match:
-                return {"name": "neoforge", "version": match.group(1)}
-            return {"name": "neoforge", "version": "*"}
-            
+        # 1) version JSON libraries / id
+        for name in (f"{instance.name}.json", "version.json"):
+            data = _read_json(instance / name)
+            if not data:
+                continue
+            vid = str(data.get("id") or "")
+            main = str(data.get("mainClass") or "")
+            libs = data.get("libraries") or []
+            lib_names = " ".join(
+                str((lib or {}).get("name") or "") for lib in libs if isinstance(lib, dict)
+            ).lower()
+
+            if "net.fabricmc" in lib_names or "fabric" in main.lower() or "fabric" in vid.lower():
+                m = re.search(r"fabric[-_]?loader[-_:]([\w.\-]+)", lib_names + " " + vid, re.I)
+                ver = m.group(1) if m else "*"
+                # 规范化 fabric-loader:version 形式
+                m2 = re.search(r"net\.fabricmc:fabric-loader:([\w.\-]+)", lib_names)
+                if m2:
+                    ver = m2.group(1)
+                return {"name": "fabric-loader", "version": ver}
+
+            if "neoforge" in lib_names or "neoforge" in vid.lower():
+                m = re.search(r"neoforge[-_:]([\w.\-]+)", lib_names + " " + vid, re.I)
+                return {"name": "neoforge", "version": m.group(1) if m else "*"}
+
+            if "minecraftforge" in lib_names or "forge" in vid.lower():
+                m = re.search(r"forge[-_:]([\d.\-]+)", lib_names + " " + vid, re.I)
+                return {"name": "forge", "version": m.group(1) if m else "*"}
+
+            if "quilt" in lib_names or "quilt" in main.lower():
+                m = re.search(r"quilt[-_]?loader[-_:]([\w.\-]+)", lib_names, re.I)
+                return {"name": "quilt-loader", "version": m.group(1) if m else "*"}
+
+        # 2) .BL.json
+        bl = _read_json(instance / ".BL.json")
+        if bl:
+            if bl.get("Fabric") or str(bl.get("loader") or "").lower() == "fabric":
+                return {
+                    "name": "fabric-loader",
+                    "version": str(bl.get("loader_version") or bl.get("fabric_loader") or "*"),
+                }
+            loader = str(bl.get("loader") or "").lower()
+            if loader in ("forge", "neoforge", "quilt"):
+                name_map = {
+                    "forge": "forge",
+                    "neoforge": "neoforge",
+                    "quilt": "quilt-loader",
+                }
+                return {
+                    "name": name_map[loader],
+                    "version": str(bl.get("loader_version") or "*"),
+                }
+
+        # 3) 弱回退：扫 mods 目录（不可靠，仅兜底）
+        mods_dir = instance / "mods"
+        if mods_dir.is_dir():
+            for jar in mods_dir.glob("fabric-loader-*.jar"):
+                m = re.search(r"fabric-loader-(\d+\.\d+\.\d+)", jar.name)
+                return {
+                    "name": "fabric-loader",
+                    "version": m.group(1) if m else "*",
+                }
     except Exception as e:
         log(f"检测加载器失败：{str(e)}", logging.WARNING)
-    
+
     return None
 
 
-def collect_files(instance_path):
-    """收集实例中的文件"""
-    files_list = []
+def _should_skip_rel(rel: str) -> bool:
+    rel = rel.replace("\\", "/").lstrip("./")
+    lower = rel.lower()
+    if lower.endswith(".ds_store"):
+        return True
+    if "/." in f"/{lower}" and not lower.startswith("mods/"):
+        # 隐藏目录（保留 mods 下 .disabled 由调用方决定）
+        parts = lower.split("/")
+        if any(p.startswith(".") and p not in (".", "..") for p in parts[:-1]):
+            if parts[0] in (".fabric", ".quilt"):
+                return True
+    for p in NEVER_EXPORT_PREFIXES:
+        if lower == p or lower.startswith(p + "/"):
+            return True
+    return False
+
+
+def get_export_candidates(instance_path) -> List[Dict[str, Any]]:
+    """返回可导出候选文件（供 UI 勾选）。"""
     instance = Path(instance_path)
-    
-    # 收集 mods 目录
+    candidates: List[Dict[str, Any]] = []
+    if not instance.exists():
+        return candidates
+
+    def add_file(abs_path: Path, rel: str, default_selected: bool):
+        rel = rel.replace(os.sep, "/")
+        if _should_skip_rel(rel):
+            return
+        try:
+            st = abs_path.stat()
+            size = st.st_size
+            mtime = int(st.st_mtime)
+        except OSError:
+            size, mtime = 0, 0
+        disabled = abs_path.name.endswith(".disabled")
+        candidates.append(
+            {
+                "path": rel,
+                "type": "file",
+                "size": size,
+                "modified": mtime,
+                "disabled": disabled,
+                "default_selected": bool(default_selected) and not disabled,
+                "source": str(abs_path),
+            }
+        )
+
+    scan_roots = (
+        "mods",
+        "config",
+        "resourcepacks",
+        "shaderpacks",
+        "datapacks",
+        "options.txt",
+    )
+    for prefix in scan_roots:
+        target = instance / prefix
+        default_sel = any(
+            prefix == p or prefix.startswith(p) for p in DEFAULT_SELECTED_PREFIXES
+        )
+        if target.is_file():
+            add_file(target, prefix, default_sel)
+            continue
+        if not target.is_dir():
+            continue
+        for f in target.rglob("*"):
+            if not f.is_file():
+                continue
+            rel = f"{prefix}/{f.relative_to(target)}".replace(os.sep, "/")
+            add_file(f, rel, default_sel)
+    return candidates
+
+
+def collect_files(instance_path, selected_paths=None) -> List[Dict[str, Any]]:
+    """收集实例中的文件。
+
+    selected_paths: 可选，相对路径列表；None 表示使用默认前缀全选；
+    空列表视为未选择任何（调用方通常会转成 None）。
+    """
+    files_list: List[Dict[str, Any]] = []
+    instance = Path(instance_path)
+    selected: Optional[Set[str]] = None
+    if selected_paths is not None:
+        selected = {str(p).replace("\\", "/") for p in selected_paths}
+
+    def want(rel: str) -> bool:
+        rel = rel.replace("\\", "/")
+        if _should_skip_rel(rel):
+            return False
+        if selected is None:
+            return any(rel == p or rel.startswith(p + "/") for p in DEFAULT_SELECTED_PREFIXES)
+        return rel in selected
+
     mods_dir = instance / "mods"
     if mods_dir.exists():
         for mod_file in mods_dir.glob("*.jar"):
             rel_path = f"mods/{mod_file.name}"
-            files_list.append({
-                "path": rel_path,
-                "source": str(mod_file),
-                "env": {"client": "required", "server": "required"}
-            })
-    
-    # 收集 config 目录
-    config_dir = instance / "config"
-    if config_dir.exists():
-        for config_file in config_dir.rglob("*"):
-            if config_file.is_file():
-                rel_path = f"config/{config_file.relative_to(config_dir)}"
-                # 使用正斜杠
-                rel_path = rel_path.replace(os.sep, '/')
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(config_file)
-                })
-    
-    # 收集 resourcepacks 目录
-    rp_dir = instance / "resourcepacks"
-    if rp_dir.exists():
-        for rp_file in rp_dir.rglob("*"):
-            if rp_file.is_file():
-                rel_path = f"resourcepacks/{rp_file.relative_to(rp_dir)}"
-                rel_path = rel_path.replace(os.sep, '/')
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(rp_file)
-                })
-    
-    # 收集 shaderpacks 目录
-    shader_dir = instance / "shaderpacks"
-    if shader_dir.exists():
-        for shader_file in shader_dir.rglob("*"):
-            if shader_file.is_file():
-                rel_path = f"shaderpacks/{shader_file.relative_to(shader_dir)}"
-                rel_path = rel_path.replace(os.sep, '/')
-                files_list.append({
-                    "path": rel_path,
-                    "source": str(shader_file)
-                })
-    
+            if want(rel_path):
+                files_list.append(
+                    {
+                        "path": rel_path,
+                        "source": str(mod_file),
+                        "env": {"client": "required", "server": "required"},
+                    }
+                )
+        # 也收集 .jar.disabled 若被显式勾选
+        for mod_file in mods_dir.glob("*.jar.disabled"):
+            rel_path = f"mods/{mod_file.name}"
+            if want(rel_path):
+                files_list.append(
+                    {
+                        "path": rel_path,
+                        "source": str(mod_file),
+                        "env": {"client": "required", "server": "required"},
+                    }
+                )
+
+    for folder in ("config", "resourcepacks", "shaderpacks", "datapacks"):
+        d = instance / folder
+        if not d.exists():
+            continue
+        for f in d.rglob("*"):
+            if not f.is_file():
+                continue
+            rel_path = f"{folder}/{f.relative_to(d)}".replace(os.sep, "/")
+            if want(rel_path):
+                files_list.append({"path": rel_path, "source": str(f)})
+
+    options = instance / "options.txt"
+    if options.is_file() and want("options.txt"):
+        files_list.append({"path": "options.txt", "source": str(options)})
+
     return files_list
 
 
-def export_to_mrpack(instance_path, output_path, name, version, summary=""):
+def lookup_modrinth_file_by_sha1(sha1: str) -> Optional[Dict[str, Any]]:
+    """通过 sha1 反查 Modrinth 文件元数据（含下载 URL）。失败返回 None。"""
+    if not sha1:
+        return None
+    if sha1 in _HASH_LOOKUP_CACHE:
+        return _HASH_LOOKUP_CACHE[sha1]
+    url = f"https://api.modrinth.com/v2/version_file/{sha1}"
+    try:
+        resp = _session().get(url, params={"algorithm": "sha1"}, timeout=12)
+        if resp.status_code == 404:
+            _HASH_LOOKUP_CACHE[sha1] = None
+            return None
+        if resp.status_code != 200:
+            log(f"Modrinth version_file 查询失败: HTTP {resp.status_code}", logging.DEBUG)
+            _HASH_LOOKUP_CACHE[sha1] = None
+            return None
+        data = resp.json()
+        if not isinstance(data, dict):
+            _HASH_LOOKUP_CACHE[sha1] = None
+            return None
+        # version 对象含 files[]
+        files = data.get("files") or []
+        primary = None
+        for f in files:
+            if not isinstance(f, dict):
+                continue
+            hashes = f.get("hashes") or {}
+            if hashes.get("sha1") == sha1 or f.get("primary"):
+                primary = f
+                if hashes.get("sha1") == sha1:
+                    break
+        if primary is None and files:
+            primary = files[0] if isinstance(files[0], dict) else None
+        if not primary:
+            _HASH_LOOKUP_CACHE[sha1] = None
+            return None
+        download_url = primary.get("url")
+        if not download_url:
+            _HASH_LOOKUP_CACHE[sha1] = None
+            return None
+        result = {
+            "url": download_url,
+            "filename": primary.get("filename"),
+            "size": primary.get("size"),
+            "hashes": primary.get("hashes") or {},
+            "project_id": data.get("project_id"),
+            "version_id": data.get("id"),
+        }
+        _HASH_LOOKUP_CACHE[sha1] = result
+        return result
+    except Exception as e:
+        log(f"Modrinth hash 反查异常: {e}", logging.DEBUG)
+        _HASH_LOOKUP_CACHE[sha1] = None
+        return None
+
+
+def _should_try_cdn(rel_path: str) -> bool:
+    rel = rel_path.replace("\\", "/").lower()
+    return any(rel.startswith(p) for p in CDN_LOOKUP_PREFIXES)
+
+
+def export_to_mrpack(
+    instance_path,
+    output_path,
+    name,
+    version,
+    summary="",
+    selected_paths=None,
+    resolve_cdn: bool = True,
+):
     """
-    导出 Minecraft 实例为 .mrpack 文件
-    
-    Args:
-        instance_path: 实例目录路径
-        output_path: 输出的 .mrpack 文件路径
-        name: 整合包名称
-        version: 整合包版本号
-        summary: 整合包简介
-    
-    Returns:
-        bool: 是否成功
+    导出 Minecraft 实例为官方兼容的 .mrpack 文件。
+
+    - 能反查 CDN 的内容：只写 index.files[]（含 downloads），不嵌入 ZIP
+    - 其余：写入 overrides/{path}
+    - 始终写入 modrinth.index.json
     """
     try:
         log(i18nText("开始导出 Modrinth 整合包"), logging.INFO)
-        
+
         instance = Path(instance_path)
         if not instance.exists():
             log(f"实例路径不存在：{instance_path}", logging.ERROR)
             return False
-        
-        # 检测游戏版本和加载器
+
         game_version = detect_game_version(instance_path)
         loader = detect_loader(instance_path)
-        
+
         log(f"检测到游戏版本：{game_version}", logging.INFO)
         if loader:
             log(f"检测到加载器：{loader['name']} {loader['version']}", logging.INFO)
-        
-        # 构建依赖项
-        dependencies = {"minecraft": game_version}
+
+        dependencies: Dict[str, str] = {"minecraft": game_version}
         if loader:
-            dependencies[loader['name']] = loader['version']
-        
-        # 收集文件
-        files_list = collect_files(instance_path)
+            dependencies[loader["name"]] = loader["version"]
+
+        files_list = collect_files(instance_path, selected_paths=selected_paths)
         log(f"收集到 {len(files_list)} 个文件", logging.INFO)
-        
         if not files_list:
             log("没有找到可导出的文件", logging.WARNING)
-        
-        # 构建 index 文件
+
         index = {
             "formatVersion": 1,
             "game": "minecraft",
             "versionId": version,
             "name": name,
-            "summary": summary,
+            "summary": summary or None,
             "files": [],
-            "dependencies": dependencies
+            "dependencies": dependencies,
         }
-        
-        # 创建 ZIP 文件
-        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            # 处理每个文件
+        # summary 为可选；空字符串时省略更干净
+        if not index["summary"]:
+            index.pop("summary", None)
+
+        override_count = 0
+        remote_count = 0
+
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file_info in files_list:
-                source_path = Path(file_info['source'])
-                target_path = file_info['path']
-                
-                if not source_path.exists():
+                source_path = Path(file_info["source"])
+                target_path = str(file_info["path"]).replace("\\", "/")
+
+                if not source_path.is_file():
                     log(f"文件不存在，跳过：{source_path}", logging.WARNING)
                     continue
-                
-                # 计算哈希
-                sha512_hash = calculate_hash(source_path, 'sha512')
-                sha1_hash = calculate_hash(source_path, 'sha1')
-                
-                if not sha512_hash or not sha1_hash:
+
+                hashes = calculate_hashes(source_path)
+                if not hashes:
                     log(f"计算哈希失败，跳过：{source_path}", logging.WARNING)
                     continue
-                
-                # 构建文件条目
-                file_entry = {
-                    "path": target_path,
-                    "hashes": {
-                        "sha512": sha512_hash,
-                        "sha1": sha1_hash
-                    },
-                    "fileSize": source_path.stat().st_size
-                }
-                
-                # 添加环境要求
-                if 'env' in file_info:
-                    file_entry['env'] = file_info['env']
-                
-                index['files'].append(file_entry)
-                
-                # 将文件添加到 ZIP 的 files/ 目录下
-                arcname = f"files/{target_path}"
-                zipf.write(source_path, arcname)
-                log(f"添加文件到整合包：{target_path}", logging.DEBUG)
-            
-            # 写入 index 文件
-            zipf.writestr('modrinth.index.json', json.dumps(index, indent=2))
-        
+
+                file_size = source_path.stat().st_size
+                cdn_meta = None
+                if resolve_cdn and _should_try_cdn(target_path):
+                    cdn_meta = lookup_modrinth_file_by_sha1(hashes["sha1"])
+
+                if cdn_meta and cdn_meta.get("url"):
+                    # 远程文件：只进 index
+                    file_entry: Dict[str, Any] = {
+                        "path": target_path,
+                        "hashes": {
+                            "sha1": hashes["sha1"],
+                            "sha512": hashes["sha512"],
+                        },
+                        "downloads": [cdn_meta["url"]],
+                        "fileSize": int(cdn_meta.get("size") or file_size),
+                    }
+                    # 合并 CDN 侧哈希（若有）
+                    for algo in ("sha1", "sha512"):
+                        if (cdn_meta.get("hashes") or {}).get(algo):
+                            file_entry["hashes"][algo] = cdn_meta["hashes"][algo]
+                    if "env" in file_info:
+                        file_entry["env"] = file_info["env"]
+                    else:
+                        file_entry["env"] = {
+                            "client": "required",
+                            "server": "required",
+                        }
+                    index["files"].append(file_entry)
+                    remote_count += 1
+                    log(f"远程引用：{target_path}", logging.DEBUG)
+                else:
+                    # 本地覆盖：进 overrides/，不进 index.files（与官方一致）
+                    arcname = f"overrides/{target_path}"
+                    zipf.write(source_path, arcname)
+                    override_count += 1
+                    log(f"覆盖文件：{target_path}", logging.DEBUG)
+
+            zipf.writestr(
+                "modrinth.index.json",
+                json.dumps(index, indent=2, ensure_ascii=False),
+            )
+
         log(f"整合包导出成功：{output_path}", logging.INFO)
         log(f"  - 名称：{name}", logging.INFO)
         log(f"  - 版本：{version}", logging.INFO)
         log(f"  - 游戏版本：{game_version}", logging.INFO)
-        log(f"  - 文件数量：{len(index['files'])}", logging.INFO)
-        
+        log(f"  - 远程文件：{remote_count}，覆盖文件：{override_count}", logging.INFO)
         return True
-        
+
     except Exception as e:
         log(f"导出整合包失败：{str(e)}", logging.ERROR)
         import traceback
+
         log(traceback.format_exc(), logging.ERROR)
         return False
 
 
 def get_instance_info(instance_path):
-    """获取实例信息用于导出对话框"""
+    """获取实例信息用于导出对话框。"""
     try:
+        loader = detect_loader(instance_path)
+        loader_label = "unknown"
+        if loader:
+            loader_label = f"{loader['name']} {loader.get('version') or ''}".strip()
         info = {
             "name": Path(instance_path).name,
             "game_version": detect_game_version(instance_path),
-            "loader": detect_loader(instance_path),
-            "file_count": len(collect_files(instance_path))
+            "loader": loader_label,
+            "file_count": len(collect_files(instance_path)),
         }
         return info
     except Exception as e:

--- a/modules/mrpack_import.py
+++ b/modules/mrpack_import.py
@@ -1,0 +1,582 @@
+"""
+Modrinth Modpack Import Module
+
+对齐官方 Modrinth App 导入行为（精简 Python 实现）：
+1. 解析 modrinth.index.json
+2. 按 dependencies 安装 Minecraft + 加载器
+3. 下载 files[]（多镜像、sha1 校验；跳过 client unsupported）
+4. 解压 overrides/ 与 client-overrides/
+5. 兼容旧 Bloret 错误格式：ZIP 内 files/ 目录
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+import time
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from modules.i18n import i18nText
+from modules.log import log
+
+ProgressCb = Optional[Callable[[str, int, int, str], None]]
+
+_SESSION: Optional[requests.Session] = None
+
+
+def _session() -> requests.Session:
+    global _SESSION
+    if _SESSION is None:
+        s = requests.Session()
+        s.headers.update(
+            {
+                "User-Agent": "Bloret-Launcher/mrpack-import (https://github.com/Bloret-Crew/Bloret-Launcher)",
+            }
+        )
+        retry = Retry(
+            total=3,
+            backoff_factor=0.5,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        _SESSION = s
+    return _SESSION
+
+
+def _emit(progress: ProgressCb, phase: str, current: int, total: int, message: str):
+    if progress:
+        try:
+            progress(phase, current, total, message)
+        except Exception:
+            pass
+    log(f"[mrpack-import] [{phase}] {current}/{total} {message}", logging.INFO)
+
+
+def _safe_join(base: Path, rel: str) -> Path:
+    """防止 zip-slip：相对路径必须落在 base 下。"""
+    rel = rel.replace("\\", "/").lstrip("/")
+    parts = []
+    for p in rel.split("/"):
+        if p in ("", "."):
+            continue
+        if p == "..":
+            raise ValueError(f"非法路径: {rel}")
+        parts.append(p)
+    target = base.joinpath(*parts) if parts else base
+    base_resolved = base.resolve()
+    # 目标可能尚不存在，用 parent 校验前缀
+    try:
+        target.resolve().relative_to(base_resolved)
+    except ValueError:
+        # 文件尚不存在时 resolve 仍可基于父目录
+        if not str(target).startswith(str(base_resolved)):
+            # 宽松：确保规范化后仍在 base 下
+            norm = os.path.normpath(str(target))
+            if not norm.startswith(str(base_resolved)):
+                raise ValueError(f"路径越界: {rel}")
+    return target
+
+
+def _sha1_bytes(data: bytes) -> str:
+    return hashlib.sha1(data).hexdigest()
+
+
+def _sha1_file(path: Path) -> str:
+    h = hashlib.sha1()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_mrpack_index(mrpack_path: str) -> Dict[str, Any]:
+    """读取并校验 modrinth.index.json。"""
+    path = Path(mrpack_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"mrpack 不存在: {mrpack_path}")
+
+    with zipfile.ZipFile(path, "r") as zf:
+        names = zf.namelist()
+        manifest_name = None
+        for n in names:
+            if n.replace("\\", "/") == "modrinth.index.json":
+                manifest_name = n
+                break
+        if not manifest_name:
+            raise ValueError("整合包中未找到 modrinth.index.json")
+        raw = zf.read(manifest_name)
+        try:
+            index = json.loads(raw.decode("utf-8"))
+        except Exception as e:
+            raise ValueError(f"modrinth.index.json 解析失败: {e}") from e
+
+    if not isinstance(index, dict):
+        raise ValueError("modrinth.index.json 格式无效")
+    if index.get("game") != "minecraft":
+        raise ValueError(f"不支持的 game 类型: {index.get('game')!r}")
+    if not isinstance(index.get("files"), list):
+        index["files"] = []
+    if not isinstance(index.get("dependencies"), dict):
+        index["dependencies"] = {}
+    return index
+
+
+def parse_dependencies(deps: Dict[str, Any]) -> Tuple[str, str, Optional[str]]:
+    """
+    返回 (minecraft_version, loader_type, loader_version)。
+    loader_type: vanilla | fabric | forge | neoforge | quilt
+    """
+    mc = str(deps.get("minecraft") or "").strip()
+    if not mc:
+        raise ValueError("dependencies 缺少 minecraft 版本")
+    # 去掉版本范围符号，取近似精确版本
+    m = re.search(r"(\d+\.\d+(?:\.\d+)?)", mc)
+    if m:
+        mc = m.group(1)
+
+    loader_type = "vanilla"
+    loader_version = None
+    mapping = (
+        ("fabric-loader", "fabric"),
+        ("quilt-loader", "quilt"),
+        ("neoforge", "neoforge"),
+        ("forge", "forge"),
+    )
+    for key, ltype in mapping:
+        if key in deps and deps[key] not in (None, ""):
+            loader_type = ltype
+            ver = str(deps[key]).strip()
+            # 去掉范围前缀
+            vm = re.search(r"([\w.\-]+)", ver.lstrip(">=~*^"))
+            loader_version = vm.group(1) if vm else ver
+            break
+    return mc, loader_type, loader_version
+
+
+def suggest_instance_name(index: Dict[str, Any], mrpack_path: str) -> str:
+    name = str(index.get("name") or "").strip()
+    version_id = str(index.get("versionId") or "").strip()
+    if name and version_id:
+        base = f"{name}-{version_id}"
+    elif name:
+        base = name
+    else:
+        base = Path(mrpack_path).stem
+    # 净化为安全目录名
+    base = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", base).strip(" .")
+    if not base:
+        base = "ImportedModpack"
+    return base[:80]
+
+
+def _unique_instance_name(minecraft_dir: str, desired: str) -> str:
+    versions = Path(minecraft_dir) / "versions"
+    candidate = desired
+    n = 2
+    while (versions / candidate).exists():
+        candidate = f"{desired}-{n}"
+        n += 1
+        if n > 999:
+            candidate = f"{desired}-{int(time.time())}"
+            break
+    return candidate
+
+
+def _client_unsupported(file_entry: dict) -> bool:
+    env = file_entry.get("env") or {}
+    if not isinstance(env, dict):
+        return False
+    return str(env.get("client") or "").lower() == "unsupported"
+
+
+def _download_one(
+    file_entry: dict,
+    instance_dir: Path,
+) -> Tuple[str, bool, str]:
+    """下载单个 files[] 条目。返回 (path, ok, message)。"""
+    rel = str(file_entry.get("path") or "").replace("\\", "/")
+    if not rel:
+        return "", False, "缺少 path"
+    if _client_unsupported(file_entry):
+        return rel, True, "skipped: unsupported on client"
+
+    hashes = file_entry.get("hashes") or {}
+    expected_sha1 = hashes.get("sha1")
+    downloads = file_entry.get("downloads") or []
+    if not downloads:
+        return rel, False, "无 downloads 且非 overrides"
+
+    target = _safe_join(instance_dir, rel)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    # 已存在且哈希匹配则跳过
+    if target.is_file() and expected_sha1:
+        try:
+            if _sha1_file(target) == expected_sha1:
+                return rel, True, "already present"
+        except Exception:
+            pass
+
+    last_err = "unknown"
+    for url in downloads:
+        try:
+            resp = _session().get(url, timeout=120, stream=True)
+            if resp.status_code != 200:
+                last_err = f"HTTP {resp.status_code}"
+                continue
+            chunks = []
+            for chunk in resp.iter_content(chunk_size=65536):
+                if chunk:
+                    chunks.append(chunk)
+            data = b"".join(chunks)
+            if expected_sha1:
+                actual = _sha1_bytes(data)
+                if actual != expected_sha1:
+                    last_err = f"sha1 mismatch: {actual} != {expected_sha1}"
+                    continue
+            tmp = target.with_suffix(target.suffix + ".part")
+            with open(tmp, "wb") as f:
+                f.write(data)
+            os.replace(tmp, target)
+            return rel, True, "downloaded"
+        except Exception as e:
+            last_err = str(e)
+            continue
+    return rel, False, last_err
+
+
+def extract_overrides(
+    mrpack_path: str,
+    instance_dir: Path,
+    progress: ProgressCb = None,
+) -> int:
+    """解压 overrides/、client-overrides/，以及兼容旧版 files/。"""
+    extracted = 0
+    prefixes = (
+        ("overrides/", True),
+        ("client-overrides/", True),
+        ("files/", True),  # 旧 Bloret 错误格式兼容
+    )
+    with zipfile.ZipFile(mrpack_path, "r") as zf:
+        entries = []
+        for info in zf.infolist():
+            name = info.filename.replace("\\", "/")
+            if name.endswith("/"):
+                continue
+            for prefix, _ in prefixes:
+                if name.startswith(prefix):
+                    rel = name[len(prefix) :]
+                    if rel:
+                        entries.append((info, rel))
+                    break
+
+        total = len(entries)
+        _emit(progress, "extract", 0, total, i18nText("正在解压覆盖文件..."))
+        for i, (info, rel) in enumerate(entries, 1):
+            try:
+                target = _safe_join(instance_dir, rel)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info, "r") as src, open(target, "wb") as dst:
+                    while True:
+                        chunk = src.read(65536)
+                        if not chunk:
+                            break
+                        dst.write(chunk)
+                extracted += 1
+            except Exception as e:
+                log(f"解压覆盖失败 {rel}: {e}", logging.WARNING)
+            if i == total or i % 10 == 0:
+                _emit(progress, "extract", i, total, rel)
+
+    return extracted
+
+
+def _install_minecraft_and_loader(
+    minecraft_version: str,
+    loader_type: str,
+    instance_name: str,
+    minecraft_dir: str,
+    backend=None,
+    progress: ProgressCb = None,
+    timeout_sec: int = 3600,
+) -> bool:
+    """直接调用安装管线（带正确 minecraft_dir），阻塞直到完成。"""
+    from modules.install import _install_minecraft_version_threaded
+
+    loader = loader_type if loader_type in ("vanilla", "fabric", "forge", "neoforge") else (
+        "fabric" if loader_type == "quilt" else "vanilla"
+    )
+    if loader_type == "quilt":
+        log("Quilt 加载器将尝试以 fabric 兼容路径安装（若失败请手动装加载器）", logging.WARNING)
+
+    _emit(
+        progress,
+        "install",
+        0,
+        1,
+        f"正在安装 Minecraft {minecraft_version} ({loader})...",
+    )
+
+    completed = threading.Event()
+    task_state = {
+        "task_id": f"mrpack-{int(time.time())}",
+        "cancel_event": threading.Event(),
+        "pause_event": threading.Event(),
+        "backend": backend,
+        "cancelled": False,
+        "is_paused": False,
+        "downloader": None,
+        "completed_event": completed,
+        "result": None,
+        "cleanup_on_fail": True,
+        "version_dir": None,
+    }
+
+    def run():
+        try:
+            task_state["result"] = bool(
+                _install_minecraft_version_threaded(
+                    minecraft_version,
+                    minecraft_dir=minecraft_dir,
+                    Fabric_Loader=(loader == "fabric"),
+                    VersionName=instance_name,
+                    backend=backend,
+                    Loader_Type=loader,
+                    task_state=task_state,
+                )
+            )
+        except Exception as exc:
+            task_state["result"] = False
+            task_state["_fail_reason"] = str(exc)
+            log(f"mrpack 安装游戏失败: {exc}", logging.ERROR)
+        finally:
+            completed.set()
+
+    # 在当前线程跑安装会阻塞进度回调；用子线程 + 等待
+    t = threading.Thread(target=run, daemon=True, name="MrpackGameInstall")
+    t.start()
+
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if completed.wait(timeout=0.8):
+            break
+        _emit(progress, "install", 0, 1, i18nText("正在安装游戏与加载器..."))
+
+    if not completed.is_set():
+        task_state["cancel_event"].set()
+        raise TimeoutError("安装 Minecraft 超时")
+
+    if not task_state.get("result"):
+        raise RuntimeError(
+            task_state.get("_fail_reason") or i18nText("游戏与加载器安装失败")
+        )
+
+    _emit(progress, "install", 1, 1, i18nText("游戏与加载器安装完成"))
+    return True
+
+
+def import_mrpack(
+    mrpack_path: str,
+    minecraft_dir: Optional[str] = None,
+    instance_name: Optional[str] = None,
+    backend=None,
+    progress: ProgressCb = None,
+    install_game: bool = True,
+    max_download_workers: int = 4,
+) -> Dict[str, Any]:
+    """
+    导入 .mrpack 到 versions/{instance_name}。
+
+    Returns:
+        dict: {ok, instance_name, instance_path, message, stats}
+    """
+    import modules.globals as BLglobals
+    import modules.config as cfg
+
+    if minecraft_dir is None:
+        try:
+            config_data = cfg.read()
+            minecraft_dir = config_data.get("minecraft_dir") or BLglobals.minecraft_dir
+        except Exception:
+            minecraft_dir = getattr(BLglobals, "minecraft_dir", None)
+    if not minecraft_dir:
+        minecraft_dir = os.path.join(BLglobals.datapath, ".minecraft")
+
+    result: Dict[str, Any] = {
+        "ok": False,
+        "instance_name": "",
+        "instance_path": "",
+        "message": "",
+        "stats": {},
+    }
+
+    try:
+        # 插件 pre hook
+        try:
+            from modules.plugin_host.dispatch import invoke_hook
+            from modules.plugin_host import hooks as hook_names
+
+            invoke_hook(
+                hook_names.MRPACK_IMPORT_PRE,
+                {"path": mrpack_path, "minecraft_dir": minecraft_dir},
+            )
+        except Exception:
+            pass
+
+        _emit(progress, "read", 0, 1, i18nText("正在读取整合包清单..."))
+        index = read_mrpack_index(mrpack_path)
+        deps = index.get("dependencies") or {}
+        mc_ver, loader_type, loader_ver = parse_dependencies(deps)
+        desired = instance_name or suggest_instance_name(index, mrpack_path)
+        desired = _unique_instance_name(minecraft_dir, desired)
+        instance_dir = Path(minecraft_dir) / "versions" / desired
+        instance_dir.mkdir(parents=True, exist_ok=True)
+
+        result["instance_name"] = desired
+        result["instance_path"] = str(instance_dir)
+
+        log(
+            f"导入 mrpack: name={index.get('name')}, mc={mc_ver}, "
+            f"loader={loader_type}:{loader_ver}, dest={instance_dir}",
+            logging.INFO,
+        )
+
+        if install_game:
+            _install_minecraft_and_loader(
+                mc_ver,
+                loader_type,
+                desired,
+                minecraft_dir,
+                backend=backend,
+                progress=progress,
+            )
+
+        # 下载 files[]
+        files = [f for f in (index.get("files") or []) if isinstance(f, dict)]
+        total = len(files)
+        _emit(progress, "download", 0, total, i18nText("正在下载整合包内容..."))
+        ok_count = 0
+        fail_count = 0
+        skip_count = 0
+        errors: List[str] = []
+
+        def _job(entry):
+            return _download_one(entry, instance_dir)
+
+        if total:
+            workers = max(1, min(max_download_workers, total))
+            done = 0
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = {pool.submit(_job, e): e for e in files}
+                for fut in as_completed(futures):
+                    rel, ok, msg = fut.result()
+                    done += 1
+                    if ok:
+                        if msg.startswith("skipped"):
+                            skip_count += 1
+                        else:
+                            ok_count += 1
+                    else:
+                        fail_count += 1
+                        errors.append(f"{rel}: {msg}")
+                    _emit(progress, "download", done, total, rel or msg)
+
+        # 解压 overrides
+        extracted = extract_overrides(mrpack_path, instance_dir, progress=progress)
+
+        # 写入导入元数据，便于后续识别
+        meta = {
+            "source": "mrpack",
+            "pack_name": index.get("name"),
+            "pack_version": index.get("versionId"),
+            "minecraft": mc_ver,
+            "loader": loader_type,
+            "loader_version": loader_ver,
+            "imported_at": int(time.time()),
+            "mrpack_file": os.path.basename(mrpack_path),
+        }
+        try:
+            with open(instance_dir / "bloret-mrpack-meta.json", "w", encoding="utf-8") as f:
+                json.dump(meta, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            log(f"写入 mrpack meta 失败: {e}", logging.DEBUG)
+
+        stats = {
+            "remote_ok": ok_count,
+            "remote_fail": fail_count,
+            "remote_skip": skip_count,
+            "overrides": extracted,
+            "minecraft": mc_ver,
+            "loader": loader_type,
+        }
+        result["stats"] = stats
+
+        if fail_count and ok_count == 0 and extracted == 0:
+            result["message"] = i18nText("导入失败：无法下载任何内容")
+            if errors:
+                result["message"] += "\n" + "\n".join(errors[:5])
+            result["ok"] = False
+        else:
+            msg = i18nText("整合包导入成功")
+            if fail_count:
+                msg += f"（{fail_count} 个文件下载失败）"
+            result["message"] = msg
+            result["ok"] = True
+
+        try:
+            from modules.plugin_host.dispatch import invoke_hook
+            from modules.plugin_host import hooks as hook_names
+
+            invoke_hook(hook_names.MRPACK_IMPORT_POST, result)
+        except Exception:
+            pass
+
+        _emit(
+            progress,
+            "done",
+            1 if result["ok"] else 0,
+            1,
+            result["message"],
+        )
+        return result
+
+    except Exception as e:
+        log(f"导入 mrpack 失败: {e}", logging.ERROR)
+        import traceback
+
+        log(traceback.format_exc(), logging.ERROR)
+        result["message"] = str(e)
+        result["ok"] = False
+        _emit(progress, "error", 0, 1, str(e))
+        return result
+
+
+def import_mrpack_file_dialog(parent_widget=None, backend=None, progress: ProgressCb = None):
+    """弹出文件选择并导入（供旧 Qt Widgets 路径使用）。"""
+    from PySide6.QtWidgets import QFileDialog
+
+    file_path, _ = QFileDialog.getOpenFileName(
+        parent_widget,
+        i18nText("选择 .mrpack 文件"),
+        "",
+        "Modrinth Modpack Files (*.mrpack)",
+    )
+    if not file_path:
+        log(i18nText("未选择文件"))
+        return {"ok": False, "message": i18nText("未选择文件"), "cancelled": True}
+
+    return import_mrpack(file_path, backend=backend, progress=progress)

--- a/modules/mrpack_import.py
+++ b/modules/mrpack_import.py
@@ -170,17 +170,21 @@ def parse_dependencies(deps: Dict[str, Any]) -> Tuple[str, str, Optional[str]]:
 def suggest_instance_name(index: Dict[str, Any], mrpack_path: str) -> str:
     name = str(index.get("name") or "").strip()
     version_id = str(index.get("versionId") or "").strip()
-    if name and version_id:
-        base = f"{name}-{version_id}"
-    elif name:
+    # 优先短名：整合包名；过长再截断。versionId 常含空格/特殊字符，仅作后缀兜底。
+    if name:
         base = name
+    elif version_id:
+        base = version_id
     else:
         base = Path(mrpack_path).stem
-    # 净化为安全目录名
-    base = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", base).strip(" .")
-    if not base:
+    # 净化为安全目录名（与 install._is_safe_version_name 对齐）
+    base = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", base)
+    base = base.replace("\\", "_").replace("/", "_").strip(" .")
+    # 空白压成下划线，避免部分平台路径问题
+    base = re.sub(r"\s+", "_", base)
+    if not base or base in (".", ".."):
         base = "ImportedModpack"
-    return base[:80]
+    return base[:64]
 
 
 def _unique_instance_name(minecraft_dir: str, desired: str) -> str:
@@ -314,14 +318,18 @@ def _install_minecraft_and_loader(
     progress: ProgressCb = None,
     timeout_sec: int = 3600,
 ) -> bool:
-    """直接调用安装管线（带正确 minecraft_dir），阻塞直到完成。"""
-    from modules.install import _install_minecraft_version_threaded
+    """通过 DownloadManager 安装游戏与加载器（会弹出下载面板），阻塞直到完成。"""
+    from modules.download_manager import DownloadManager
+    from modules.install import _is_safe_version_name
 
     loader = loader_type if loader_type in ("vanilla", "fabric", "forge", "neoforge") else (
         "fabric" if loader_type == "quilt" else "vanilla"
     )
     if loader_type == "quilt":
         log("Quilt 加载器将尝试以 fabric 兼容路径安装（若失败请手动装加载器）", logging.WARNING)
+
+    if not _is_safe_version_name(instance_name):
+        raise ValueError(f"不安全的实例名: {instance_name!r}")
 
     _emit(
         progress,
@@ -331,62 +339,68 @@ def _install_minecraft_and_loader(
         f"正在安装 Minecraft {minecraft_version} ({loader})...",
     )
 
-    completed = threading.Event()
-    task_state = {
-        "task_id": f"mrpack-{int(time.time())}",
-        "cancel_event": threading.Event(),
-        "pause_event": threading.Event(),
-        "backend": backend,
-        "cancelled": False,
-        "is_paused": False,
-        "downloader": None,
-        "completed_event": completed,
-        "result": None,
-        "cleanup_on_fail": True,
-        "version_dir": None,
-    }
-
-    def run():
+    dm = DownloadManager()
+    task_id = dm.start_download(
+        minecraft_version,
+        instance_name,
+        loader,
+        backend,
+        minecraft_dir=minecraft_dir,
+    )
+    # 打开下载管理面板，避免“选完文件无反应”
+    if backend is not None:
         try:
-            task_state["result"] = bool(
-                _install_minecraft_version_threaded(
-                    minecraft_version,
-                    minecraft_dir=minecraft_dir,
-                    Fabric_Loader=(loader == "fabric"),
-                    VersionName=instance_name,
-                    backend=backend,
-                    Loader_Type=loader,
-                    task_state=task_state,
-                )
+            if hasattr(backend, "openDownloadManager"):
+                backend.openDownloadManager()
+            elif hasattr(backend, "downloadManagerOpenRequested"):
+                backend.downloadManagerOpenRequested.emit()
+        except Exception:
+            pass
+        try:
+            backend.downloadNotify.emit(
+                i18nText("正在导入整合包"),
+                f"{instance_name} · Minecraft {minecraft_version} ({loader})",
+                True,
             )
-        except Exception as exc:
-            task_state["result"] = False
-            task_state["_fail_reason"] = str(exc)
-            log(f"mrpack 安装游戏失败: {exc}", logging.ERROR)
-        finally:
-            completed.set()
-
-    # 在当前线程跑安装会阻塞进度回调；用子线程 + 等待
-    t = threading.Thread(target=run, daemon=True, name="MrpackGameInstall")
-    t.start()
+        except Exception:
+            pass
 
     deadline = time.monotonic() + timeout_sec
+    last_status = ""
     while time.monotonic() < deadline:
-        if completed.wait(timeout=0.8):
-            break
-        _emit(progress, "install", 0, 1, i18nText("正在安装游戏与加载器..."))
+        task = dm.get_task(task_id)
+        if task is None:
+            time.sleep(0.5)
+            continue
+        status_text = task.status_text or ""
+        if status_text and status_text != last_status:
+            last_status = status_text
+            try:
+                pct = int(float(task.progress or 0))
+            except (TypeError, ValueError):
+                pct = 0
+            _emit(progress, "install", pct, 100, status_text)
+        if task.completed_event.is_set() or task.status in (
+            "completed",
+            "failed",
+            "cancelled",
+        ):
+            # 再等一下确保 result 写完
+            task.completed_event.wait(timeout=2.0)
+            if task.status == "completed" and bool(task.result):
+                _emit(progress, "install", 100, 100, i18nText("游戏与加载器安装完成"))
+                return True
+            raise RuntimeError(
+                task.error_message
+                or f"安装失败: status={task.status}"
+            )
+        time.sleep(0.8)
 
-    if not completed.is_set():
-        task_state["cancel_event"].set()
-        raise TimeoutError("安装 Minecraft 超时")
-
-    if not task_state.get("result"):
-        raise RuntimeError(
-            task_state.get("_fail_reason") or i18nText("游戏与加载器安装失败")
-        )
-
-    _emit(progress, "install", 1, 1, i18nText("游戏与加载器安装完成"))
-    return True
+    try:
+        dm.cancel_task(task_id)
+    except Exception:
+        pass
+    raise TimeoutError("安装 Minecraft 超时")
 
 
 def import_mrpack(

--- a/modules/resourcepack_editor/agent_backend.py
+++ b/modules/resourcepack_editor/agent_backend.py
@@ -11,17 +11,30 @@
 - 多 Agent 角色
 """
 
+import array
 import json
 import os
+import tempfile
 import time
 import logging
 import threading
 import requests
 from modules.i18n import i18nText
-from PySide6.QtCore import QObject, Signal, Slot, Property
+from PySide6.QtCore import QObject, Signal, Slot, Property, QIODevice, QByteArray, QBuffer, QTimer
 from PySide6.QtGui import QGuiApplication
 
 from .agent_loop import AgentLoop, run_agent_async, AGENT_ROLES
+
+# 复用 Blora Agent 的图片编码 / STT 工具
+from modules.bloriko_agent.backend import (
+    _build_user_content,
+    _content_text_preview,
+    _transcriptions_url_from_chat_api,
+    _pcm_to_wav_bytes,
+    _MAX_IMAGE_COUNT,
+    _MAX_IMAGE_FILE_BYTES,
+    _MAX_VOICE_SECONDS,
+)
 
 log = logging.getLogger(__name__)
 
@@ -318,6 +331,11 @@ class AgentBackend(QObject):
     # 角色信号
     roleChanged = Signal()
 
+    # 语音 STT
+    voiceStateChanged = Signal(str)  # idle | recording | transcribing
+    transcriptionReady = Signal(str)
+    transcriptionFailed = Signal(str)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self._agent = None
@@ -327,6 +345,14 @@ class AgentBackend(QObject):
         self._current_text = ""
         self._current_tool_calls = []
         self._had_error = False
+        self._voice_state = "idle"
+        self._audio_source = None
+        self._audio_buffer = None
+        self._audio_io = None
+        self._audio_sample_rate = 16000
+        self._audio_channels = 1
+        self._audio_sample_width = 2
+        self._voice_max_timer = None
         # 从全局 config.json 读取供应商和模型设置
         self._current_provider, self._current_model = self._load_global_ai_settings()
 
@@ -387,6 +413,15 @@ class AgentBackend(QObject):
     @Property(bool, notify=busyChanged)
     def busy(self):
         return self._busy
+
+    @Property(str, notify=voiceStateChanged)
+    def voiceState(self):
+        return self._voice_state
+
+    def _set_voice_state(self, state: str):
+        if self._voice_state != state:
+            self._voice_state = state
+            self.voiceStateChanged.emit(state)
 
     @Property(str, notify=roleChanged)
     def agentRole(self):
@@ -819,8 +854,32 @@ class AgentBackend(QObject):
         except Exception as e:
             log.warning(f"保存项目设置失败: {e}")
 
+    def _resolve_auth(self, provider: dict):
+        """返回 Authorization 头；失败 emit 错误并返回 None。无需认证返回 ''。"""
+        if not provider.get("needs_auth", False):
+            log.info("[Agent] 无需认证（内置供应商）")
+            return ""
+        api_key = provider.get("api_key", "")
+        if not api_key:
+            if self._current_provider == "bloret_passport":
+                auth_header = _build_bloret_passport_auth()
+                if not auth_header:
+                    log.error("[Agent] Bloret PassPort API Key 未配置")
+                    self.errorOccurred.emit(i18nText("请先在 Bloret PassPort 的 /ai 页面创建 API Key，并在设置中配置"))
+                    return None
+                log.info("[Agent] 使用 Bloret PassPort API Key 认证")
+                return auth_header
+            log.error(f"[Agent] 供应商 {provider.get('name', '')} 需要 API 密钥但未提供")
+            self.errorOccurred.emit(
+                i18nText("供应商 {v0} 需要 API 密钥").replace("{v0}", str(provider.get("name", "")))
+            )
+            return None
+        log.info("[Agent] 使用 API 密钥认证")
+        return f"Bearer {api_key}"
+
     @Slot(str)
-    def sendMessage(self, text):
+    @Slot(str, str)
+    def sendMessage(self, text, images_json="[]"):
         log.info(f"[Agent] sendMessage 调用, busy={self._busy}, pack_path='{self._pack_path}', history_len={len(self._history)}")
         print(f"[Agent DEBUG] sendMessage 调用, busy={self._busy}, pack_path='{self._pack_path}', history_len={len(self._history)}")
         if self._busy:
@@ -830,6 +889,45 @@ class AgentBackend(QObject):
         if not self._pack_path:
             log.error("[Agent] sendMessage 被拒绝: 未设置资源包路径")
             self.errorOccurred.emit(i18nText("请先打开一个资源包"))
+            return
+
+        text = (text or "").strip()
+        try:
+            image_paths = json.loads(images_json) if images_json else []
+            if not isinstance(image_paths, list):
+                image_paths = []
+        except Exception:
+            image_paths = []
+
+        valid_paths = []
+        for p in image_paths:
+            if not isinstance(p, str):
+                continue
+            path = p
+            if path.startswith("file://"):
+                path = path[7:]
+                if os.name == "nt" and path.startswith("/") and len(path) > 2 and path[2] == ":":
+                    path = path[1:]
+            if os.path.isfile(path):
+                valid_paths.append(path)
+        if len(valid_paths) > _MAX_IMAGE_COUNT:
+            self.errorOccurred.emit(i18nText("最多只能附加 {v0} 张图片").replace("{v0}", str(_MAX_IMAGE_COUNT)))
+            return
+        for path in valid_paths:
+            try:
+                if os.path.getsize(path) > _MAX_IMAGE_FILE_BYTES:
+                    self.errorOccurred.emit(
+                        i18nText("图片过大（超过 5MB）: {v0}").replace("{v0}", os.path.basename(path))
+                    )
+                    return
+            except OSError:
+                self.errorOccurred.emit(
+                    i18nText("无法读取图片: {v0}").replace("{v0}", os.path.basename(path))
+                )
+                return
+
+        if not text and not valid_paths:
+            log.warning("[Agent] sendMessage 被拒绝: 空消息")
             return
 
         # 获取 API 配置
@@ -849,32 +947,16 @@ class AgentBackend(QObject):
             self.errorOccurred.emit(i18nText("供应商配置不完整"))
             return
 
-        # 认证
-        auth_header = ""
-        if provider.get("needs_auth", False):
-            api_key = provider.get("api_key", "")
-            if not api_key:
-                # 内置 Bloret PassPort：从 config.json 自动构建 OAuth 三段式 Token
-                if self._current_provider == "bloret_passport":
-                    auth_header = _build_bloret_passport_auth()
-                    if not auth_header:
-                        log.error("[Agent] Bloret PassPort API Key 未配置")
-                        self.errorOccurred.emit(i18nText("请先在 Bloret PassPort 的 /ai 页面创建 API Key，并在设置中配置"))
-                        return
-                    log.info("[Agent] 使用 Bloret PassPort API Key 认证")
-                else:
-                    log.error(f"[Agent] 供应商 {provider.get('name', '')} 需要 API 密钥但未提供")
-                    self.errorOccurred.emit(
-                        i18nText("供应商 {v0} 需要 API 密钥").replace(
-                            "{v0}", str(provider.get("name", ""))
-                        )
-                    )
-                    return
-            else:
-                auth_header = f"Bearer {api_key}"
-                log.info("[Agent] 使用 API 密钥认证")
-        else:
-            log.info("[Agent] 无需认证（内置供应商）")
+        auth_header = self._resolve_auth(provider)
+        if auth_header is None:
+            return
+
+        user_content = _build_user_content(text, valid_paths)
+        if not user_content:
+            self.errorOccurred.emit(i18nText("无法处理图片附件"))
+            return
+
+        title_source = text or _content_text_preview(user_content) or i18nText("图片消息")
 
         # 第一条消息时自动生成对话标题（后台线程，不阻塞主线程）
         if not self._title and len(self._history) == 0:
@@ -883,19 +965,24 @@ class AgentBackend(QObject):
             def _gen_title():
                 try:
                     from .agent_loop import generate_title
-                    title = generate_title(api_url, auth_header, text, model)
+                    title = generate_title(api_url, auth_header, title_source, model)
                     self._title = title
                     log.info(f"[Agent] 对话标题生成成功: '{title}'")
                     self.titleChanged.emit(title)
                 except Exception as e:
                     log.warning(f"[Agent] 标题生成失败: {e}，使用截断消息作为标题")
-                    self._title = text[:15]
+                    self._title = title_source[:15]
                     self.titleChanged.emit(self._title)
 
             threading.Thread(target=_gen_title, daemon=True).start()
 
-        log.info(f"[Agent] 启动 Agent, 消息: '{text[:50]}...'") if len(text) > 50 else log.info(f"[Agent] 启动 Agent, 消息: '{text}'")
-        self._history.append({"role": "user", "content": text})
+        preview = title_source[:50]
+        log.info(f"[Agent] 启动 Agent, 消息: '{preview}...', images={len(valid_paths)}")
+        self._history.append({
+            "role": "user",
+            "content": user_content,
+            "image_paths": valid_paths,
+        })
         # 注意：不在这里 emit messageAdded，因为 QML sendBtn 已经 append 了用户消息
         self._current_text = ""
         self._current_tool_calls = []
@@ -907,7 +994,7 @@ class AgentBackend(QObject):
             pack_path=self._pack_path,
             api_url=api_url,
             auth_header=auth_header,
-            user_message=text,
+            user_message=user_content,
             history=self._history[:-1],
             on_text_chunk=self._on_text_chunk,
             on_tool_call_start=self._on_tool_call_start,
@@ -920,6 +1007,192 @@ class AgentBackend(QObject):
             role=self._agent_role,
         )
         log.info("[Agent] Agent 线程已启动")
+
+    # ========== 语音 STT ==========
+
+    @Slot()
+    def startVoiceCapture(self):
+        if self._voice_state != "idle":
+            return
+        try:
+            from PySide6.QtMultimedia import QAudioFormat, QAudioSource, QMediaDevices
+        except Exception as e:
+            self.transcriptionFailed.emit(i18nText("语音模块不可用: {v0}").replace("{v0}", str(e)))
+            return
+
+        device = QMediaDevices.defaultAudioInput()
+        if device.isNull():
+            self.transcriptionFailed.emit(i18nText("未检测到麦克风设备"))
+            return
+
+        fmt = QAudioFormat()
+        fmt.setSampleRate(16000)
+        fmt.setChannelCount(1)
+        fmt.setSampleFormat(QAudioFormat.SampleFormat.Int16)
+        if not device.isFormatSupported(fmt):
+            fmt = device.preferredFormat()
+
+        try:
+            self._audio_buffer = QByteArray()
+            self._audio_io = QBuffer(self._audio_buffer)
+            self._audio_io.open(QIODevice.OpenModeFlag.WriteOnly)
+            self._audio_source = QAudioSource(device, fmt, self)
+            self._audio_sample_rate = fmt.sampleRate() or 16000
+            self._audio_channels = fmt.channelCount() or 1
+            self._audio_sample_width = 2
+            if fmt.sampleFormat() == QAudioFormat.SampleFormat.UInt8:
+                self._audio_sample_width = 1
+            elif fmt.sampleFormat() == QAudioFormat.SampleFormat.Int16:
+                self._audio_sample_width = 2
+            elif fmt.sampleFormat() in (
+                QAudioFormat.SampleFormat.Int32,
+                QAudioFormat.SampleFormat.Float,
+            ):
+                self._audio_sample_width = 4
+            self._audio_source.start(self._audio_io)
+            self._set_voice_state("recording")
+            if self._voice_max_timer is None:
+                self._voice_max_timer = QTimer(self)
+                self._voice_max_timer.setSingleShot(True)
+                self._voice_max_timer.timeout.connect(self.stopVoiceCaptureAndTranscribe)
+            self._voice_max_timer.start(_MAX_VOICE_SECONDS * 1000)
+        except Exception as e:
+            log.error(f"[Agent] 启动录音失败: {e}", exc_info=True)
+            self._cleanup_audio_capture()
+            self.transcriptionFailed.emit(i18nText("无法开始录音: {v0}").replace("{v0}", str(e)))
+
+    @Slot()
+    def stopVoiceCaptureAndTranscribe(self):
+        if self._voice_state != "recording":
+            return
+        if self._voice_max_timer and self._voice_max_timer.isActive():
+            self._voice_max_timer.stop()
+
+        pcm = b""
+        sample_rate = self._audio_sample_rate
+        channels = self._audio_channels
+        sample_width = self._audio_sample_width
+        try:
+            if self._audio_source:
+                self._audio_source.stop()
+            if self._audio_io:
+                self._audio_io.close()
+            if self._audio_buffer is not None:
+                pcm = bytes(self._audio_buffer.data())
+        except Exception as e:
+            log.warning(f"[Agent] 停止录音时出错: {e}")
+        finally:
+            self._cleanup_audio_capture(keep_state=True)
+
+        if len(pcm) < sample_rate * sample_width * channels * 0.2:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit(i18nText("录音太短，请重试"))
+            return
+
+        try:
+            if sample_width in (1, 2):
+                wav_bytes = _pcm_to_wav_bytes(pcm, sample_rate=sample_rate, channels=channels, sample_width=sample_width)
+            else:
+                ints = array.array("i")
+                ints.frombytes(pcm[: len(pcm) - (len(pcm) % 4)])
+                scaled = array.array("h", (max(-32768, min(32767, v >> 16)) for v in ints))
+                wav_bytes = _pcm_to_wav_bytes(scaled.tobytes(), sample_rate=sample_rate, channels=channels, sample_width=2)
+        except Exception as e:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit(i18nText("音频编码失败: {v0}").replace("{v0}", str(e)))
+            return
+
+        self._set_voice_state("transcribing")
+        provider = BUILTIN_PROVIDERS.get(self._current_provider) or self._custom_providers.get(self._current_provider)
+        api_url = (provider or {}).get("api", "")
+        stt_url = _transcriptions_url_from_chat_api(api_url)
+        if not stt_url:
+            self._set_voice_state("idle")
+            self.transcriptionFailed.emit(i18nText("当前供应商不支持语音识别（无法推导 transcriptions 地址）"))
+            return
+        auth_header = ""
+        if provider:
+            auth_header = self._resolve_auth(provider)
+            if auth_header is None:
+                self._set_voice_state("idle")
+                return
+
+        def _worker():
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(suffix=".wav", prefix="rpe_stt_")
+                os.write(fd, wav_bytes)
+                os.close(fd)
+                headers = {}
+                if auth_header:
+                    headers["Authorization"] = auth_header
+                with open(tmp_path, "rb") as f:
+                    files = {"file": ("audio.wav", f, "audio/wav")}
+                    data = {"model": "whisper-1"}
+                    resp = requests.post(stt_url, headers=headers, files=files, data=data, timeout=60)
+                if resp.status_code >= 400:
+                    msg = (
+                        i18nText("当前供应商不支持语音识别，请配置支持 Whisper 的供应商")
+                        if resp.status_code in (404, 405, 501)
+                        else i18nText("语音识别失败 (HTTP {v0})").replace("{v0}", str(resp.status_code))
+                    )
+                    self.transcriptionFailed.emit(msg)
+                    return
+                try:
+                    payload = resp.json()
+                    out = (payload.get("text") or "").strip()
+                except Exception:
+                    out = (resp.text or "").strip()
+                if not out:
+                    self.transcriptionFailed.emit(i18nText("未识别到有效语音"))
+                    return
+                self.transcriptionReady.emit(out)
+            except Exception as e:
+                log.error(f"[Agent] STT 失败: {e}", exc_info=True)
+                self.transcriptionFailed.emit(i18nText("语音识别失败: {v0}").replace("{v0}", str(e)))
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
+                self._set_voice_state("idle")
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    @Slot()
+    def cancelVoiceCapture(self):
+        if self._voice_max_timer and self._voice_max_timer.isActive():
+            self._voice_max_timer.stop()
+        if self._voice_state == "recording":
+            try:
+                if self._audio_source:
+                    self._audio_source.stop()
+            except Exception:
+                pass
+            self._cleanup_audio_capture()
+            self._set_voice_state("idle")
+
+    def _cleanup_audio_capture(self, keep_state: bool = False):
+        try:
+            if self._audio_source:
+                try:
+                    self._audio_source.stop()
+                except Exception:
+                    pass
+                self._audio_source.deleteLater()
+        except Exception:
+            pass
+        self._audio_source = None
+        try:
+            if self._audio_io:
+                self._audio_io.close()
+        except Exception:
+            pass
+        self._audio_io = None
+        self._audio_buffer = None
+        if not keep_state and self._voice_state == "recording":
+            self._set_voice_state("idle")
 
     @Slot()
     def cancelAgent(self):
@@ -1119,26 +1392,49 @@ class AgentBackend(QObject):
         for msg in self._history:
             role = msg.get("role", "")
             if role == "user":
+                content = msg.get("content", "")
+                text = _content_text_preview(content)
+                image_paths = [p for p in (msg.get("image_paths") or []) if p]
                 messages.append({
                     "role": "user",
-                    "content": msg.get("content", ""),
+                    "content": text,
+                    "images": image_paths,
+                    "imagesJson": json.dumps(image_paths, ensure_ascii=False),
                     "toolName": "", "toolArgs": "", "toolResult": "",
                 })
             elif role == "assistant":
+                content = msg.get("content", "")
                 messages.append({
                     "role": "assistant",
-                    "content": msg.get("content", ""),
+                    "content": content if isinstance(content, str) else _content_text_preview(content),
+                    "images": [],
+                    "imagesJson": "[]",
                     "toolName": "", "toolArgs": "", "toolResult": "",
                 })
             elif role == "tool_call":
                 messages.append({
                     "role": "tool_call",
                     "content": "",
+                    "images": [],
+                    "imagesJson": "[]",
                     "toolName": msg.get("toolName", ""),
                     "toolArgs": msg.get("toolArgs", ""),
                     "toolResult": msg.get("toolResult", ""),
                 })
         return json.dumps(messages, ensure_ascii=False)
+
+    @Slot(result=str)
+    def getCurrentModelName(self):
+        try:
+            models = json.loads(self.getModels())
+            for m in models:
+                if m.get("id") == self._current_model:
+                    return m.get("name") or m.get("id") or ""
+            if models:
+                return models[0].get("name") or models[0].get("id") or ""
+        except Exception:
+            pass
+        return self._current_model or ""
 
     # ========== 内部回调 ==========
 

--- a/modules/resourcepack_editor/agent_loop.py
+++ b/modules/resourcepack_editor/agent_loop.py
@@ -217,8 +217,51 @@ class AgentLoop:
     def cancel(self):
         self._cancelled = True
 
-    def run(self, user_message: str, history: list = None):
-        log.info(f"[AgentLoop] run 开始, 模型={self.model}, 角色={self.role}, 消息='{user_message[:50]}...'" if len(user_message) > 50 else f"[AgentLoop] run 开始, 模型={self.model}, 角色={self.role}, 消息='{user_message}'")
+    @staticmethod
+    def _content_to_text(content) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        parts.append(str(part.get("text", "")))
+                    elif part.get("type") == "image_url":
+                        parts.append("[图片]")
+                elif isinstance(part, str):
+                    parts.append(part)
+            return "\n".join(p for p in parts if p)
+        return str(content)
+
+    @staticmethod
+    def _content_for_token_estimate(content) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        parts.append(str(part.get("text", "")))
+                    elif part.get("type") == "image_url":
+                        parts.append("[image~1000tokens]")
+                elif isinstance(part, str):
+                    parts.append(part)
+            return "\n".join(parts)
+        return str(content)
+
+    def run(self, user_message, history: list = None):
+        preview = self._content_to_text(user_message)
+        log.info(
+            f"[AgentLoop] run 开始, 模型={self.model}, 角色={self.role}, 消息='{preview[:50]}...'"
+            if len(preview) > 50
+            else f"[AgentLoop] run 开始, 模型={self.model}, 角色={self.role}, 消息='{preview}'"
+        )
         print(f"[AgentLoop DEBUG] run 开始, 模型={self.model}, url={self.api_url}")
         try:
             self._run_internal(user_message, history)
@@ -342,8 +385,20 @@ class AgentLoop:
 
     @staticmethod
     def _estimate_tokens(messages: list) -> int:
-        """粗略估算消息列表的 token 数量"""
-        return len(str(messages)) // 4
+        """粗略估算消息列表的 token 数量（忽略 base64 图片）"""
+        total = 0
+        for msg in messages:
+            content = msg.get("content", "")
+            total += len(AgentLoop._content_for_token_estimate(content))
+            if msg.get("tool_calls"):
+                total += len(str(msg.get("tool_calls")))
+            if msg.get("toolName"):
+                total += (
+                    len(str(msg.get("toolName", "")))
+                    + len(str(msg.get("toolArgs", "")))
+                    + len(str(msg.get("toolResult", "")))
+                )
+        return total // 4
 
     def _compact_messages(self, messages: list) -> list:
         """压缩旧的工具结果以减少上下文大小
@@ -379,15 +434,30 @@ class AgentLoop:
                     result.append(msg)  # 保留
                 else:
                     # 压缩旧的工具结果
-                    original_len = len(msg.get("content", ""))
+                    content = msg.get("content", "")
+                    original_len = len(content) if isinstance(content, str) else len(str(content))
                     compacted = dict(msg)
                     compacted["content"] = f"[结果已压缩: 原始长度 {original_len} 字符]"
                     result.append(compacted)
             elif role == "assistant":
                 content = msg.get("content", "")
-                if len(content) > 2000:
+                if isinstance(content, str) and len(content) > 2000:
                     compacted = dict(msg)
                     compacted["content"] = content[:500] + "...[已压缩]"
+                    result.append(compacted)
+                else:
+                    result.append(msg)
+            elif role == "user":
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    compacted = dict(msg)
+                    new_parts = []
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "image_url":
+                            new_parts.append({"type": "text", "text": "[图片已压缩]"})
+                        else:
+                            new_parts.append(part)
+                    compacted["content"] = new_parts
                     result.append(compacted)
                 else:
                     result.append(msg)
@@ -556,14 +626,20 @@ class AgentLoop:
                     "tool_call_id": tc_id,
                     "content": tool_result
                 })
+            elif role in ("user", "assistant", "system"):
+                entry = {"role": role, "content": msg.get("content", "")}
+                if msg.get("tool_calls"):
+                    entry["tool_calls"] = msg["tool_calls"]
+                if msg.get("name"):
+                    entry["name"] = msg["name"]
+                result.append(entry)
             else:
-                # user / assistant 消息直接保留
-                result.append(msg)
+                result.append({"role": role or "user", "content": msg.get("content", "")})
 
         return result
 
-    def _run_internal(self, user_message: str, history: list = None):
-        """内部执行逻辑"""
+    def _run_internal(self, user_message, history: list = None):
+        """内部执行逻辑；user_message 可为 str 或 OpenAI 多模态 content list"""
         log.info("[AgentLoop] 构建系统提示词...")
         system_prompt = self._build_system_prompt()
         log.info(f"[AgentLoop] 系统提示词长度: {len(system_prompt)} 字符")
@@ -575,7 +651,8 @@ class AgentLoop:
             log.info(f"[AgentLoop] 历史消息数: {len(history)} (转换后 {len(converted)} 条)")
 
         messages.append({"role": "user", "content": user_message})
-        log.info(f"[AgentLoop] 总消息数: {len(messages)} (含系统提示)")
+        preview = self._content_to_text(user_message)[:80]
+        log.info(f"[AgentLoop] 总消息数: {len(messages)} (含系统提示), user_preview='{preview}'")
 
         for iteration in range(MAX_ITERATIONS):
             if self._cancelled:
@@ -984,7 +1061,7 @@ def run_agent_async(
     pack_path: str,
     api_url: str,
     auth_header: str,
-    user_message: str,
+    user_message,
     history: list = None,
     on_text_chunk: Optional[Callable[[str], None]] = None,
     on_tool_call_start: Optional[Callable[[str, str], None]] = None,
@@ -1021,8 +1098,10 @@ def run_agent_async(
     return agent
 
 
-def generate_title(api_url: str, auth_header: str, user_message: str, model: str = "Bloriko") -> str:
+def generate_title(api_url: str, auth_header: str, user_message, model: str = "Bloriko") -> str:
     """生成简短的对话标题（同步调用，单次 LLM 请求）"""
+    if not isinstance(user_message, str):
+        user_message = AgentLoop._content_to_text(user_message)
     log.info(f"[Title] 开始生成标题, model='{model}', url='{api_url}'")
     headers = {"Content-Type": "application/json"}
     if auth_header:

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -21,6 +21,15 @@ Item {
     property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
     property string voiceState: "idle"
     property int maxPendingImages: 4
+    // 仅在首段文字/工具输出出现前显示「正在思考」
+    property bool awaitingFirstToken: false
+
+    function beginAwaitingReply() { awaitingFirstToken = true }
+    function endAwaitingReply() { awaitingFirstToken = false }
+    function markReplyStarted() {
+        if (awaitingFirstToken)
+            awaitingFirstToken = false
+    }
 
     function loadProviders() {
         providerModel.clear()
@@ -124,6 +133,7 @@ Item {
             role: "user", content: text, imagesJson: imagesJson,
             toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false
         })
+        beginAwaitingReply()
         Agent.sendMessage(text, imagesJson)
         inputField.text = ""
         clearPendingImages()
@@ -270,6 +280,7 @@ Item {
                             font.pixelSize: 14
                             onClicked: {
                                 messageModel.clear()
+                                endAwaitingReply()
                                 if (Agent) Agent.clearHistory()
                             }
                         }
@@ -408,7 +419,7 @@ Item {
                             anchors.left: parent.left
                             anchors.verticalCenter: parent.verticalCenter
                             width: implicitWidth
-                            active: Agent && Agent.busy
+                            active: agentPage.awaitingFirstToken
                             orbSize: 18
                             orbSpeed: 1.1
                             orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
@@ -425,7 +436,7 @@ Item {
                             text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
                             color: Theme.currentTheme.colors.textSecondaryColor
-                            opacity: (Agent && Agent.busy) ? 0 : 1
+                            opacity: agentPage.awaitingFirstToken ? 0 : 1
                             visible: opacity > 0.01
                             Behavior on opacity {
                                 NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
@@ -453,7 +464,11 @@ Item {
                         flat: true
                         font.pixelSize: 11
                         enabled: Agent && !Agent.busy
-                        onClicked: { messageModel.clear(); if (Agent) Agent.clearHistory() }
+                        onClicked: {
+                            messageModel.clear()
+                            endAwaitingReply()
+                            if (Agent) Agent.clearHistory()
+                        }
                     }
                 }
 
@@ -488,7 +503,7 @@ Item {
                         anchors.leftMargin: 16
                         anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        active: Agent && Agent.busy
+                        active: agentPage.awaitingFirstToken
                         orbSize: 22
                         showAvatar: true
                         avatarSource: Qt.resolvedUrl("../../../icon/Bloriko.jpg")
@@ -500,7 +515,7 @@ Item {
                         target: Agent
                         enabled: Agent !== null
                         function onBusyChanged() {
-                            if (Agent && Agent.busy)
+                            if (Agent && Agent.busy && agentPage.awaitingFirstToken)
                                 Qt.callLater(function() { msgView.positionViewAtEnd() })
                         }
                     }
@@ -510,7 +525,7 @@ Item {
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0 && !(Agent && Agent.busy)
+                    visible: messageModel.count === 0 && !agentPage.awaitingFirstToken
 
                     ColumnLayout {
                         id: emptyCol
@@ -639,7 +654,7 @@ Item {
 
                         ThinkingStatus {
                             Layout.fillWidth: true
-                            active: streaming && (!content || content.length === 0)
+                            active: agentPage.awaitingFirstToken && streaming && (!content || content.length === 0)
                             orbSize: 20
                             orbSpeed: 1.1
                             showAvatar: false
@@ -649,7 +664,7 @@ Item {
 
                         Text {
                             Layout.fillWidth: true
-                            opacity: (streaming && (!content || content.length === 0)) ? 0 : 1
+                            opacity: (agentPage.awaitingFirstToken && streaming && (!content || content.length === 0)) ? 0 : 1
                             visible: opacity > 0.01 || (content && content.length > 0)
                             text: content || ""
                             font.pixelSize: 13
@@ -1535,11 +1550,19 @@ Item {
         }
 
         function onBusyChanged() {
-            if (Agent && Agent.busy)
+            if (!Agent) return
+            if (Agent.busy) {
+                if (!awaitingFirstToken)
+                    beginAwaitingReply()
                 Qt.callLater(function() { msgView.positionViewAtEnd() })
+            } else {
+                endAwaitingReply()
+            }
         }
 
         function onTextUpdated(text) {
+            if (text && String(text).length > 0)
+                markReplyStarted()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
                 messageModel.set(lastIdx, {role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true})
@@ -1551,6 +1574,7 @@ Item {
 
         function onToolCallStarted(toolName, argsJson) {
             console.log("[AgentTab] onToolCallStarted: " + toolName)
+            markReplyStarted()
             // 找到最后一个 tool_call 之后的位置（连续的 tool_calls 应该在一起）
             var insertIdx = messageModel.count
             for (var i = messageModel.count - 1; i >= 0; i--) {
@@ -1582,10 +1606,12 @@ Item {
         }
 
         function onErrorOccurred(msg) {
+            endAwaitingReply()
             messageModel.append({role: "error", content: msg, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
+            markReplyStarted()
             // 找到流式 assistant 消息并终结
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -399,27 +399,38 @@ Item {
                         visible: conversationTitle.length > 0
                     }
 
-                    RowLayout {
-                        spacing: 6
-                        visible: Agent && Agent.busy
-                        ThinkingOrb {
-                            size: 18
-                            running: visible
-                            state: "composing"
-                            speed: 1.1
-                            ink: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                    Item {
+                        Layout.preferredWidth: Math.max(agentTopThinking.implicitWidth, agentReadyLabel.implicitWidth)
+                        Layout.preferredHeight: Math.max(agentTopThinking.implicitHeight, agentReadyLabel.implicitHeight)
+
+                        ThinkingStatus {
+                            id: agentTopThinking
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: implicitWidth
+                            active: Agent && Agent.busy
+                            orbSize: 18
+                            orbSpeed: 1.1
+                            orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                            labelColor: Theme.accentColor || "#0078D4"
+                            labelPixelSize: 11
+                            showAvatar: false
+                            showPulseDots: false
+                            fadeMs: 280
                         }
                         Text {
-                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            id: agentReadyLabel
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
-                            color: Theme.accentColor || "#0078D4"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            opacity: (Agent && Agent.busy) ? 0 : 1
+                            visible: opacity > 0.01
+                            Behavior on opacity {
+                                NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
+                            }
                         }
-                    }
-                    Text {
-                        visible: !(Agent && Agent.busy)
-                        text: Backend ? Backend.tr("就绪") : "就绪"
-                        font.pixelSize: 11
-                        color: Theme.currentTheme.colors.textSecondaryColor
                     }
 
                     ComboBox {
@@ -462,64 +473,27 @@ Item {
 
                 footer: Item {
                     width: msgView.width
-                    height: agentThinkingFooter.visible ? agentThinkingFooter.height + 12 : 0
-                    visible: Agent && Agent.busy
+                    height: agentThinkingStatus.active || agentThinkingStatus.opacity > 0.01
+                            ? agentThinkingStatus.implicitHeight + 16
+                            : 0
+                    Behavior on height {
+                        NumberAnimation { duration: 320; easing.type: Easing.InOutQuad }
+                    }
 
-                    RowLayout {
-                        id: agentThinkingFooter
+                    ThinkingStatus {
+                        id: agentThinkingStatus
                         anchors.left: parent.left
-                        anchors.leftMargin: 16
                         anchors.right: parent.right
-                        anchors.rightMargin: 16
                         anchors.top: parent.top
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        spacing: 10
-
-                        Rectangle {
-                            width: 22; height: 22; radius: 11; clip: true; color: "transparent"
-                            Layout.alignment: Qt.AlignVCenter
-                            Image {
-                                anchors.fill: parent
-                                source: Qt.resolvedUrl("../../../icon/Bloriko.jpg")
-                                fillMode: Image.PreserveAspectCrop
-                                mipmap: true
-                            }
-                        }
-                        ThinkingOrb {
-                            size: 22
-                            running: agentThinkingFooter.visible
-                            state: "composing"
-                            speed: 1.15
-                            ink: Theme.currentTheme.colors.textColor
-                            Layout.alignment: Qt.AlignVCenter
-                        }
-                        Text {
-                            text: Backend ? Backend.tr("正在思考") : "正在思考"
-                            font.pixelSize: 13
-                            color: Theme.currentTheme.colors.textSecondaryColor
-                            Layout.alignment: Qt.AlignVCenter
-                        }
-                        Row {
-                            spacing: 3
-                            Layout.alignment: Qt.AlignVCenter
-                            Repeater {
-                                model: 3
-                                Rectangle {
-                                    width: 4; height: 4; radius: 2
-                                    color: Theme.currentTheme.colors.textSecondaryColor
-                                    opacity: 0.35
-                                    SequentialAnimation on opacity {
-                                        loops: Animation.Infinite
-                                        running: agentThinkingFooter.visible
-                                        PauseAnimation { duration: index * 160 }
-                                        NumberAnimation { to: 1.0; duration: 320; easing.type: Easing.InOutQuad }
-                                        NumberAnimation { to: 0.35; duration: 320; easing.type: Easing.InOutQuad }
-                                        PauseAnimation { duration: (2 - index) * 160 }
-                                    }
-                                }
-                            }
-                        }
-                        Item { Layout.fillWidth: true }
+                        active: Agent && Agent.busy
+                        orbSize: 22
+                        showAvatar: true
+                        avatarSource: Qt.resolvedUrl("../../../icon/Bloriko.jpg")
+                        showPulseDots: true
+                        fadeMs: 320
                     }
 
                     Connections {
@@ -663,36 +637,29 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
-                        RowLayout {
+                        ThinkingStatus {
                             Layout.fillWidth: true
-                            spacing: 8
-                            visible: streaming && (!content || content.length === 0)
-                            ThinkingOrb {
-                                size: 20
-                                running: visible
-                                state: "composing"
-                                speed: 1.1
-                                ink: Theme.currentTheme.colors.textColor
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                            Text {
-                                text: Backend ? Backend.tr("正在思考") : "正在思考"
-                                font.pixelSize: 13
-                                color: Theme.currentTheme.colors.textSecondaryColor
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                            Item { Layout.fillWidth: true }
+                            active: streaming && (!content || content.length === 0)
+                            orbSize: 20
+                            orbSpeed: 1.1
+                            showAvatar: false
+                            showPulseDots: true
+                            fadeMs: 280
                         }
 
                         Text {
                             Layout.fillWidth: true
-                            visible: !(streaming && (!content || content.length === 0))
+                            opacity: (streaming && (!content || content.length === 0)) ? 0 : 1
+                            visible: opacity > 0.01 || (content && content.length > 0)
                             text: content || ""
                             font.pixelSize: 13
                             color: Theme.currentTheme.colors.textColor
                             wrapMode: Text.Wrap
                             textFormat: Text.MarkdownText
                             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
+                            Behavior on opacity {
+                                NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
+                            }
                         }
                     }
 

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -22,15 +22,36 @@ Item {
     property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
     property string voiceState: "idle"
     property int maxPendingImages: 4
-    // 仅在首段文字/工具输出出现前显示「正在思考」
-    property bool awaitingFirstToken: false
-
-    function beginAwaitingReply() { awaitingFirstToken = true }
-    function endAwaitingReply() { awaitingFirstToken = false }
-    function markReplyStarted() {
-        if (awaitingFirstToken)
-            awaitingFirstToken = false
+    // Agent 活动阶段：idle | thinking | replying | working
+    property string agentPhase: "idle"
+    readonly property bool agentActive: agentPhase !== "idle"
+    readonly property bool awaitingFirstToken: agentPhase === "thinking"
+    readonly property string agentPhaseLabel: {
+        if (agentPhase === "thinking")
+            return Backend ? Backend.tr("正在思考") : "正在思考"
+        if (agentPhase === "replying")
+            return Backend ? Backend.tr("正在回复") : "正在回复"
+        if (agentPhase === "working")
+            return Backend ? Backend.tr("正在工作") : "正在工作"
+        return ""
     }
+    readonly property string agentPhaseOrbState: {
+        if (agentPhase === "working")
+            return "working"
+        return "composing"
+    }
+
+    function beginAwaitingReply() { agentPhase = "thinking" }
+    function endAwaitingReply() { agentPhase = "idle" }
+    function markReplying() {
+        if (agentPhase === "idle") return
+        agentPhase = "replying"
+    }
+    function markWorking() {
+        if (agentPhase === "idle") return
+        agentPhase = "working"
+    }
+    function markReplyStarted() { markReplying() }
 
     function loadProviders() {
         providerModel.clear()
@@ -482,7 +503,9 @@ Item {
                             anchors.left: parent.left
                             anchors.verticalCenter: parent.verticalCenter
                             width: implicitWidth
-                            active: agentPage.awaitingFirstToken
+                            active: agentPage.agentActive
+                            label: agentPage.agentPhaseLabel
+                            orbState: agentPage.agentPhaseOrbState
                             orbSize: 18
                             orbSpeed: 1.1
                             orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
@@ -499,7 +522,7 @@ Item {
                             text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
                             color: Theme.currentTheme.colors.textSecondaryColor
-                            opacity: agentPage.awaitingFirstToken ? 0 : 1
+                            opacity: agentPage.agentActive ? 0 : 1
                             visible: opacity > 0.01
                             Behavior on opacity {
                                 NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
@@ -566,7 +589,9 @@ Item {
                         anchors.leftMargin: 16
                         anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        active: agentPage.awaitingFirstToken
+                        active: agentPage.agentActive
+                        label: agentPage.agentPhaseLabel
+                        orbState: agentPage.agentPhaseOrbState
                         orbSize: 22
                         showAvatar: true
                         avatarSource: Qt.resolvedUrl("../../../icon/Bloriko.jpg")
@@ -578,7 +603,7 @@ Item {
                         target: Agent
                         enabled: Agent !== null
                         function onBusyChanged() {
-                            if (Agent && Agent.busy && agentPage.awaitingFirstToken)
+                            if (Agent && Agent.busy && agentPage.agentActive)
                                 Qt.callLater(function() { msgView.positionViewAtEnd() })
                         }
                     }
@@ -588,7 +613,7 @@ Item {
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0 && !agentPage.awaitingFirstToken
+                    visible: messageModel.count === 0 && !agentPage.agentActive
 
                     ColumnLayout {
                         id: emptyCol
@@ -718,6 +743,8 @@ Item {
                         ThinkingStatus {
                             Layout.fillWidth: true
                             active: agentPage.awaitingFirstToken && streaming && (!content || content.length === 0)
+                            label: agentPage.agentPhaseLabel
+                            orbState: agentPage.agentPhaseOrbState
                             orbSize: 20
                             orbSpeed: 1.1
                             showAvatar: false
@@ -1591,7 +1618,7 @@ Item {
         function onBusyChanged() {
             if (!Agent) return
             if (Agent.busy) {
-                if (!awaitingFirstToken)
+                if (agentPhase === "idle")
                     beginAwaitingReply()
                 Qt.callLater(function() { msgView.positionViewAtEnd() })
             } else {
@@ -1601,7 +1628,7 @@ Item {
 
         function onTextUpdated(text) {
             if (text && String(text).length > 0)
-                markReplyStarted()
+                markReplying()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
                 messageModel.set(lastIdx, {
@@ -1621,13 +1648,15 @@ Item {
 
         function onToolCallStarted(toolName, argsJson) {
             console.log("[AgentTab] onToolCallStarted: " + toolName)
-            markReplyStarted()
+            markWorking()
             startToolInGroup(toolName, argsJson)
             Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallFinished(toolName, argsJson, result) {
             finishToolInGroup(toolName, argsJson, result)
+            if (Agent && Agent.busy && agentPhase === "working")
+                markReplying()
         }
 
         function onErrorOccurred(msg) {
@@ -1640,7 +1669,10 @@ Item {
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
-            markReplyStarted()
+            if (Agent && Agent.busy)
+                markReplying()
+            else
+                endAwaitingReply()
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {
                     messageModel.set(i, {

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -38,7 +38,9 @@ Item {
     readonly property string agentPhaseOrbState: {
         if (agentPhase === "working")
             return "working"
-        return "composing"
+        if (agentPhase === "replying")
+            return "composing"
+        return "composing"  // thinking
     }
 
     function beginAwaitingReply() { agentPhase = "thinking" }
@@ -52,6 +54,20 @@ Item {
         agentPhase = "working"
     }
     function markReplyStarted() { markReplying() }
+
+    function appendUserMessage(text, imagesJson) {
+        messageModel.append({
+            role: "user",
+            content: text || "",
+            imagesJson: imagesJson || "[]",
+            toolName: "",
+            toolArgs: "",
+            toolResult: "",
+            toolsJson: "[]",
+            streaming: false,
+            expanded: false
+        })
+    }
 
     function loadProviders() {
         providerModel.clear()
@@ -224,11 +240,7 @@ Item {
         var text = inputField.text.trim()
         var imagesJson = pendingImagesJson()
         if (text.length === 0 && pendingImagesModel.count === 0) return
-        messageModel.append({
-            role: "user", content: text, imagesJson: imagesJson,
-            toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
-            streaming: false, expanded: false
-        })
+        appendUserMessage(text, imagesJson)
         beginAwaitingReply()
         Agent.sendMessage(text, imagesJson)
         inputField.text = ""
@@ -1610,7 +1622,7 @@ Item {
                 role: "error",
                 content: msg || (Backend ? Backend.tr("语音识别失败") : "语音识别失败"),
                 imagesJson: "[]",
-                toolName: "", toolArgs: "", toolResult: "",
+                toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
                 streaming: false, expanded: false
             })
         }
@@ -1740,7 +1752,17 @@ Item {
         }
 
         function onStatusMessage(msg) {
-            messageModel.append({role: "system", content: msg, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
+            messageModel.append({
+                role: "system",
+                content: msg,
+                imagesJson: "[]",
+                toolName: "",
+                toolArgs: "",
+                toolResult: "",
+                toolsJson: "[]",
+                streaming: false,
+                expanded: false
+            })
         }
     }
 }

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
 import Qt.labs.platform 1.1 as Platform
 import RinUI
+import "../../components"
 
 Item {
     id: agentPage
@@ -398,12 +399,27 @@ Item {
                         visible: conversationTitle.length > 0
                     }
 
+                    RowLayout {
+                        spacing: 6
+                        visible: Agent && Agent.busy
+                        ThinkingOrb {
+                            size: 18
+                            running: visible
+                            state: "composing"
+                            speed: 1.1
+                            ink: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                        }
+                        Text {
+                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            font.pixelSize: 11
+                            color: Theme.accentColor || "#0078D4"
+                        }
+                    }
                     Text {
-                        text: Agent && Agent.busy
-                            ? (Backend ? Backend.tr("思考中...") : "思考中...")
-                            : (Backend ? Backend.tr("就绪") : "就绪")
+                        visible: !(Agent && Agent.busy)
+                        text: Backend ? Backend.tr("就绪") : "就绪"
                         font.pixelSize: 11
-                        color: Agent && Agent.busy ? (Theme.accentColor || "#0078D4") : Theme.currentTheme.colors.textSecondaryColor
+                        color: Theme.currentTheme.colors.textSecondaryColor
                     }
 
                     ComboBox {
@@ -444,11 +460,83 @@ Item {
 
                 onCountChanged: Qt.callLater(function() { msgView.positionViewAtEnd() })
 
+                footer: Item {
+                    width: msgView.width
+                    height: agentThinkingFooter.visible ? agentThinkingFooter.height + 12 : 0
+                    visible: Agent && Agent.busy
+
+                    RowLayout {
+                        id: agentThinkingFooter
+                        anchors.left: parent.left
+                        anchors.leftMargin: 16
+                        anchors.right: parent.right
+                        anchors.rightMargin: 16
+                        anchors.top: parent.top
+                        anchors.topMargin: 8
+                        spacing: 10
+
+                        Rectangle {
+                            width: 22; height: 22; radius: 11; clip: true; color: "transparent"
+                            Layout.alignment: Qt.AlignVCenter
+                            Image {
+                                anchors.fill: parent
+                                source: Qt.resolvedUrl("../../../icon/Bloriko.jpg")
+                                fillMode: Image.PreserveAspectCrop
+                                mipmap: true
+                            }
+                        }
+                        ThinkingOrb {
+                            size: 22
+                            running: agentThinkingFooter.visible
+                            state: "composing"
+                            speed: 1.15
+                            ink: Theme.currentTheme.colors.textColor
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        Text {
+                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            font.pixelSize: 13
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        Row {
+                            spacing: 3
+                            Layout.alignment: Qt.AlignVCenter
+                            Repeater {
+                                model: 3
+                                Rectangle {
+                                    width: 4; height: 4; radius: 2
+                                    color: Theme.currentTheme.colors.textSecondaryColor
+                                    opacity: 0.35
+                                    SequentialAnimation on opacity {
+                                        loops: Animation.Infinite
+                                        running: agentThinkingFooter.visible
+                                        PauseAnimation { duration: index * 160 }
+                                        NumberAnimation { to: 1.0; duration: 320; easing.type: Easing.InOutQuad }
+                                        NumberAnimation { to: 0.35; duration: 320; easing.type: Easing.InOutQuad }
+                                        PauseAnimation { duration: (2 - index) * 160 }
+                                    }
+                                }
+                            }
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    Connections {
+                        target: Agent
+                        enabled: Agent !== null
+                        function onBusyChanged() {
+                            if (Agent && Agent.busy)
+                                Qt.callLater(function() { msgView.positionViewAtEnd() })
+                        }
+                    }
+                }
+
                 // 空状态
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0
+                    visible: messageModel.count === 0 && !(Agent && Agent.busy)
 
                     ColumnLayout {
                         id: emptyCol
@@ -575,9 +663,31 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            visible: streaming && (!content || content.length === 0)
+                            ThinkingOrb {
+                                size: 20
+                                running: visible
+                                state: "composing"
+                                speed: 1.1
+                                ink: Theme.currentTheme.colors.textColor
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            Text {
+                                text: Backend ? Backend.tr("正在思考") : "正在思考"
+                                font.pixelSize: 13
+                                color: Theme.currentTheme.colors.textSecondaryColor
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            Item { Layout.fillWidth: true }
+                        }
+
                         Text {
                             Layout.fillWidth: true
-                            text: content || "..."
+                            visible: !(streaming && (!content || content.length === 0))
+                            text: content || ""
                             font.pixelSize: 13
                             color: Theme.currentTheme.colors.textColor
                             wrapMode: Text.Wrap
@@ -1457,6 +1567,11 @@ Item {
             })
         }
 
+        function onBusyChanged() {
+            if (Agent && Agent.busy)
+                Qt.callLater(function() { msgView.positionViewAtEnd() })
+        }
+
         function onTextUpdated(text) {
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
@@ -1464,6 +1579,7 @@ Item {
             } else {
                 messageModel.append({role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true, expanded: false})
             }
+            Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallStarted(toolName, argsJson) {

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -1065,6 +1065,13 @@ Item {
                 id: modelComboDlg
                 Layout.fillWidth: true
                 model: modelModel; textRole: "name"
+                onActivated: function(index) {
+                    if (index < 0 || index >= modelModel.count) return
+                    var m = modelModel.get(index)
+                    Agent.setModel(m.id)
+                    modelCombo.currentIndex = index
+                    updateCurrentModelLabel()
+                }
             }
             RowLayout {
                 Layout.fillWidth: true
@@ -1080,16 +1087,30 @@ Item {
                     highlighted: true
                     Layout.fillWidth: true
                     onClicked: {
+                        // 先保存选中的模型 id，避免 loadModels clear 冲掉 ComboBox 索引
+                        var selectedModelId = ""
+                        var selectedModelIndex = modelComboDlg.currentIndex
+                        if (selectedModelIndex >= 0 && selectedModelIndex < modelModel.count)
+                            selectedModelId = modelModel.get(selectedModelIndex).id || ""
+
                         if (providerComboDlg.currentIndex >= 0 && providerComboDlg.currentIndex < providerModel.count) {
                             var p = providerModel.get(providerComboDlg.currentIndex)
                             Agent.setProvider(p.key)
                             providerCombo.currentIndex = providerComboDlg.currentIndex
                         }
+
+                        if (selectedModelId.length > 0)
+                            Agent.setModel(selectedModelId)
+
                         loadModels()
-                        if (modelComboDlg.currentIndex >= 0 && modelComboDlg.currentIndex < modelModel.count) {
-                            var m = modelModel.get(modelComboDlg.currentIndex)
-                            Agent.setModel(m.id)
-                            modelCombo.currentIndex = modelComboDlg.currentIndex
+                        if (selectedModelId.length > 0) {
+                            for (var i = 0; i < modelModel.count; i++) {
+                                if (modelModel.get(i).id === selectedModelId) {
+                                    modelCombo.currentIndex = i
+                                    modelComboDlg.currentIndex = i
+                                    break
+                                }
+                            }
                         }
                         updateCurrentModelLabel()
                         modelSelectDlg.close()

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
+import Qt.labs.platform 1.1 as Platform
 import RinUI
 
 Item {
@@ -12,9 +13,13 @@ Item {
     ListModel { id: modelModel }
     ListModel { id: roleModel }
     ListModel { id: historyListModel }
+    ListModel { id: pendingImagesModel }
 
     property bool historyPanelOpen: false
     property string conversationTitle: ""
+    property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
+    property string voiceState: "idle"
+    property int maxPendingImages: 4
 
     function loadProviders() {
         providerModel.clear()
@@ -44,19 +49,92 @@ Item {
             var models = JSON.parse(Agent.getModels())
             for (var i = 0; i < models.length; i++)
                 modelModel.append(models[i])
-            // 根据全局设置选中当前模型
+            var selected = false
             if (Backend) {
                 var globalModel = Backend.getGlobalAIModel()
                 for (var j = 0; j < modelModel.count; j++) {
                     if (modelModel.get(j).id === globalModel) {
-                        modelCombo.currentIndex = j
-                        return
+                        if (modelCombo) modelCombo.currentIndex = j
+                        selected = true
+                        break
                     }
                 }
             }
-            if (modelCombo.currentIndex < 0 && modelModel.count > 0)
-                modelCombo.currentIndex = 0
+            if (!selected && modelModel.count > 0) {
+                if (modelCombo) modelCombo.currentIndex = 0
+            }
+            updateCurrentModelLabel()
         } catch(e) {}
+    }
+
+    function updateCurrentModelLabel() {
+        if (modelModel.count > 0 && modelCombo && modelCombo.currentIndex >= 0 && modelCombo.currentIndex < modelModel.count) {
+            currentModelLabel = modelModel.get(modelCombo.currentIndex).name || modelModel.get(modelCombo.currentIndex).id || (Backend ? Backend.tr("选择模型") : "选择模型")
+            return
+        }
+        if (Agent && typeof Agent.getCurrentModelName === "function") {
+            var n = Agent.getCurrentModelName()
+            if (n && n.length > 0) { currentModelLabel = n; return }
+        }
+        currentModelLabel = Backend ? Backend.tr("选择模型") : "选择模型"
+    }
+
+    function pathFromFileUrl(url) {
+        var s = (url || "").toString()
+        if (s.indexOf("file://") === 0)
+            s = decodeURIComponent(s.substring(Qt.platform.os === "windows" ? 8 : 7))
+        return s
+    }
+
+    function fileUrlFromPath(path) {
+        if (!path) return ""
+        var s = path.toString()
+        if (s.indexOf("file://") === 0) return s
+        if (Qt.platform.os === "windows")
+            return "file:///" + s.replace(/\\/g, "/")
+        return "file://" + s
+    }
+
+    function pendingImagesJson() {
+        var arr = []
+        for (var i = 0; i < pendingImagesModel.count; i++)
+            arr.push(pendingImagesModel.get(i).path)
+        return JSON.stringify(arr)
+    }
+
+    function addPendingImage(path) {
+        if (!path || path.length === 0) return
+        if (pendingImagesModel.count >= maxPendingImages) return
+        for (var i = 0; i < pendingImagesModel.count; i++) {
+            if (pendingImagesModel.get(i).path === path) return
+        }
+        pendingImagesModel.append({ path: path, previewUrl: fileUrlFromPath(path) })
+    }
+
+    function clearPendingImages() { pendingImagesModel.clear() }
+
+    function doSendMessage() {
+        if (!Agent) return
+        if (Agent.busy) { Agent.cancelAgent(); return }
+        var text = inputField.text.trim()
+        var imagesJson = pendingImagesJson()
+        if (text.length === 0 && pendingImagesModel.count === 0) return
+        messageModel.append({
+            role: "user", content: text, imagesJson: imagesJson,
+            toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false
+        })
+        Agent.sendMessage(text, imagesJson)
+        inputField.text = ""
+        clearPendingImages()
+    }
+
+    function appendTranscription(text) {
+        if (!text || text.length === 0) return
+        var cur = inputField.text || ""
+        if (cur.length > 0 && !/\s$/.test(cur)) cur += " "
+        inputField.text = cur + text
+        inputField.cursorPosition = inputField.text.length
+        inputField.forceActiveFocus()
     }
 
     function loadRoles() {
@@ -114,9 +192,13 @@ Item {
         try {
             var msgs = JSON.parse(Agent.getHistoryMessages())
             for (var i = 0; i < msgs.length; i++) {
+                var imgs = msgs[i].imagesJson || "[]"
+                if ((!imgs || imgs === "[]") && msgs[i].images && msgs[i].images.length)
+                    imgs = JSON.stringify(msgs[i].images)
                 messageModel.append({
                     role: msgs[i].role,
                     content: msgs[i].content,
+                    imagesJson: imgs || "[]",
                     toolName: msgs[i].toolName || "",
                     toolArgs: msgs[i].toolArgs || "",
                     toolResult: msgs[i].toolResult || "",
@@ -130,7 +212,11 @@ Item {
     Component.onCompleted: {
         loadProviders()
         loadRoles()
-        if (Agent) Agent.loadLatestSession()
+        updateCurrentModelLabel()
+        if (Agent) {
+            voiceState = Agent.voiceState || "idle"
+            Agent.loadLatestSession()
+        }
     }
 
     // ============================================================
@@ -415,11 +501,51 @@ Item {
                         visible: role === "user"
                         anchors.right: parent.right; anchors.rightMargin: 16
                         anchors.top: parent.top; anchors.topMargin: 4
-                        width: Math.min(Math.max(userTxt.contentWidth + 24, 50), parent.width * 0.65)
-                        spacing: 0
+                        width: Math.min(Math.max(
+                            Math.max(userTxt.implicitWidth + 24, userImagesRow.visible ? 120 : 0),
+                            50
+                        ), parent.width * 0.65)
+                        spacing: 6
+
+                        Flow {
+                            id: userImagesRow
+                            width: parent.width
+                            spacing: 4
+                            visible: {
+                                try {
+                                    var arr = JSON.parse(imagesJson || "[]")
+                                    return arr && arr.length > 0
+                                } catch (e) { return false }
+                            }
+                            property var imageList: {
+                                try { return JSON.parse(imagesJson || "[]") } catch (e) { return [] }
+                            }
+                            Repeater {
+                                model: userImagesRow.imageList
+                                delegate: Rectangle {
+                                    width: 88; height: 88
+                                    radius: 8
+                                    color: "#00000022"
+                                    clip: true
+                                    Image {
+                                        anchors.fill: parent
+                                        source: {
+                                            var p = modelData || ""
+                                            if (!p) return ""
+                                            if (p.indexOf("file://") === 0 || p.indexOf("data:") === 0) return p
+                                            return agentPage.fileUrlFromPath(p)
+                                        }
+                                        fillMode: Image.PreserveAspectCrop
+                                        asynchronous: true
+                                    }
+                                }
+                            }
+                        }
 
                         Rectangle {
-                            width: parent.width; height: userTxt.contentHeight + 16
+                            width: parent.width
+                            height: (content && content.length > 0) ? (userTxt.contentHeight + 16) : 0
+                            visible: content && content.length > 0
                             radius: 8
                             color: Theme.accentColor || "#0078D4"
 
@@ -668,7 +794,7 @@ Item {
             // ===== 输入栏 =====
             Rectangle {
                 Layout.fillWidth: true
-                Layout.preferredHeight: (Agent && Agent.busy ? progressBar.height + 4 : 0) + inputRow.implicitHeight + 16
+                Layout.preferredHeight: (Agent && Agent.busy ? progressBar.height + 4 : 0) + inputCard.implicitHeight + 20
                 color: Theme.currentTheme.colors.cardColor || "#FFFFFF"
                 Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: Theme.currentTheme.colors.controlBorderColor }
 
@@ -681,90 +807,292 @@ Item {
                     visible: Agent && Agent.busy
                 }
 
-                ColumnLayout {
-                    id: inputRow
-                    anchors.fill: parent; anchors.margins: 8; anchors.leftMargin: 12; anchors.rightMargin: 12
-                    spacing: 6
+                // 一体输入卡片
+                Rectangle {
+                    id: inputCard
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: 10
+                    implicitHeight: inputCardCol.implicitHeight + 16
+                    radius: 22
+                    color: Theme.currentTheme.colors.controlColor || Theme.currentTheme.colors.cardColor || "#FFFFFF"
+                    border.color: inputField.activeFocus
+                        ? (Theme.accentColor || "#0078D4")
+                        : (Theme.currentTheme.colors.controlBorderColor || "#E0E0E0")
+                    border.width: 1
 
-                    RowLayout {
-                        Layout.fillWidth: true; spacing: 8
+                    ColumnLayout {
+                        id: inputCardCol
+                        anchors.fill: parent
+                        anchors.margins: 10
+                        spacing: 8
 
-                        ComboBox {
-                            id: providerCombo
-                            Layout.preferredWidth: 130
-                            model: providerModel; textRole: "name"
-                            font.pixelSize: 10
-                            enabled: Agent && !Agent.busy
-                            onActivated: function(index) {
-                                var item = providerModel.get(index)
-                                Agent.setProvider(item.key); loadModels()
-                            }
-                        }
-
-                        ComboBox {
-                            id: modelCombo
+                        Flow {
                             Layout.fillWidth: true
-                            model: modelModel; textRole: "name"
-                            font.pixelSize: 10
-                            enabled: Agent && !Agent.busy && modelModel.count > 0
-                            onActivated: function(index) {
-                                if (modelModel.count > 0) Agent.setModel(modelModel.get(index).id)
-                            }
-                        }
-                    }
-
-                    RowLayout {
-                        Layout.fillWidth: true; spacing: 8
-
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: Math.max(inputField.implicitHeight + 12, 36)
-                            radius: 8
-                            color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
-                            border.color: inputField.activeFocus ? (Theme.accentColor || "#0078D4") : (Theme.currentTheme.colors.controlBorderColor || "#E0E0E0")
-                            border.width: 1
-
-                            TextArea {
-                                id: inputField
-                                anchors.fill: parent; anchors.margins: 6
-                                placeholderText: (Backend ? Backend.tr("输入消息... (Enter 发送, Shift+Enter 换行)") : "输入消息... (Enter 发送, Shift+Enter 换行)")
-                                wrapMode: TextArea.Wrap
-                                font.pixelSize: 13
-                                color: Theme.currentTheme.colors.textColor
-                                enabled: Agent && !Agent.busy
-                                background: Item {}
-
-                                Keys.onPressed: function(event) {
-                                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                        if (event.modifiers & Qt.ShiftModifier) {
-                                            inputField.insert(inputField.cursorPosition, "\n")
-                                        } else {
-                                            sendBtn.clicked(); event.accepted = true
+                            spacing: 6
+                            visible: pendingImagesModel.count > 0
+                            Repeater {
+                                model: pendingImagesModel
+                                delegate: Item {
+                                    width: 64; height: 64
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        radius: 10
+                                        color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                                        clip: true
+                                        Image {
+                                            anchors.fill: parent
+                                            source: model.previewUrl
+                                            fillMode: Image.PreserveAspectCrop
+                                            asynchronous: true
                                         }
+                                    }
+                                    RoundButton {
+                                        anchors.top: parent.top
+                                        anchors.right: parent.right
+                                        anchors.margins: -4
+                                        width: 20; height: 20
+                                        flat: true
+                                        icon.name: "ic_fluent_dismiss_20_regular"
+                                        onClicked: pendingImagesModel.remove(index)
                                     }
                                 }
                             }
                         }
 
-                        Button {
-                            id: sendBtn
-                            icon.name: Agent && Agent.busy ? "ic_fluent_stop_20_regular" : "ic_fluent_send_20_regular"
-                            Layout.preferredWidth: 36; Layout.preferredHeight: 36
-                            highlighted: true
-                            enabled: {
-                                if (!Agent) return false
-                                if (Agent.busy) return true
-                                return inputField.text.trim().length > 0
-                            }
-                            onClicked: {
-                                if (Agent.busy) { Agent.cancelAgent(); return }
-                                var text = inputField.text.trim()
-                                if (text.length === 0) return
-                                messageModel.append({role: "user", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
-                                Agent.sendMessage(text)
-                                inputField.text = ""
+                        TextArea {
+                            id: inputField
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Math.min(Math.max(implicitHeight, 28), 120)
+                            placeholderText: (Backend ? Backend.tr("向 Blora Agent 说些什么...") : "向 Blora Agent 说些什么...")
+                            wrapMode: TextArea.Wrap
+                            font.pixelSize: 14
+                            color: Theme.currentTheme.colors.textColor
+                            enabled: Agent && !Agent.busy
+                            background: Item {}
+                            topPadding: 2; bottomPadding: 2; leftPadding: 4; rightPadding: 4
+                            Keys.onPressed: function(event) {
+                                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                    if (event.modifiers & Qt.ShiftModifier) {
+                                        inputField.insert(inputField.cursorPosition, "\n")
+                                    } else {
+                                        doSendMessage(); event.accepted = true
+                                    }
+                                }
                             }
                         }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            RoundButton {
+                                Layout.preferredWidth: 32
+                                Layout.preferredHeight: 32
+                                flat: true
+                                icon.name: "ic_fluent_add_20_regular"
+                                enabled: Agent && !Agent.busy && pendingImagesModel.count < maxPendingImages
+                                ToolTip.visible: hovered
+                                ToolTip.text: Backend ? Backend.tr("添加图片") : "添加图片"
+                                ToolTip.delay: 400
+                                onClicked: imageFileDialog.open()
+                            }
+
+                            Rectangle {
+                                Layout.preferredHeight: 32
+                                Layout.preferredWidth: Math.min(modelPillRow.implicitWidth + 16, 180)
+                                Layout.maximumWidth: 200
+                                radius: 16
+                                color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                                border.color: Theme.currentTheme.colors.controlBorderColor || "#E0E0E0"
+                                border.width: 1
+                                opacity: Agent && !Agent.busy ? 1.0 : 0.55
+                                RowLayout {
+                                    id: modelPillRow
+                                    anchors.centerIn: parent
+                                    anchors.leftMargin: 8; anchors.rightMargin: 8
+                                    spacing: 4
+                                    Icon { icon: "ic_fluent_lightbulb_20_regular"; size: 14; color: Theme.currentTheme.colors.textColor }
+                                    Text {
+                                        text: currentModelLabel
+                                        font.pixelSize: 12
+                                        color: Theme.currentTheme.colors.textColor
+                                        elide: Text.ElideRight
+                                        Layout.maximumWidth: 140
+                                    }
+                                }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    enabled: Agent && !Agent.busy
+                                    onClicked: modelSelectDlg.open()
+                                }
+                            }
+
+                            Item { Layout.fillWidth: true }
+
+                            RoundButton {
+                                Layout.preferredWidth: 32
+                                Layout.preferredHeight: 32
+                                flat: true
+                                highlighted: voiceState === "recording"
+                                icon.name: voiceState === "recording"
+                                    ? "ic_fluent_mic_record_20_filled"
+                                    : (voiceState === "transcribing"
+                                        ? "ic_fluent_spinner_ios_20_regular"
+                                        : "ic_fluent_mic_20_regular")
+                                enabled: Agent && !Agent.busy && voiceState !== "transcribing"
+                                ToolTip.visible: hovered
+                                ToolTip.text: voiceState === "recording"
+                                    ? (Backend ? Backend.tr("录音中，再次点击结束") : "录音中，再次点击结束")
+                                    : (Backend ? Backend.tr("语音输入") : "语音输入")
+                                ToolTip.delay: 400
+                                onClicked: {
+                                    if (!Agent) return
+                                    if (voiceState === "recording")
+                                        Agent.stopVoiceCaptureAndTranscribe()
+                                    else if (voiceState === "idle")
+                                        Agent.startVoiceCapture()
+                                }
+                            }
+
+                            RoundButton {
+                                id: sendBtn
+                                Layout.preferredWidth: 34
+                                Layout.preferredHeight: 34
+                                highlighted: true
+                                icon.name: Agent && Agent.busy
+                                    ? "ic_fluent_stop_20_regular"
+                                    : "ic_fluent_arrow_up_20_filled"
+                                enabled: {
+                                    if (!Agent) return false
+                                    if (Agent.busy) return true
+                                    return inputField.text.trim().length > 0 || pendingImagesModel.count > 0
+                                }
+                                onClicked: doSendMessage()
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    width: 0; height: 0; visible: false
+                    ComboBox {
+                        id: providerCombo
+                        model: providerModel; textRole: "name"
+                        onActivated: function(index) {
+                            var item = providerModel.get(index)
+                            Agent.setProvider(item.key); loadModels()
+                        }
+                    }
+                    ComboBox {
+                        id: modelCombo
+                        model: modelModel; textRole: "name"
+                        onActivated: function(index) {
+                            if (modelModel.count > 0) Agent.setModel(modelModel.get(index).id)
+                            updateCurrentModelLabel()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Platform.FileDialog {
+        id: imageFileDialog
+        title: Backend ? Backend.tr("选择图片") : "选择图片"
+        fileMode: Platform.FileDialog.OpenFiles
+        nameFilters: [
+            Backend ? Backend.tr("图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)") : "图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)",
+            Backend ? Backend.tr("所有文件 (*)") : "所有文件 (*)"
+        ]
+        onAccepted: {
+            var files = imageFileDialog.files || []
+            for (var i = 0; i < files.length; i++) {
+                if (pendingImagesModel.count >= maxPendingImages) break
+                addPendingImage(pathFromFileUrl(files[i]))
+            }
+            if (files.length === 0 && imageFileDialog.file)
+                addPendingImage(pathFromFileUrl(imageFileDialog.file))
+        }
+    }
+
+    Dialog {
+        id: modelSelectDlg
+        title: Backend ? Backend.tr("切换模型") : "切换模型"
+        modal: true
+        width: 360
+        standardButtons: Dialog.NoButton
+        onOpened: {
+            loadProviders()
+            providerComboDlg.currentIndex = providerCombo.currentIndex
+            modelComboDlg.currentIndex = modelCombo.currentIndex
+        }
+        contentItem: ColumnLayout {
+            spacing: 12
+            Text {
+                text: modelSelectDlg.title
+                font.pixelSize: 16; font.bold: true
+                color: Theme.currentTheme.colors.textColor
+                Layout.fillWidth: true
+            }
+            Text {
+                text: Backend ? Backend.tr("供应商") : "供应商"
+                font.pixelSize: 12
+                color: Theme.currentTheme.colors.textSecondaryColor
+                Layout.fillWidth: true
+            }
+            ComboBox {
+                id: providerComboDlg
+                Layout.fillWidth: true
+                model: providerModel; textRole: "name"
+                onActivated: function(index) {
+                    var item = providerModel.get(index)
+                    Agent.setProvider(item.key)
+                    providerCombo.currentIndex = index
+                    loadModels()
+                    modelComboDlg.currentIndex = modelCombo.currentIndex >= 0 ? modelCombo.currentIndex : 0
+                }
+            }
+            Text {
+                text: Backend ? Backend.tr("模型") : "模型"
+                font.pixelSize: 12
+                color: Theme.currentTheme.colors.textSecondaryColor
+                Layout.fillWidth: true
+            }
+            ComboBox {
+                id: modelComboDlg
+                Layout.fillWidth: true
+                model: modelModel; textRole: "name"
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+                Button {
+                    text: Backend ? Backend.tr("取消") : "取消"
+                    flat: true
+                    Layout.fillWidth: true
+                    onClicked: modelSelectDlg.close()
+                }
+                Button {
+                    text: Backend ? Backend.tr("确定") : "确定"
+                    highlighted: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        if (providerComboDlg.currentIndex >= 0 && providerComboDlg.currentIndex < providerModel.count) {
+                            var p = providerModel.get(providerComboDlg.currentIndex)
+                            Agent.setProvider(p.key)
+                            providerCombo.currentIndex = providerComboDlg.currentIndex
+                        }
+                        loadModels()
+                        if (modelComboDlg.currentIndex >= 0 && modelComboDlg.currentIndex < modelModel.count) {
+                            var m = modelModel.get(modelComboDlg.currentIndex)
+                            Agent.setModel(m.id)
+                            modelCombo.currentIndex = modelComboDlg.currentIndex
+                        }
+                        updateCurrentModelLabel()
+                        modelSelectDlg.close()
                     }
                 }
             }
@@ -1088,6 +1416,26 @@ Item {
     Connections {
         target: Agent; enabled: Agent !== null
 
+        function onVoiceStateChanged(state) {
+            voiceState = state || "idle"
+        }
+
+        function onTranscriptionReady(text) {
+            if (agentPage.visible)
+                appendTranscription(text)
+        }
+
+        function onTranscriptionFailed(msg) {
+            if (!agentPage.visible) return
+            messageModel.append({
+                role: "error",
+                content: msg || (Backend ? Backend.tr("语音识别失败") : "语音识别失败"),
+                imagesJson: "[]",
+                toolName: "", toolArgs: "", toolResult: "",
+                streaming: false, expanded: false
+            })
+        }
+
         function onTextUpdated(text) {
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
@@ -1182,6 +1530,8 @@ Item {
             rebuildMessageModelFromHistory()
             conversationTitle = Agent ? (Agent.title || "") : ""
             syncRoleCombo()
+            loadProviders()
+            updateCurrentModelLabel()
         }
 
         function onRoleChanged() {

--- a/qml/ResourcePackEditor/pages/AgentTab.qml
+++ b/qml/ResourcePackEditor/pages/AgentTab.qml
@@ -4,11 +4,12 @@ import QtQuick.Layouts 2.15
 import Qt.labs.platform 1.1 as Platform
 import RinUI
 import "../../components"
+import "../../components/ToolCallGroups.js" as ToolGroups
 
 Item {
     id: agentPage
 
-    // 消息模型
+    // 消息模型：user | assistant | tool_group | error | system
     ListModel { id: messageModel }
     ListModel { id: providerModel }
     ListModel { id: modelModel }
@@ -123,6 +124,79 @@ Item {
 
     function clearPendingImages() { pendingImagesModel.clear() }
 
+    function findOpenToolGroupIndex() {
+        for (var i = messageModel.count - 1; i >= 0; i--) {
+            var item = messageModel.get(i)
+            if (item.role === "tool_group")
+                return i
+            if (item.role === "assistant" || item.role === "user" || item.role === "error" || item.role === "system")
+                break
+        }
+        return -1
+    }
+
+    function ensureToolGroup() {
+        var idx = findOpenToolGroupIndex()
+        if (idx >= 0)
+            return idx
+        messageModel.append({
+            role: "tool_group",
+            content: Backend ? Backend.tr("正在使用工具…") : "正在使用工具…",
+            imagesJson: "[]",
+            toolName: "", toolArgs: "", toolResult: "",
+            toolsJson: "[]",
+            streaming: false, expanded: false
+        })
+        return messageModel.count - 1
+    }
+
+    function refreshToolGroupSummary(idx) {
+        if (idx < 0 || idx >= messageModel.count) return
+        var tools = ToolGroups.parseToolsJson(messageModel.get(idx).toolsJson)
+        var summary = ToolGroups.summarizeTools(tools)
+        if (!summary || summary.length === 0)
+            summary = Backend ? Backend.tr("正在使用工具…") : "正在使用工具…"
+        messageModel.setProperty(idx, "content", summary)
+    }
+
+    function startToolInGroup(toolName, argsJson) {
+        var idx = ensureToolGroup()
+        var tools = ToolGroups.parseToolsJson(messageModel.get(idx).toolsJson)
+        tools.push(ToolGroups.makeToolEntry(toolName, argsJson, ""))
+        messageModel.setProperty(idx, "toolsJson", JSON.stringify(tools))
+        refreshToolGroupSummary(idx)
+        return idx
+    }
+
+    function finishToolInGroup(toolName, argsJson, result) {
+        for (var g = messageModel.count - 1; g >= 0; g--) {
+            var item = messageModel.get(g)
+            if (item.role !== "tool_group") {
+                if (item.role === "assistant" || item.role === "user")
+                    break
+                continue
+            }
+            var tools = ToolGroups.parseToolsJson(item.toolsJson)
+            for (var t = tools.length - 1; t >= 0; t--) {
+                if (tools[t].toolName === toolName && (!tools[t].toolResult || tools[t].toolResult.length === 0)) {
+                    tools[t].toolResult = result || ""
+                    if (argsJson)
+                        tools[t].toolArgs = argsJson
+                    messageModel.setProperty(g, "toolsJson", JSON.stringify(tools))
+                    refreshToolGroupSummary(g)
+                    return
+                }
+            }
+            tools.push(ToolGroups.makeToolEntry(toolName, argsJson, result))
+            messageModel.setProperty(g, "toolsJson", JSON.stringify(tools))
+            refreshToolGroupSummary(g)
+            return
+        }
+        var idx = ensureToolGroup()
+        messageModel.setProperty(idx, "toolsJson", JSON.stringify([ToolGroups.makeToolEntry(toolName, argsJson, result)]))
+        refreshToolGroupSummary(idx)
+    }
+
     function doSendMessage() {
         if (!Agent) return
         if (Agent.busy) { Agent.cancelAgent(); return }
@@ -131,7 +205,8 @@ Item {
         if (text.length === 0 && pendingImagesModel.count === 0) return
         messageModel.append({
             role: "user", content: text, imagesJson: imagesJson,
-            toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false
+            toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+            streaming: false, expanded: false
         })
         beginAwaitingReply()
         Agent.sendMessage(text, imagesJson)
@@ -202,21 +277,9 @@ Item {
         if (!Agent) return
         try {
             var msgs = JSON.parse(Agent.getHistoryMessages())
-            for (var i = 0; i < msgs.length; i++) {
-                var imgs = msgs[i].imagesJson || "[]"
-                if ((!imgs || imgs === "[]") && msgs[i].images && msgs[i].images.length)
-                    imgs = JSON.stringify(msgs[i].images)
-                messageModel.append({
-                    role: msgs[i].role,
-                    content: msgs[i].content,
-                    imagesJson: imgs || "[]",
-                    toolName: msgs[i].toolName || "",
-                    toolArgs: msgs[i].toolArgs || "",
-                    toolResult: msgs[i].toolResult || "",
-                    streaming: false,
-                    expanded: false
-                })
-            }
+            var collapsed = ToolGroups.collapseHistoryMessages(msgs)
+            for (var i = 0; i < collapsed.length; i++)
+                messageModel.append(collapsed[i])
         } catch(e) {}
     }
 
@@ -565,10 +628,10 @@ Item {
                         var h = 0
                         if (role === "user") h = userCol.height + 8
                         else if (role === "assistant") h = aiCol.height + 8
-                        else if (role === "tool_call") h = tcCol.height + (toolResult && toolResult.length > 0 && expanded ? trResultCol.height + 4 : 0) + 4
+                        else if (role === "tool_group") h = tgCol.height + 6
+                        else if (role === "tool_call") h = tcCol.height + 4
                         else if (role === "error") h = errCol.height + 6
                         else if (role === "system") h = sysCol.height + 4
-                        if (role === "tool_call") console.log("[AgentTab] tool_call height: tcCol=" + tcCol.height + ", item=" + h)
                         return h
                     }
 
@@ -678,164 +741,140 @@ Item {
                         }
                     }
 
-                    // --- 工具调用（含可折叠结果） ---
+                    // --- 连续工具组（Claude Code 风格汇总） ---
                     Column {
-                        id: tcCol
-                        visible: role === "tool_call"
-                        Component.onCompleted: console.log("[AgentTab] tcCol 创建: role=" + role + ", toolName=" + toolName + ", height=" + height)
+                        id: tgCol
+                        visible: role === "tool_group"
                         anchors.left: parent.left; anchors.leftMargin: 44
                         anchors.right: parent.right; anchors.rightMargin: 16
                         anchors.top: parent.top; anchors.topMargin: 2
                         width: parent.width - 60
                         spacing: 4
+                        property var toolList: ToolGroups.parseToolsJson(toolsJson || "[]")
 
-                        // 工具调用摘要（始终显示）
                         RowLayout {
                             width: parent.width
-                            Layout.preferredHeight: 20
                             spacing: 6
-
-                            // 点击切换展开/折叠
                             MouseArea {
                                 Layout.fillWidth: true
-                                Layout.preferredHeight: 20
-                                cursorShape: toolResult && toolResult.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                Layout.preferredHeight: Math.max(tgSummary.implicitHeight, 20)
+                                cursorShape: tgCol.toolList.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
                                 onClicked: {
-                                    if (toolResult && toolResult.length > 0) {
+                                    if (tgCol.toolList.length > 0)
                                         messageModel.setProperty(index, "expanded", !expanded)
-                                    }
                                 }
-
                                 RowLayout {
                                     width: parent.width
                                     spacing: 6
-
                                     Icon {
-                                        icon: "ic_fluent_lightbulb_20_regular"
+                                        icon: "ic_fluent_wrench_20_regular"
                                         size: 14
                                         color: Theme.currentTheme.colors.textSecondaryColor
-                                        Layout.alignment: Qt.AlignTop
+                                        Layout.alignment: Qt.AlignVCenter
                                     }
-
                                     Text {
+                                        id: tgSummary
                                         Layout.fillWidth: true
-                                        text: {
-                                            var n = toolName || ""
-                                            var a = ""
-                                            try {
-                                                var obj = JSON.parse(toolArgs || "{}")
-                                                // 生成人类可读摘要
-                                                if (n === "read_file") a = obj.path || ""
-                                                else if (n === "write_file") a = obj.path || ""
-                                                else if (n === "edit_file") a = obj.path || ""
-                                                else if (n === "list_files") a = obj.pattern || "*"
-                                                else if (n === "search_text") a = obj.query || ""
-                                                else if (n === "get_pack_info") a = ""
-                                                else if (n === "analyze_pack") a = ""
-                                                else if (n === "read_language") a = obj.lang || ""
-                                                else if (n === "edit_language") a = obj.lang || ""
-                                                else if (n === "validate_json") a = obj.path || ""
-                                                else if (n === "get_file_tree") a = ""
-                                                else if (n === "ask_user") a = obj.question || ""
-                                                else if (n === "execute_command") a = obj.command || ""
-                                                else if (n === "execute_command_background") a = obj.command || ""
-                                                else if (n === "spawn_agent") a = (obj.agent_type || "general") + ": " + (obj.prompt || "").substring(0, 40)
-                                                else {
-                                                    // fallback: 显示参数摘要
-                                                    var parts = []
-                                                    for (var k in obj) {
-                                                        var v = String(obj[k])
-                                                        if (v.length > 40) v = v.substring(0, 40) + "…"
-                                                        parts.push(v)
-                                                    }
-                                                    a = parts.join(", ")
-                                                }
-                                                // 截断过长内容
-                                                if (a.length > 80) a = a.substring(0, 80) + "…"
-                                            } catch(e) { a = toolArgs || "" }
-
-                                            // 工具名中文映射
-                                            var nameMap = {
-                                                "read_file": (Backend ? Backend.tr("读取") : "读取"),
-                                                "write_file": (Backend ? Backend.tr("写入") : "写入"),
-                                                "edit_file": (Backend ? Backend.tr("编辑") : "编辑"),
-                                                "list_files": (Backend ? Backend.tr("列出文件") : "列出文件"),
-                                                "search_text": (Backend ? Backend.tr("搜索") : "搜索"),
-                                                "get_pack_info": (Backend ? Backend.tr("获取资源包信息") : "获取资源包信息"),
-                                                "analyze_pack": (Backend ? Backend.tr("分析资源包") : "分析资源包"),
-                                                "read_language": (Backend ? Backend.tr("读取语言文件") : "读取语言文件"),
-                                                "edit_language": (Backend ? Backend.tr("编辑语言文件") : "编辑语言文件"),
-                                                "validate_json": (Backend ? Backend.tr("验证 JSON") : "验证 JSON"),
-                                                "get_file_tree": (Backend ? Backend.tr("获取文件树") : "获取文件树"),
-                                                "ask_user": (Backend ? Backend.tr("向用户提问") : "向用户提问"),
-                                                "execute_command": (Backend ? Backend.tr("执行命令") : "执行命令"),
-                                                "execute_command_background": (Backend ? Backend.tr("后台执行") : "后台执行"),
-                                                "spawn_agent": (Backend ? Backend.tr("生成子 Agent") : "生成子 Agent")
-                                            }
-                                            var displayName = nameMap[n] || n
-                                            return a ? displayName + " " + a : displayName
-                                        }
+                                        text: content || (Backend ? Backend.tr("正在使用工具…") : "正在使用工具…")
                                         font.pixelSize: 12
-                                        color: Theme.currentTheme.colors.textColor
-                                        opacity: 0.7
+                                        color: Theme.currentTheme.colors.textSecondaryColor
                                         wrapMode: Text.Wrap
                                     }
-
                                     Text {
-                                        text: toolResult && toolResult.length > 0 ? (expanded ? "▼" : "▶") : ""
+                                        text: tgCol.toolList.length > 0 ? (expanded ? "▼" : "▶") : ""
                                         font.pixelSize: 11
-                                        color: Theme.currentTheme.colors.textColor
-                                        opacity: 0.5
-                                        Layout.alignment: Qt.AlignTop
+                                        color: Theme.currentTheme.colors.textSecondaryColor
+                                        opacity: 0.6
                                     }
                                 }
                             }
                         }
 
-                        // 工具结果（可折叠）
-                        RowLayout {
-                            id: trResultCol
-                            visible: toolResult && toolResult.length > 0 && expanded
+                        Column {
+                            visible: expanded && tgCol.toolList.length > 0
                             width: parent.width
-                            spacing: 6
-
-                            Text {
-                                text: "└"
-                                font.pixelSize: 11
-                                font.family: "Consolas, monospace"
-                                color: Theme.currentTheme.colors.textSecondaryColor
-                                Layout.alignment: Qt.AlignTop
-                            }
-
-                            Rectangle {
-                                Layout.fillWidth: true
-                                Layout.preferredHeight: Math.min(trResultTxt.contentHeight + 12, 160)
-                                radius: 4
-                                color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F5F5F5"
-                                border.color: Theme.currentTheme.colors.controlBorderColor || "#E8E8E8"
-                                border.width: 1
-
-                                Flickable {
-                                    anchors.fill: parent; anchors.margins: 6
-                                    contentHeight: trResultTxt.contentHeight
-                                    clip: true
-                                    interactive: contentHeight > height
-
-                                    TextEdit {
-                                        id: trResultTxt
+                            spacing: 4
+                            Repeater {
+                                model: tgCol.toolList
+                                delegate: Column {
+                                    width: parent.width
+                                    spacing: 2
+                                    RowLayout {
                                         width: parent.width
-                                        text: {
-                                            var r = toolResult || ""
-                                            if (r.length > 500) r = r.substring(0, 500) + "\n" + (Backend ? Backend.tr("... (已截断)") : "... (已截断)")
-                                            return r
+                                        spacing: 6
+                                        Text {
+                                            text: "·"
+                                            font.pixelSize: 12
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            Layout.alignment: Qt.AlignTop
                                         }
-                                        font.pixelSize: 11
-                                        font.family: "Consolas, monospace"
-                                        color: Theme.currentTheme.colors.textSecondaryColor
-                                        wrapMode: TextEdit.Wrap
-                                        readOnly: true; selectByMouse: true
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: ToolGroups.toolLineLabel(modelData)
+                                            font.pixelSize: 11
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            wrapMode: Text.Wrap
+                                            opacity: 0.9
+                                        }
+                                    }
+                                    Rectangle {
+                                        visible: modelData.toolResult && String(modelData.toolResult).length > 0
+                                        width: parent.width - 12
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: 12
+                                        height: Math.min(detailTxt.implicitHeight + 10, 100)
+                                        radius: 4
+                                        color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F5F5F5"
+                                        border.color: Theme.currentTheme.colors.controlBorderColor || "#E8E8E8"
+                                        border.width: 1
+                                        clip: true
+                                        Text {
+                                            id: detailTxt
+                                            anchors.fill: parent
+                                            anchors.margins: 5
+                                            text: {
+                                                var r = String(modelData.toolResult || "")
+                                                if (r.length > 300)
+                                                    r = r.substring(0, 300) + (Backend ? Backend.tr("\n... (已截断)") : "\n... (已截断)")
+                                                return r
+                                            }
+                                            font.pixelSize: 10
+                                            font.family: "Consolas, monospace"
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            wrapMode: Text.Wrap
+                                            elide: Text.ElideRight
+                                            maximumLineCount: 6
+                                        }
                                     }
                                 }
+                            }
+                        }
+                    }
+
+                    // --- 兼容旧会话单条 tool_call ---
+                    Column {
+                        id: tcCol
+                        visible: role === "tool_call"
+                        anchors.left: parent.left; anchors.leftMargin: 44
+                        anchors.right: parent.right; anchors.rightMargin: 16
+                        anchors.top: parent.top; anchors.topMargin: 2
+                        width: parent.width - 60
+                        spacing: 4
+                        RowLayout {
+                            width: parent.width
+                            spacing: 6
+                            Icon {
+                                icon: "ic_fluent_lightbulb_20_regular"
+                                size: 14
+                                color: Theme.currentTheme.colors.textSecondaryColor
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: ToolGroups.toolLineLabel({ toolName: toolName, toolArgs: toolArgs })
+                                font.pixelSize: 12
+                                color: Theme.currentTheme.colors.textColor
+                                opacity: 0.7
+                                wrapMode: Text.Wrap
                             }
                         }
                     }
@@ -1565,9 +1604,17 @@ Item {
                 markReplyStarted()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
-                messageModel.set(lastIdx, {role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true})
+                messageModel.set(lastIdx, {
+                    role: "assistant", content: text, imagesJson: "[]",
+                    toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                    streaming: true, expanded: false
+                })
             } else {
-                messageModel.append({role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true, expanded: false})
+                messageModel.append({
+                    role: "assistant", content: text, imagesJson: "[]",
+                    toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                    streaming: true, expanded: false
+                })
             }
             Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
@@ -1575,52 +1622,40 @@ Item {
         function onToolCallStarted(toolName, argsJson) {
             console.log("[AgentTab] onToolCallStarted: " + toolName)
             markReplyStarted()
-            // 找到最后一个 tool_call 之后的位置（连续的 tool_calls 应该在一起）
-            var insertIdx = messageModel.count
-            for (var i = messageModel.count - 1; i >= 0; i--) {
-                var item = messageModel.get(i)
-                if (item.role === "tool_call") {
-                    insertIdx = i + 1
-                    break
-                }
-                if (item.role === "assistant") {
-                    // 在 assistant 之后插入（tool calls 紧跟在 text 之后）
-                    insertIdx = i + 1
-                    break
-                }
-            }
-            messageModel.insert(insertIdx, {role: "tool_call", content: "", toolName: toolName, toolArgs: argsJson, toolResult: "", streaming: false, expanded: false})
+            startToolInGroup(toolName, argsJson)
+            Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallFinished(toolName, argsJson, result) {
-            // 更新最后一条 tool_call 的结果，而非新增条目
-            for (var i = messageModel.count - 1; i >= 0; i--) {
-                var item = messageModel.get(i)
-                if (item.role === "tool_call" && item.toolName === toolName && item.toolResult === "") {
-                    messageModel.set(i, {toolResult: result})
-                    return
-                }
-            }
-            // 兜底：如果没有找到匹配的 tool_call，追加一条
-            messageModel.append({role: "tool_call", content: "", toolName: toolName, toolArgs: argsJson, toolResult: result, streaming: false, expanded: false})
+            finishToolInGroup(toolName, argsJson, result)
         }
 
         function onErrorOccurred(msg) {
             endAwaitingReply()
-            messageModel.append({role: "error", content: msg, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
+            messageModel.append({
+                role: "error", content: msg, imagesJson: "[]",
+                toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                streaming: false, expanded: false
+            })
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
             markReplyStarted()
-            // 找到流式 assistant 消息并终结
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {
-                    messageModel.set(i, {role: "assistant", content: content, streaming: false})
+                    messageModel.set(i, {
+                        role: "assistant", content: content, imagesJson: "[]",
+                        toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                        streaming: false, expanded: false
+                    })
                     return
                 }
             }
-            // 没有流式消息（历史恢复场景），直接追加
-            messageModel.append({role: role, content: content, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
+            messageModel.append({
+                role: role, content: content, imagesJson: "[]",
+                toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                streaming: false, expanded: false
+            })
         }
 
         function onProvidersChanged() { loadProviders() }

--- a/qml/components/ExportMrpackDialog.qml
+++ b/qml/components/ExportMrpackDialog.qml
@@ -8,12 +8,15 @@ Dialog {
 
     title: (Backend ? Backend.tr("导出 Modrinth 整合包") : "导出 Modrinth 整合包")
     modal: true
-    width: 450
-    implicitHeight: 480
+    width: 520
+    implicitHeight: 560
+    height: Math.min(640, Overlay.overlay ? Overlay.overlay.height - 40 : 560)
     standardButtons: Dialog.NoButton
 
     property string versionName: ""
     property var instanceInfo: ({})
+    property var exportCandidates: []
+    property var selectedPaths: ({})
 
     property bool exporting: false
     property bool exportDone: false
@@ -35,6 +38,31 @@ Dialog {
         }
     }
 
+    function loadCandidates() {
+        exportCandidates = []
+        selectedPaths = ({})
+        if (!Backend || !versionName) return
+        var res = Backend.getMrpackExportCandidates(versionName) || {}
+        var list = (res && res.ok) ? (res.data || []) : []
+        exportCandidates = list
+        var sel = ({})
+        for (var i = 0; i < list.length; i++) {
+            var c = list[i]
+            if (c && c.path && c.default_selected)
+                sel[c.path] = true
+        }
+        selectedPaths = sel
+    }
+
+    function selectedPathList() {
+        var out = []
+        var keys = Object.keys(selectedPaths)
+        for (var i = 0; i < keys.length; i++) {
+            if (selectedPaths[keys[i]]) out.push(keys[i])
+        }
+        return out
+    }
+
     function openForVersion(name) {
         versionName = name
         exporting = false
@@ -43,18 +71,18 @@ Dialog {
         outputPath = ""
         exportError = ""
         if (Backend) {
-            instanceInfo = Backend.getMrpackInstanceInfo(name)
+            instanceInfo = Backend.getMrpackInstanceInfo(name) || {}
         }
         packNameField.text = instanceInfo.name || name
         packVersionField.text = "1.0.0"
+        loadCandidates()
         open()
     }
 
     ColumnLayout {
         Layout.fillWidth: true
-        spacing: 16
+        spacing: 12
 
-        // 实例信息
         Rectangle {
             Layout.fillWidth: true
             implicitHeight: infoLayout.implicitHeight + 16
@@ -88,17 +116,17 @@ Dialog {
                     visible: instanceInfo.loader && instanceInfo.loader !== "unknown"
                 }
                 Label {
-                    text: (Backend ? Backend.tr("文件数: %1").arg(instanceInfo.file_count || 0) : "文件数: " + (instanceInfo.file_count || 0))
+                    text: (Backend ? Backend.tr("候选文件: %1 / 已选 %2").arg(exportCandidates.length).arg(selectedPathList().length)
+                                   : ("候选: " + exportCandidates.length + " 已选: " + selectedPathList().length))
                     font.pixelSize: 12
                     color: Theme.currentTheme.colors.textColor
                 }
             }
         }
 
-        // 输入区域
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 12
+            spacing: 10
             visible: !exporting && !exportDone
 
             ColumnLayout {
@@ -139,7 +167,6 @@ Dialog {
                 RowLayout {
                     Layout.fillWidth: true
                     spacing: 8
-
                     TextField {
                         id: savePathField
                         Layout.fillWidth: true
@@ -147,7 +174,6 @@ Dialog {
                         placeholderText: (Backend ? Backend.tr("点击浏览选择保存位置") : "点击浏览选择保存位置")
                         text: exportDialog.outputPath
                     }
-
                     Button {
                         text: (Backend ? Backend.tr("浏览...") : "浏览...")
                         onClicked: {
@@ -158,27 +184,69 @@ Dialog {
                                     defaultName,
                                     "Modrinth Modpack Files (*.mrpack)"
                                 )
-                                if (path && path.length > 0) {
+                                if (path && path.length > 0)
                                     exportDialog.outputPath = path
+                            }
+                        }
+                    }
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 6
+                RowLayout {
+                    Layout.fillWidth: true
+                    Label {
+                        text: (Backend ? Backend.tr("导出内容") : "导出内容")
+                        font.weight: Font.DemiBold
+                        color: Theme.currentTheme.colors.textColor
+                    }
+                    Item { Layout.fillWidth: true }
+                    Button {
+                        text: (Backend ? Backend.tr("全选默认") : "全选默认")
+                        flat: true
+                        onClicked: loadCandidates()
+                    }
+                }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 160
+                    clip: true
+                    ColumnLayout {
+                        width: parent.width - 12
+                        spacing: 4
+                        Repeater {
+                            model: exportCandidates
+                            CheckBox {
+                                text: {
+                                    var sz = modelData.size ? (" · " + Math.round(modelData.size / 1024) + "KB") : ""
+                                    return (modelData.path || "") + sz
+                                }
+                                checked: !!(selectedPaths[modelData.path])
+                                onCheckedChanged: {
+                                    var s = Object.assign({}, selectedPaths)
+                                    if (checked) s[modelData.path] = true
+                                    else delete s[modelData.path]
+                                    selectedPaths = s
                                 }
                             }
+                        }
+                        Label {
+                            visible: exportCandidates.length === 0
+                            text: (Backend ? Backend.tr("无可导出文件（或未扫描到）") : "无可导出文件")
+                            color: Theme.currentTheme.colors.textSecondaryColor
                         }
                     }
                 }
             }
         }
 
-        // 导出中
         ColumnLayout {
             Layout.fillWidth: true
             spacing: 12
             visible: exporting
-
-            ProgressBar {
-                Layout.fillWidth: true
-                indeterminate: true
-            }
-
+            ProgressBar { Layout.fillWidth: true; indeterminate: true }
             Label {
                 text: (Backend ? Backend.tr("正在导出整合包...") : "正在导出整合包...")
                 Layout.alignment: Qt.AlignHCenter
@@ -186,12 +254,10 @@ Dialog {
             }
         }
 
-        // 导出结果
         ColumnLayout {
             Layout.fillWidth: true
             spacing: 12
             visible: exportDone
-
             Label {
                 text: exportDialog.exportSuccess
                     ? (Backend ? Backend.tr("整合包已成功导出到:") : "整合包已成功导出到:")
@@ -200,7 +266,6 @@ Dialog {
                 Layout.fillWidth: true
                 color: Theme.currentTheme.colors.textColor
             }
-
             Label {
                 text: exportDialog.outputPath
                 wrapMode: Text.WrapAnywhere
@@ -211,19 +276,15 @@ Dialog {
             }
         }
 
-        // 按钮区域
         RowLayout {
             Layout.fillWidth: true
             spacing: 8
             visible: !exporting
-
             Item { Layout.fillWidth: true }
-
             Button {
                 text: (Backend ? Backend.tr("取消") : "取消")
                 onClicked: exportDialog.close()
             }
-
             Button {
                 text: exportDialog.exportDone
                     ? (Backend ? Backend.tr("关闭") : "关闭")
@@ -234,27 +295,39 @@ Dialog {
                 onClicked: {
                     if (exportDialog.exportDone) {
                         exportDialog.close()
-                    } else {
-                        exportDialog.exporting = true
-                        exportDialog.exportRequestSerial++
-                        exportDialog.activeExportRequestId = "export:" + exportDialog.exportRequestSerial
-                        var submitted = Backend && Backend.requestMrpackExport(
+                        return
+                    }
+                    exportDialog.exporting = true
+                    exportDialog.exportRequestSerial++
+                    exportDialog.activeExportRequestId = "export:" + exportDialog.exportRequestSerial
+                    var paths = selectedPathList()
+                    var submitted = false
+                    if (Backend && Backend.requestMrpackExportWithSelection) {
+                        submitted = Backend.requestMrpackExportWithSelection(
+                            exportDialog.versionName,
+                            packNameField.text.trim(),
+                            packVersionField.text.trim(),
+                            exportDialog.outputPath,
+                            exportDialog.activeExportRequestId,
+                            paths
+                        )
+                    } else if (Backend) {
+                        submitted = Backend.requestMrpackExport(
                             exportDialog.versionName,
                             packNameField.text.trim(),
                             packVersionField.text.trim(),
                             exportDialog.outputPath,
                             exportDialog.activeExportRequestId
                         )
-                        if (!submitted) {
-                            exportDialog.exporting = false
-                            exportDialog.exportDone = true
-                            exportDialog.exportSuccess = false
-                            exportDialog.exportError = Backend ? Backend.tr("相同路径已有导出任务") : "An export is already running for this path"
-                        }
+                    }
+                    if (!submitted) {
+                        exportDialog.exporting = false
+                        exportDialog.exportDone = true
+                        exportDialog.exportSuccess = false
+                        exportDialog.exportError = Backend ? Backend.tr("相同路径已有导出任务") : "An export is already running for this path"
                     }
                 }
             }
         }
     }
-
 }

--- a/qml/components/ThinkingOrb.qml
+++ b/qml/components/ThinkingOrb.qml
@@ -21,9 +21,10 @@ Item {
     implicitWidth: size
     implicitHeight: size
 
-    property real _t: 0
+    // 动画相位（勿用 _t：QML 无法为以下划线开头的属性生成 on_tChanged）
+    property real phase: 0
 
-    NumberAnimation on _t {
+    NumberAnimation on phase {
         id: clock
         from: 0
         to: Math.PI * 200
@@ -35,7 +36,7 @@ Item {
     onRunningChanged: if (running) canvas.requestPaint()
     onStateChanged: canvas.requestPaint()
     onInkChanged: canvas.requestPaint()
-    on_tChanged: if (running) canvas.requestPaint()
+    onPhaseChanged: if (running) canvas.requestPaint()
     onSizeChanged: canvas.requestPaint()
 
     Canvas {
@@ -54,7 +55,7 @@ Item {
             var cx = w / 2
             var cy = h / 2
             var R = Math.min(w, h) * 0.42
-            var t = root._t
+            var t = root.phase
             var ink = root.ink
             var baseA = root.inkOpacity
 

--- a/qml/components/ThinkingOrb.qml
+++ b/qml/components/ThinkingOrb.qml
@@ -1,0 +1,166 @@
+import QtQuick 2.15
+import RinUI
+
+/**
+ * Dotted thinking-orb indicator (inspired by https://orbs.jakubantalik.com).
+ * Pure QML Canvas — monochrome dots on tilted orbital rings.
+ */
+Item {
+    id: root
+
+    property int size: 20
+    property bool running: true
+    property real speed: 1.0
+    // working | composing | searching | breathing
+    property string state: "composing"
+    property color ink: Theme.currentTheme.colors.textColor
+    property real inkOpacity: 0.85
+
+    width: size
+    height: size
+    implicitWidth: size
+    implicitHeight: size
+
+    property real _t: 0
+
+    NumberAnimation on _t {
+        id: clock
+        from: 0
+        to: Math.PI * 200
+        duration: Math.max(8000, 24000 / Math.max(0.25, root.speed))
+        loops: Animation.Infinite
+        running: root.running && root.visible
+    }
+
+    onRunningChanged: if (running) canvas.requestPaint()
+    onStateChanged: canvas.requestPaint()
+    onInkChanged: canvas.requestPaint()
+    on_tChanged: if (running) canvas.requestPaint()
+    onSizeChanged: canvas.requestPaint()
+
+    Canvas {
+        id: canvas
+        anchors.fill: parent
+        antialiasing: true
+        renderTarget: Canvas.Image
+        renderStrategy: Canvas.Cooperative
+
+        onPaint: {
+            var ctx = getContext("2d")
+            var w = width
+            var h = height
+            ctx.clearRect(0, 0, w, h)
+
+            var cx = w / 2
+            var cy = h / 2
+            var R = Math.min(w, h) * 0.42
+            var t = root._t
+            var ink = root.ink
+            var baseA = root.inkOpacity
+
+            function setInk(a) {
+                // Qt Canvas accepts css rgba
+                var c = ink
+                // Theme colors may be QColor-like strings "#RRGGBB" or "rgba..."
+                ctx.fillStyle = ink
+                ctx.globalAlpha = Math.max(0, Math.min(1, a))
+            }
+
+            function dot(x, y, r, a) {
+                setInk(a)
+                ctx.beginPath()
+                ctx.arc(x, y, r, 0, Math.PI * 2)
+                ctx.fill()
+            }
+
+            // Project a 3D point on a tilted ring into 2D with simple perspective
+            function project(angle, ringR, tilt, phase, yOff) {
+                var a = angle + phase
+                var x3 = Math.cos(a) * ringR
+                var y3 = Math.sin(a) * ringR * Math.sin(tilt) + (yOff || 0)
+                var z3 = Math.sin(a) * ringR * Math.cos(tilt)
+                var persp = 1 / (1.55 - z3 / (R * 1.2))
+                return {
+                    x: cx + x3 * persp,
+                    y: cy + y3 * persp,
+                    z: z3,
+                    s: persp
+                }
+            }
+
+            var st = root.state
+            var rings = 3
+            var dotsPerRing = root.size >= 40 ? 18 : (root.size >= 28 ? 14 : 10)
+            var dotR = Math.max(0.8, root.size * 0.045)
+
+            if (st === "breathing") {
+                var breathe = 0.85 + 0.15 * Math.sin(t * 1.2)
+                for (var i = 0; i < dotsPerRing; i++) {
+                    var ang = (i / dotsPerRing) * Math.PI * 2
+                    var p = project(ang, R * breathe, 0.55, t * 0.35, 0)
+                    var depth = (p.z / R + 1) * 0.5
+                    dot(p.x, p.y, dotR * (0.7 + 0.6 * p.s), baseA * (0.35 + 0.65 * depth))
+                }
+            } else if (st === "searching") {
+                // Globe + sweeping meridian highlight
+                for (var ri = 0; ri < rings; ri++) {
+                    var rr = R * (0.45 + ri * 0.25)
+                    var tilt = 0.35 + ri * 0.25
+                    for (var j = 0; j < dotsPerRing; j++) {
+                        var ang2 = (j / dotsPerRing) * Math.PI * 2
+                        var p2 = project(ang2, rr, tilt, t * 0.2, 0)
+                        var meridian = Math.abs(Math.sin(ang2 - t * 1.4))
+                        var hi = Math.pow(1 - meridian, 6)
+                        var depth2 = (p2.z / R + 1) * 0.5
+                        dot(p2.x, p2.y, dotR * (0.6 + 0.7 * p2.s + hi * 0.5),
+                            baseA * (0.25 + 0.55 * depth2 + hi * 0.45))
+                    }
+                }
+            } else if (st === "working") {
+                // Particles racing on tilted orbits
+                for (var r2 = 0; r2 < rings; r2++) {
+                    var rr2 = R * (0.4 + r2 * 0.28)
+                    var tilt2 = 0.5 + r2 * 0.2
+                    var spin = t * (0.6 + r2 * 0.35) * (r2 % 2 === 0 ? 1 : -1)
+                    var n = dotsPerRing - r2 * 2
+                    for (var k = 0; k < n; k++) {
+                        var ang3 = (k / n) * Math.PI * 2
+                        var p3 = project(ang3, rr2, tilt2, spin, 0)
+                        var depth3 = (p3.z / R + 1) * 0.5
+                        // lead particles brighter
+                        var lead = Math.pow((Math.sin(ang3 * 2 + spin * 3) + 1) * 0.5, 3)
+                        dot(p3.x, p3.y, dotR * (0.65 + 0.7 * p3.s + lead * 0.4),
+                            baseA * (0.3 + 0.5 * depth3 + lead * 0.35))
+                    }
+                }
+            } else {
+                // composing (default): undulating multi-band sash
+                for (var r3 = 0; r3 < rings; r3++) {
+                    var rr3 = R * (0.42 + r3 * 0.26)
+                    var tilt3 = 0.4 + r3 * 0.28
+                    var phase = t * (0.45 + r3 * 0.15) + r3 * 0.9
+                    var n3 = dotsPerRing
+                    for (var m = 0; m < n3; m++) {
+                        var ang4 = (m / n3) * Math.PI * 2
+                        var wave = Math.sin(ang4 * 3 + t * 1.8 + r3) * R * 0.08
+                        var p4 = project(ang4, rr3, tilt3, phase, wave)
+                        var depth4 = (p4.z / R + 1) * 0.5
+                        var sash = 0.5 + 0.5 * Math.sin(ang4 * 2 - t * 1.2 + r3)
+                        dot(p4.x, p4.y, dotR * (0.6 + 0.75 * p4.s),
+                            baseA * (0.28 + 0.5 * depth4 + 0.25 * sash))
+                    }
+                }
+                // soft core
+                setInk(baseA * 0.35)
+                ctx.beginPath()
+                ctx.arc(cx, cy, Math.max(1.2, root.size * 0.06), 0, Math.PI * 2)
+                ctx.fill()
+            }
+
+            ctx.globalAlpha = 1
+        }
+    }
+
+    // Static fallback when not running: single ring of dots
+    Component.onCompleted: canvas.requestPaint()
+}

--- a/qml/components/ThinkingStatus.qml
+++ b/qml/components/ThinkingStatus.qml
@@ -1,0 +1,127 @@
+import QtQuick 2.15
+import QtQuick.Layouts 2.15
+import RinUI
+
+/**
+ * 思考状态行：点阵球 + 「正在思考」+ 可选脉冲点。
+ * active 切换时淡入淡出（不 abrupt visible 跳变）。
+ */
+Item {
+    id: root
+
+    property bool active: false
+    property int orbSize: 22
+    property string orbState: "composing"
+    property real orbSpeed: 1.15
+    property color orbInk: Theme.currentTheme.colors.textColor
+    property color labelColor: Theme.currentTheme.colors.textSecondaryColor
+    property int labelPixelSize: 13
+    property bool showAvatar: false
+    property url avatarSource: ""
+    property bool showPulseDots: true
+    property int fadeMs: 320
+
+    // 布局占用：淡出后高度收为 0，避免占位
+    readonly property real contentHeight: row.implicitHeight
+    implicitWidth: row.implicitWidth
+    implicitHeight: opacity > 0.01 ? contentHeight : 0
+    height: implicitHeight
+    width: parent ? parent.width : row.implicitWidth
+
+    opacity: active ? 1 : 0
+    visible: opacity > 0.01
+    clip: true
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: root.fadeMs
+            easing.type: Easing.InOutQuad
+        }
+    }
+    Behavior on implicitHeight {
+        enabled: root.visible || root.active
+        NumberAnimation {
+            duration: root.fadeMs
+            easing.type: Easing.InOutQuad
+        }
+    }
+
+    // 轻微上浮：淡入时从略下方进入
+    transform: Translate {
+        id: slide
+        y: root.active ? 0 : 6
+        Behavior on y {
+            NumberAnimation {
+                duration: root.fadeMs
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    RowLayout {
+        id: row
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 10
+
+        Rectangle {
+            visible: root.showAvatar
+            width: 22
+            height: 22
+            radius: 11
+            clip: true
+            color: "transparent"
+            Layout.alignment: Qt.AlignVCenter
+            Image {
+                anchors.fill: parent
+                source: root.avatarSource
+                fillMode: Image.PreserveAspectCrop
+                mipmap: true
+                visible: root.avatarSource.toString().length > 0
+            }
+        }
+
+        ThinkingOrb {
+            size: root.orbSize
+            running: root.active && root.visible
+            state: root.orbState
+            speed: root.orbSpeed
+            ink: root.orbInk
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Text {
+            text: Backend ? Backend.tr("正在思考") : "正在思考"
+            font.pixelSize: root.labelPixelSize
+            color: root.labelColor
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        Row {
+            visible: root.showPulseDots
+            spacing: 3
+            Layout.alignment: Qt.AlignVCenter
+            Repeater {
+                model: 3
+                Rectangle {
+                    width: 4
+                    height: 4
+                    radius: 2
+                    color: root.labelColor
+                    opacity: 0.35
+                    SequentialAnimation on opacity {
+                        loops: Animation.Infinite
+                        running: root.active && root.visible && root.showPulseDots
+                        PauseAnimation { duration: index * 160 }
+                        NumberAnimation { to: 1.0; duration: 320; easing.type: Easing.InOutQuad }
+                        NumberAnimation { to: 0.35; duration: 320; easing.type: Easing.InOutQuad }
+                        PauseAnimation { duration: (2 - index) * 160 }
+                    }
+                }
+            }
+        }
+
+        Item { Layout.fillWidth: true }
+    }
+}

--- a/qml/components/ThinkingStatus.qml
+++ b/qml/components/ThinkingStatus.qml
@@ -3,13 +3,15 @@ import QtQuick.Layouts 2.15
 import RinUI
 
 /**
- * 思考状态行：点阵球 + 「正在思考」+ 可选脉冲点。
- * active 切换时淡入淡出（不 abrupt visible 跳变）。
+ * Agent 活动状态行：点阵球 + 状态文案 + 可选脉冲点。
+ * active 切换时淡入淡出；label 变化时文案可直接更新。
  */
 Item {
     id: root
 
     property bool active: false
+    /** 显示文案，如「正在思考」「正在回复」「正在工作」 */
+    property string label: Backend ? Backend.tr("正在思考") : "正在思考"
     property int orbSize: 22
     property string orbState: "composing"
     property real orbSpeed: 1.15
@@ -92,7 +94,7 @@ Item {
         }
 
         Text {
-            text: Backend ? Backend.tr("正在思考") : "正在思考"
+            text: root.label
             font.pixelSize: root.labelPixelSize
             color: root.labelColor
             Layout.alignment: Qt.AlignVCenter

--- a/qml/components/ToolCallGroups.js
+++ b/qml/components/ToolCallGroups.js
@@ -1,0 +1,251 @@
+.pragma library
+
+/**
+ * Shared helpers for collapsing consecutive tool_call rows into Claude-style
+ * summary groups: 「查看了 5 个文件，编辑了 6 个文件，…」
+ */
+
+// .pragma library 无 QML 上下文属性；文案用中文，需要 i18n 时由调用方再包 Backend.tr
+function tr(s, fallback) {
+    return fallback !== undefined ? fallback : s
+}
+
+/** Map tool name → summary category key */
+function toolCategory(name) {
+    switch (name) {
+    case "read_file":
+    case "list_files":
+    case "search_text":
+    case "get_directory_tree":
+    case "get_pack_info":
+    case "analyze_pack":
+    case "get_file_tree":
+    case "read_language":
+    case "validate_json":
+        return "view"
+    case "write_file":
+    case "edit_file":
+    case "edit_language":
+        return "edit"
+    case "execute_command":
+    case "execute_command_background":
+        return "command"
+    case "set_emotion":
+        return "emotion"
+    case "memory":
+        return "memory"
+    case "ask_user":
+        return "ask"
+    case "spawn_agent":
+        return "spawn"
+    default:
+        return "other"
+    }
+}
+
+function categoryLabel(cat, count) {
+    // Claude Code style plurals in Chinese
+    switch (cat) {
+    case "view":
+        return count === 1
+            ? tr("查看了 1 个文件", "查看了 1 个文件")
+            : tr("查看了 %1 个文件", "查看了 %1 个文件").replace("%1", count)
+    case "edit":
+        return count === 1
+            ? tr("编辑了 1 个文件", "编辑了 1 个文件")
+            : tr("编辑了 %1 个文件", "编辑了 %1 个文件").replace("%1", count)
+    case "command":
+        return count === 1
+            ? tr("执行了 1 个命令", "执行了 1 个命令")
+            : tr("执行了 %1 个命令", "执行了 %1 个命令").replace("%1", count)
+    case "emotion":
+        return tr("更新了情感", "更新了情感")
+    case "memory":
+        return tr("更新了记忆", "更新了记忆")
+    case "ask":
+        return count === 1
+            ? tr("向用户提问 1 次", "向用户提问 1 次")
+            : tr("向用户提问 %1 次", "向用户提问 %1 次").replace("%1", count)
+    case "spawn":
+        return count === 1
+            ? tr("启动了 1 个子 Agent", "启动了 1 个子 Agent")
+            : tr("启动了 %1 个子 Agent", "启动了 %1 个子 Agent").replace("%1", count)
+    default:
+        return count === 1
+            ? tr("使用了 1 个工具", "使用了 1 个工具")
+            : tr("使用了 %1 个工具", "使用了 %1 个工具").replace("%1", count)
+    }
+}
+
+/** Preferred display order for summary fragments */
+var CATEGORY_ORDER = ["view", "edit", "command", "emotion", "memory", "ask", "spawn", "other"]
+
+/**
+ * Build summary string from an array of tool call objects
+ * each: { toolName, toolArgs, toolResult }
+ */
+function summarizeTools(tools) {
+    if (!tools || tools.length === 0)
+        return ""
+    var counts = {}
+    for (var i = 0; i < tools.length; i++) {
+        var cat = toolCategory(tools[i].toolName || tools[i].name || "")
+        counts[cat] = (counts[cat] || 0) + 1
+    }
+    var parts = []
+    for (var o = 0; o < CATEGORY_ORDER.length; o++) {
+        var c = CATEGORY_ORDER[o]
+        if (counts[c])
+            parts.push(categoryLabel(c, counts[c]))
+    }
+    return parts.join(tr("，", "，"))
+}
+
+function toolDisplayName(name) {
+    var map = {
+        "read_file": tr("读取", "读取"),
+        "write_file": tr("写入", "写入"),
+        "edit_file": tr("编辑", "编辑"),
+        "list_files": tr("列出文件", "列出文件"),
+        "search_text": tr("搜索", "搜索"),
+        "get_directory_tree": tr("查看目录树", "查看目录树"),
+        "get_pack_info": tr("资源包信息", "资源包信息"),
+        "analyze_pack": tr("分析资源包", "分析资源包"),
+        "get_file_tree": tr("文件树", "文件树"),
+        "read_language": tr("读取语言", "读取语言"),
+        "edit_language": tr("编辑语言", "编辑语言"),
+        "validate_json": tr("校验 JSON", "校验 JSON"),
+        "ask_user": tr("向用户提问", "向用户提问"),
+        "execute_command": tr("执行命令", "执行命令"),
+        "execute_command_background": tr("后台执行", "后台执行"),
+        "spawn_agent": tr("生成子 Agent", "生成子 Agent"),
+        "memory": tr("管理记忆", "管理记忆"),
+        "set_emotion": tr("更新情感", "更新情感")
+    }
+    return map[name] || name
+}
+
+function toolArgsSummary(name, argsJson) {
+    var a = ""
+    try {
+        var obj = typeof argsJson === "string" ? JSON.parse(argsJson || "{}") : (argsJson || {})
+        if (name === "read_file" || name === "write_file" || name === "edit_file" || name === "validate_json")
+            a = obj.path || ""
+        else if (name === "list_files")
+            a = obj.pattern || "*"
+        else if (name === "search_text")
+            a = obj.query || ""
+        else if (name === "get_directory_tree")
+            a = obj.path || ""
+        else if (name === "ask_user")
+            a = obj.question || ""
+        else if (name === "execute_command" || name === "execute_command_background")
+            a = obj.command || ""
+        else if (name === "spawn_agent")
+            a = (obj.agent_type || "general") + ": " + (obj.prompt || "").substring(0, 40)
+        else if (name === "memory")
+            a = (obj.action || "") + " " + (obj.target || "") + ": " + (obj.content || obj.old_text || "").substring(0, 30)
+        else if (name === "set_emotion")
+            a = obj.emotion || ""
+        else if (name === "read_language" || name === "edit_language")
+            a = obj.lang || ""
+        else {
+            var parts = []
+            for (var k in obj) {
+                var v = String(obj[k])
+                if (v.length > 40) v = v.substring(0, 40) + "…"
+                parts.push(v)
+            }
+            a = parts.join(", ")
+        }
+        if (a.length > 80) a = a.substring(0, 80) + "…"
+    } catch (e) {
+        a = String(argsJson || "")
+        if (a.length > 80) a = a.substring(0, 80) + "…"
+    }
+    return a
+}
+
+function toolLineLabel(tool) {
+    var n = tool.toolName || tool.name || ""
+    var a = toolArgsSummary(n, tool.toolArgs || tool.arguments || "")
+    var display = toolDisplayName(n)
+    return a ? (display + " " + a) : display
+}
+
+function emptyMsgFields() {
+    return {
+        imagesJson: "[]",
+        toolName: "",
+        toolArgs: "",
+        toolResult: "",
+        toolsJson: "[]",
+        streaming: false,
+        expanded: false
+    }
+}
+
+function makeToolEntry(toolName, argsJson, result) {
+    return {
+        toolName: toolName || "",
+        toolArgs: argsJson || "",
+        toolResult: result || ""
+    }
+}
+
+function parseToolsJson(s) {
+    try {
+        var arr = JSON.parse(s || "[]")
+        return Array.isArray(arr) ? arr : []
+    } catch (e) {
+        return []
+    }
+}
+
+/**
+ * Collapse consecutive raw tool_call history messages into tool_group rows.
+ * Input: array of history message objects from getHistoryMessages / similar.
+ * Output: array suitable for messageModel.append (with toolsJson).
+ */
+function collapseHistoryMessages(msgs) {
+    var out = []
+    var i = 0
+    while (i < msgs.length) {
+        var m = msgs[i]
+        if (m.role === "tool_call") {
+            var batch = []
+            while (i < msgs.length && msgs[i].role === "tool_call") {
+                batch.push(makeToolEntry(msgs[i].toolName, msgs[i].toolArgs, msgs[i].toolResult))
+                i++
+            }
+            out.push({
+                role: "tool_group",
+                content: summarizeTools(batch),
+                imagesJson: "[]",
+                toolName: "",
+                toolArgs: "",
+                toolResult: "",
+                toolsJson: JSON.stringify(batch),
+                streaming: false,
+                expanded: false
+            })
+        } else {
+            var imgs = m.imagesJson || "[]"
+            if ((!imgs || imgs === "[]") && m.images && m.images.length)
+                imgs = JSON.stringify(m.images)
+            out.push({
+                role: m.role,
+                content: m.content || "",
+                imagesJson: imgs || "[]",
+                toolName: m.toolName || "",
+                toolArgs: m.toolArgs || "",
+                toolResult: m.toolResult || "",
+                toolsJson: "[]",
+                streaming: false,
+                expanded: false
+            })
+            i++
+        }
+    }
+    return out
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -20,15 +20,23 @@ FluentWindow {
 
     // 首页发送给 Blora Agent 的待处理消息（跳转到 Blora Agent 页后消费）
     property string pendingBlorikoMessage: ""
+    property string pendingBlorikoImagesJson: "[]"
 
-    function navigateToBlorikoWithMessage(message) {
+    function navigateToBlorikoWithMessage(message, imagesJson) {
         var text = (message || "").trim()
-        if (text.length === 0) {
+        var imgs = (imagesJson && imagesJson.length > 0) ? imagesJson : "[]"
+        var hasImages = false
+        try {
+            var arr = JSON.parse(imgs)
+            hasImages = arr && arr.length > 0
+        } catch (e) { hasImages = false }
+        if (text.length === 0 && !hasImages) {
             console.log("[Main] navigateToBlorikoWithMessage: 空消息，忽略")
             return
         }
-        console.log("[Main] 跳转 Blora Agent 页处理消息:", text.substring(0, 80))
+        console.log("[Main] 跳转 Blora Agent 页处理消息:", text.substring(0, 80), "images=", imgs)
         pendingBlorikoMessage = text
+        pendingBlorikoImagesJson = imgs
         // currentPage 只更新导航高亮，真正切页需 navigationView.push / safePush
         if (navItems && navItems.length > 1 && navigationView) {
             var blorikoPage = navItems[1].page

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -5,11 +5,14 @@ import QtQuick.Window 2.15
 import Qt.labs.platform 1.1 as Platform
 import RinUI
 import "../components"
+import "../components/ToolCallGroups.js" as ToolGroups
 
 Item {
     id: blorikoPage
 
     // 消息模型
+    // role: user | assistant | tool_group | error | system
+    // tool_group 使用 toolsJson（工具数组 JSON）+ content（汇总文案）
     ListModel { id: messageModel }
     ListModel { id: providerModel }
     ListModel { id: modelModel }
@@ -157,6 +160,101 @@ Item {
         pendingImagesModel.clear()
     }
 
+    function appendUserMessage(text, imagesJson) {
+        messageModel.append({
+            role: "user",
+            content: text || "",
+            imagesJson: imagesJson || "[]",
+            toolName: "",
+            toolArgs: "",
+            toolResult: "",
+            toolsJson: "[]",
+            streaming: false,
+            expanded: false
+        })
+    }
+
+    function findOpenToolGroupIndex() {
+        for (var i = messageModel.count - 1; i >= 0; i--) {
+            var item = messageModel.get(i)
+            if (item.role === "tool_group")
+                return i
+            // 连续工具组只认紧挨着的；若中途有 assistant 正文/错误则新开一组
+            if (item.role === "assistant" || item.role === "user" || item.role === "error" || item.role === "system")
+                break
+        }
+        return -1
+    }
+
+    function ensureToolGroup() {
+        var idx = findOpenToolGroupIndex()
+        if (idx >= 0)
+            return idx
+        messageModel.append({
+            role: "tool_group",
+            content: Backend ? Backend.tr("正在使用工具…") : "正在使用工具…",
+            imagesJson: "[]",
+            toolName: "",
+            toolArgs: "",
+            toolResult: "",
+            toolsJson: "[]",
+            streaming: false,
+            expanded: false
+        })
+        return messageModel.count - 1
+    }
+
+    function refreshToolGroupSummary(idx) {
+        if (idx < 0 || idx >= messageModel.count) return
+        var tools = ToolGroups.parseToolsJson(messageModel.get(idx).toolsJson)
+        var summary = ToolGroups.summarizeTools(tools)
+        if (!summary || summary.length === 0)
+            summary = Backend ? Backend.tr("正在使用工具…") : "正在使用工具…"
+        messageModel.setProperty(idx, "content", summary)
+    }
+
+    function startToolInGroup(toolName, argsJson) {
+        var idx = ensureToolGroup()
+        var tools = ToolGroups.parseToolsJson(messageModel.get(idx).toolsJson)
+        tools.push(ToolGroups.makeToolEntry(toolName, argsJson, ""))
+        messageModel.setProperty(idx, "toolsJson", JSON.stringify(tools))
+        refreshToolGroupSummary(idx)
+        return idx
+    }
+
+    function finishToolInGroup(toolName, argsJson, result) {
+        // 从后往前找未完成的同名工具
+        for (var g = messageModel.count - 1; g >= 0; g--) {
+            var item = messageModel.get(g)
+            if (item.role !== "tool_group") {
+                if (item.role === "assistant" || item.role === "user")
+                    break
+                continue
+            }
+            var tools = ToolGroups.parseToolsJson(item.toolsJson)
+            for (var t = tools.length - 1; t >= 0; t--) {
+                if (tools[t].toolName === toolName && (!tools[t].toolResult || tools[t].toolResult.length === 0)) {
+                    tools[t].toolResult = result || ""
+                    if (argsJson)
+                        tools[t].toolArgs = argsJson
+                    messageModel.setProperty(g, "toolsJson", JSON.stringify(tools))
+                    refreshToolGroupSummary(g)
+                    return
+                }
+            }
+            // 没找到未完成的，追加一条已完成记录
+            tools.push(ToolGroups.makeToolEntry(toolName, argsJson, result))
+            messageModel.setProperty(g, "toolsJson", JSON.stringify(tools))
+            refreshToolGroupSummary(g)
+            return
+        }
+        // 完全没有 group：新建
+        var idx = ensureToolGroup()
+        var tools2 = [ToolGroups.makeToolEntry(toolName, argsJson, result)]
+        messageModel.setProperty(idx, "toolsJson", JSON.stringify(tools2))
+        refreshToolGroupSummary(idx)
+    }
+
     function doSendMessage() {
         if (!Bloriko) return
         if (Bloriko.busy) {
@@ -168,16 +266,7 @@ Item {
         var hasImages = pendingImagesModel.count > 0
         if (text.length === 0 && !hasImages)
             return
-        messageModel.append({
-            role: "user",
-            content: text,
-            imagesJson: imagesJson,
-            toolName: "",
-            toolArgs: "",
-            toolResult: "",
-            streaming: false,
-            expanded: false
-        })
+        appendUserMessage(text, imagesJson)
         beginAwaitingReply()
         Bloriko.sendMessage(text, imagesJson)
         inputField.text = ""
@@ -246,21 +335,9 @@ Item {
         if (!Bloriko) return
         try {
             var msgs = JSON.parse(Bloriko.getHistoryMessages())
-            for (var i = 0; i < msgs.length; i++) {
-                var imgs = msgs[i].imagesJson || "[]"
-                if ((!imgs || imgs === "[]") && msgs[i].images && msgs[i].images.length)
-                    imgs = JSON.stringify(msgs[i].images)
-                messageModel.append({
-                    role: msgs[i].role,
-                    content: msgs[i].content,
-                    imagesJson: imgs || "[]",
-                    toolName: msgs[i].toolName || "",
-                    toolArgs: msgs[i].toolArgs || "",
-                    toolResult: msgs[i].toolResult || "",
-                    streaming: false,
-                    expanded: false
-                })
-            }
+            var collapsed = ToolGroups.collapseHistoryMessages(msgs)
+            for (var i = 0; i < collapsed.length; i++)
+                messageModel.append(collapsed[i])
         } catch(e) {}
     }
 
@@ -297,16 +374,7 @@ Item {
             return
         }
 
-        messageModel.append({
-            role: "user",
-            content: text,
-            imagesJson: imagesJson || "[]",
-            toolName: "",
-            toolArgs: "",
-            toolResult: "",
-            streaming: false,
-            expanded: false
-        })
+        appendUserMessage(text, imagesJson || "[]")
         console.log("[Bloriko] 自动发送首页消息到 Agent")
         beginAwaitingReply()
         Bloriko.sendMessage(text, imagesJson || "[]")
@@ -782,7 +850,8 @@ Item {
                         var h = 0
                         if (role === "user") h = userCol.height + 8
                         else if (role === "assistant") h = aiCol.height + 8
-                        else if (role === "tool_call") h = tcCol.height + (toolResult && toolResult.length > 0 && expanded ? trResultCol.height + 4 : 0) + 4
+                        else if (role === "tool_group") h = tgCol.height + 6
+                        else if (role === "tool_call") h = tcCol.height + 4
                         else if (role === "error") h = errCol.height + 6
                         else if (role === "system") h = sysCol.height + 4
                         return h
@@ -897,7 +966,136 @@ Item {
                         }
                     }
 
-                    // --- 工具调用（含可折叠结果） ---
+                    // --- 连续工具组（Claude Code 风格汇总，可展开明细） ---
+                    Column {
+                        id: tgCol
+                        visible: role === "tool_group"
+                        anchors.left: parent.left; anchors.leftMargin: 44
+                        anchors.right: parent.right; anchors.rightMargin: 16
+                        anchors.top: parent.top; anchors.topMargin: 2
+                        width: parent.width - 60
+                        spacing: 4
+
+                        property var toolList: ToolGroups.parseToolsJson(toolsJson || "[]")
+
+                        RowLayout {
+                            width: parent.width
+                            spacing: 6
+
+                            MouseArea {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: Math.max(tgSummary.implicitHeight, 20)
+                                cursorShape: tgCol.toolList.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                onClicked: {
+                                    if (tgCol.toolList.length > 0)
+                                        messageModel.setProperty(index, "expanded", !expanded)
+                                }
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: 6
+
+                                    Icon {
+                                        icon: "ic_fluent_wrench_20_regular"
+                                        size: 14
+                                        color: Theme.currentTheme.colors.textSecondaryColor
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+
+                                    Text {
+                                        id: tgSummary
+                                        Layout.fillWidth: true
+                                        text: content || (Backend ? Backend.tr("正在使用工具…") : "正在使用工具…")
+                                        font.pixelSize: 12
+                                        color: Theme.currentTheme.colors.textSecondaryColor
+                                        wrapMode: Text.Wrap
+                                    }
+
+                                    Text {
+                                        text: tgCol.toolList.length > 0 ? (expanded ? "▼" : "▶") : ""
+                                        font.pixelSize: 11
+                                        color: Theme.currentTheme.colors.textSecondaryColor
+                                        opacity: 0.6
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+                                }
+                            }
+                        }
+
+                        Column {
+                            visible: expanded && tgCol.toolList.length > 0
+                            width: parent.width
+                            spacing: 4
+
+                            Repeater {
+                                model: tgCol.toolList
+                                delegate: Column {
+                                    width: parent.width
+                                    spacing: 2
+
+                                    RowLayout {
+                                        width: parent.width
+                                        spacing: 6
+                                        Text {
+                                            text: "·"
+                                            font.pixelSize: 12
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            Layout.alignment: Qt.AlignTop
+                                        }
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: ToolGroups.toolLineLabel(modelData)
+                                            font.pixelSize: 11
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            wrapMode: Text.Wrap
+                                            opacity: 0.9
+                                        }
+                                        Text {
+                                            visible: modelData.toolResult && String(modelData.toolResult).length > 0
+                                            text: "✓"
+                                            font.pixelSize: 11
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            opacity: 0.5
+                                            Layout.alignment: Qt.AlignTop
+                                        }
+                                    }
+
+                                    Rectangle {
+                                        visible: modelData.toolResult && String(modelData.toolResult).length > 0
+                                        width: parent.width - 12
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: 12
+                                        height: Math.min(detailTxt.implicitHeight + 10, 100)
+                                        radius: 4
+                                        color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F5F5F5"
+                                        border.color: Theme.currentTheme.colors.controlBorderColor || "#E8E8E8"
+                                        border.width: 1
+                                        clip: true
+
+                                        Text {
+                                            id: detailTxt
+                                            anchors.fill: parent
+                                            anchors.margins: 5
+                                            text: {
+                                                var r = String(modelData.toolResult || "")
+                                                if (r.length > 300)
+                                                    r = r.substring(0, 300) + (Backend ? Backend.tr("\n... (已截断)") : "\n... (已截断)")
+                                                return r
+                                            }
+                                            font.pixelSize: 10
+                                            font.family: "Consolas, monospace"
+                                            color: Theme.currentTheme.colors.textSecondaryColor
+                                            wrapMode: Text.Wrap
+                                            elide: Text.ElideRight
+                                            maximumLineCount: 6
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // --- 兼容旧会话中的单条 tool_call ---
                     Column {
                         id: tcCol
                         visible: role === "tool_call"
@@ -907,142 +1105,21 @@ Item {
                         width: parent.width - 60
                         spacing: 4
 
-                        // 工具调用摘要（始终显示）
                         RowLayout {
                             width: parent.width
-                            Layout.preferredHeight: 20
                             spacing: 6
-
-                            MouseArea {
-                                Layout.fillWidth: true
-                                Layout.preferredHeight: 20
-                                cursorShape: toolResult && toolResult.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
-                                onClicked: {
-                                    if (toolResult && toolResult.length > 0) {
-                                        messageModel.setProperty(index, "expanded", !expanded)
-                                    }
-                                }
-
-                                RowLayout {
-                                    width: parent.width
-                                    spacing: 6
-
-                                    Icon {
-                                        icon: "ic_fluent_lightbulb_20_regular"
-                                        size: 14
-                                        color: Theme.currentTheme.colors.textSecondaryColor
-                                        Layout.alignment: Qt.AlignTop
-                                    }
-
-                                    Text {
-                                        Layout.fillWidth: true
-                                        text: {
-                                            var n = toolName || ""
-                                            var a = ""
-                                            try {
-                                                var obj = JSON.parse(toolArgs || "{}")
-                                                if (n === "read_file") a = obj.path || ""
-                                                else if (n === "write_file") a = obj.path || ""
-                                                else if (n === "edit_file") a = obj.path || ""
-                                                else if (n === "list_files") a = obj.pattern || "*"
-                                                else if (n === "search_text") a = obj.query || ""
-                                                else if (n === "get_directory_tree") a = obj.path || ""
-                                                else if (n === "ask_user") a = obj.question || ""
-                                                else if (n === "execute_command") a = obj.command || ""
-                                                else if (n === "execute_command_background") a = obj.command || ""
-                                                else if (n === "spawn_agent") a = (obj.agent_type || "general") + ": " + (obj.prompt || "").substring(0, 40)
-                                                else if (n === "memory") a = obj.action + " " + obj.target + ": " + (obj.content || obj.old_text || "").substring(0, 30)
-                                                else if (n === "set_emotion") a = obj.emotion || ""
-                                                else {
-                                                    var parts = []
-                                                    for (var k in obj) {
-                                                        var v = String(obj[k])
-                                                        if (v.length > 40) v = v.substring(0, 40) + "…"
-                                                        parts.push(v)
-                                                    }
-                                                    a = parts.join(", ")
-                                                }
-                                                if (a.length > 80) a = a.substring(0, 80) + "…"
-                                            } catch(e) { a = toolArgs || "" }
-
-                                            var nameMap = {
-                                                "read_file": (Backend ? Backend.tr("读取") : "读取"),
-                                                "write_file": (Backend ? Backend.tr("写入") : "写入"),
-                                                "edit_file": (Backend ? Backend.tr("编辑") : "编辑"),
-                                                "list_files": (Backend ? Backend.tr("列出文件") : "列出文件"),
-                                                "search_text": (Backend ? Backend.tr("搜索") : "搜索"),
-                                                "get_directory_tree": (Backend ? Backend.tr("查看目录树") : "查看目录树"),
-                                                "ask_user": (Backend ? Backend.tr("向用户提问") : "向用户提问"),
-                                                "execute_command": (Backend ? Backend.tr("执行命令") : "执行命令"),
-                                                "execute_command_background": (Backend ? Backend.tr("后台执行") : "后台执行"),
-                                                "spawn_agent": (Backend ? Backend.tr("生成子 Agent") : "生成子 Agent"),
-                                                "memory": (Backend ? Backend.tr("管理记忆") : "管理记忆"),
-                                                "set_emotion": (Backend ? Backend.tr("更新情感") : "更新情感")
-                                            }
-                                            var displayName = nameMap[n] || n
-                                            return a ? displayName + " " + a : displayName
-                                        }
-                                        font.pixelSize: 12
-                                        color: Theme.currentTheme.colors.textColor
-                                        opacity: 0.7
-                                        wrapMode: Text.Wrap
-                                    }
-
-                                    Text {
-                                        text: toolResult && toolResult.length > 0 ? (expanded ? "▼" : "▶") : ""
-                                        font.pixelSize: 11
-                                        color: Theme.currentTheme.colors.textColor
-                                        opacity: 0.5
-                                        Layout.alignment: Qt.AlignTop
-                                    }
-                                }
-                            }
-                        }
-
-                        // 工具结果（可折叠）
-                        RowLayout {
-                            id: trResultCol
-                            visible: toolResult && toolResult.length > 0 && expanded
-                            width: parent.width
-                            spacing: 6
-
-                            Text {
-                                text: "└"
-                                font.pixelSize: 11
-                                font.family: "Consolas, monospace"
+                            Icon {
+                                icon: "ic_fluent_lightbulb_20_regular"
+                                size: 14
                                 color: Theme.currentTheme.colors.textSecondaryColor
-                                Layout.alignment: Qt.AlignTop
                             }
-
-                            Rectangle {
+                            Text {
                                 Layout.fillWidth: true
-                                Layout.preferredHeight: Math.min(trResultTxt.contentHeight + 12, 160)
-                                radius: 4
-                                color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F5F5F5"
-                                border.color: Theme.currentTheme.colors.controlBorderColor || "#E8E8E8"
-                                border.width: 1
-
-                                Flickable {
-                                    anchors.fill: parent; anchors.margins: 6
-                                    contentHeight: trResultTxt.contentHeight
-                                    clip: true
-                                    interactive: contentHeight > height
-
-                                    TextEdit {
-                                        id: trResultTxt
-                                        width: parent.width
-                                        text: {
-                                            var r = toolResult || ""
-                                            if (r.length > 500) r = r.substring(0, 500) + (Backend ? Backend.tr("\n... (已截断)") : "\n... (已截断)")
-                                            return r
-                                        }
-                                        font.pixelSize: 11
-                                        font.family: "Consolas, monospace"
-                                        color: Theme.currentTheme.colors.textSecondaryColor
-                                        wrapMode: TextEdit.Wrap
-                                        readOnly: true; selectByMouse: true
-                                    }
-                                }
+                                text: ToolGroups.toolLineLabel({ toolName: toolName, toolArgs: toolArgs })
+                                font.pixelSize: 12
+                                color: Theme.currentTheme.colors.textColor
+                                opacity: 0.7
+                                wrapMode: Text.Wrap
                             }
                         }
                     }
@@ -1782,56 +1859,55 @@ Item {
                 markReplyStarted()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
-                messageModel.set(lastIdx, {role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true})
+                messageModel.set(lastIdx, {
+                    role: "assistant", content: text, imagesJson: "[]",
+                    toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]", streaming: true, expanded: false
+                })
             } else {
-                messageModel.append({role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true, expanded: false})
+                messageModel.append({
+                    role: "assistant", content: text, imagesJson: "[]",
+                    toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]", streaming: true, expanded: false
+                })
             }
             Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallStarted(toolName, argsJson) {
-            // 工具调用也算「已开始产出」，不再显示正在思考
             markReplyStarted()
-            var insertIdx = messageModel.count
-            for (var i = messageModel.count - 1; i >= 0; i--) {
-                var item = messageModel.get(i)
-                if (item.role === "tool_call") {
-                    insertIdx = i + 1
-                    break
-                }
-                if (item.role === "assistant") {
-                    insertIdx = i + 1
-                    break
-                }
-            }
-            messageModel.insert(insertIdx, {role: "tool_call", content: "", toolName: toolName, toolArgs: argsJson, toolResult: "", streaming: false, expanded: false})
+            startToolInGroup(toolName, argsJson)
+            Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallFinished(toolName, argsJson, result) {
-            for (var i = messageModel.count - 1; i >= 0; i--) {
-                var item = messageModel.get(i)
-                if (item.role === "tool_call" && item.toolName === toolName && item.toolResult === "") {
-                    messageModel.set(i, {toolResult: result})
-                    return
-                }
-            }
-            messageModel.append({role: "tool_call", content: "", toolName: toolName, toolArgs: argsJson, toolResult: result, streaming: false, expanded: false})
+            finishToolInGroup(toolName, argsJson, result)
         }
 
         function onErrorOccurred(msg) {
             endAwaitingReply()
-            messageModel.append({role: "error", content: msg, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
+            messageModel.append({
+                role: "error", content: msg, imagesJson: "[]",
+                toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                streaming: false, expanded: false
+            })
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
             markReplyStarted()
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {
-                    messageModel.set(i, {role: "assistant", content: content, streaming: false})
+                    messageModel.set(i, {
+                        role: "assistant", content: content, imagesJson: "[]",
+                        toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                        streaming: false, expanded: false
+                    })
                     return
                 }
             }
-            messageModel.append({role: role, content: content, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
+            messageModel.append({
+                role: role, content: content, imagesJson: "[]",
+                toolName: "", toolArgs: "", toolResult: "", toolsJson: "[]",
+                streaming: false, expanded: false
+            })
         }
 
         function onProvidersChanged() { loadProviders() }

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -604,31 +604,40 @@ Item {
                         }
                     }
 
-                    // 忙碌态：点阵思考球 + 「正在思考」
-                    RowLayout {
-                        spacing: 6
+                    // 忙碌态 / 就绪：淡入淡出切换
+                    Item {
                         Layout.alignment: Qt.AlignVCenter
-                        visible: Bloriko && Bloriko.busy
+                        Layout.preferredWidth: Math.max(topThinking.implicitWidth, readyLabel.implicitWidth)
+                        Layout.preferredHeight: Math.max(topThinking.implicitHeight, readyLabel.implicitHeight)
 
-                        ThinkingOrb {
-                            size: 18
-                            running: visible
-                            state: "composing"
-                            speed: 1.1
-                            ink: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                        ThinkingStatus {
+                            id: topThinking
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: implicitWidth
+                            active: Bloriko && Bloriko.busy
+                            orbSize: 18
+                            orbSpeed: 1.1
+                            orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                            labelColor: Theme.accentColor || "#0078D4"
+                            labelPixelSize: 11
+                            showAvatar: false
+                            showPulseDots: false
+                            fadeMs: 280
                         }
                         Text {
-                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            id: readyLabel
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
-                            color: Theme.accentColor || "#0078D4"
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            opacity: (Bloriko && Bloriko.busy) ? 0 : 1
+                            visible: opacity > 0.01
+                            Behavior on opacity {
+                                NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
+                            }
                         }
-                    }
-                    Text {
-                        visible: !(Bloriko && Bloriko.busy)
-                        text: Backend ? Backend.tr("就绪") : "就绪"
-                        font.pixelSize: 11
-                        color: Theme.currentTheme.colors.textSecondaryColor
-                        Layout.alignment: Qt.AlignVCenter
                     }
 
                     ComboBox {
@@ -670,72 +679,31 @@ Item {
 
                 onCountChanged: Qt.callLater(function() { msgView.positionViewAtEnd() })
 
-                // Agent 忙碌时在列表底部展示「正在思考」动画（不写入 messageModel）
+                // Agent 忙碌时在列表底部展示「正在思考」（淡入淡出，不写入 messageModel）
                 footer: Item {
+                    id: thinkingFooterHost
                     width: msgView.width
-                    height: thinkingFooter.visible ? thinkingFooter.height + 12 : 0
-                    visible: Bloriko && Bloriko.busy
+                    height: thinkingStatus.active || thinkingStatus.opacity > 0.01
+                            ? thinkingStatus.implicitHeight + 16
+                            : 0
+                    Behavior on height {
+                        NumberAnimation { duration: 320; easing.type: Easing.InOutQuad }
+                    }
 
-                    RowLayout {
-                        id: thinkingFooter
+                    ThinkingStatus {
+                        id: thinkingStatus
                         anchors.left: parent.left
-                        anchors.leftMargin: 16
                         anchors.right: parent.right
-                        anchors.rightMargin: 16
                         anchors.top: parent.top
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        spacing: 10
-
-                        Rectangle {
-                            width: 22; height: 22; radius: 11; clip: true; color: "transparent"
-                            Layout.alignment: Qt.AlignVCenter
-                            Image {
-                                anchors.fill: parent
-                                source: Qt.resolvedUrl("../../icon/Bloriko.jpg")
-                                fillMode: Image.PreserveAspectCrop
-                                mipmap: true
-                            }
-                        }
-
-                        ThinkingOrb {
-                            size: 22
-                            running: thinkingFooter.visible
-                            state: "composing"
-                            speed: 1.15
-                            ink: Theme.currentTheme.colors.textColor
-                            Layout.alignment: Qt.AlignVCenter
-                        }
-
-                        Text {
-                            text: Backend ? Backend.tr("正在思考") : "正在思考"
-                            font.pixelSize: 13
-                            color: Theme.currentTheme.colors.textSecondaryColor
-                            Layout.alignment: Qt.AlignVCenter
-                        }
-
-                        // 三点脉冲（补充文字节奏感）
-                        Row {
-                            spacing: 3
-                            Layout.alignment: Qt.AlignVCenter
-                            Repeater {
-                                model: 3
-                                Rectangle {
-                                    width: 4; height: 4; radius: 2
-                                    color: Theme.currentTheme.colors.textSecondaryColor
-                                    opacity: 0.35
-                                    SequentialAnimation on opacity {
-                                        loops: Animation.Infinite
-                                        running: thinkingFooter.visible
-                                        PauseAnimation { duration: index * 160 }
-                                        NumberAnimation { to: 1.0; duration: 320; easing.type: Easing.InOutQuad }
-                                        NumberAnimation { to: 0.35; duration: 320; easing.type: Easing.InOutQuad }
-                                        PauseAnimation { duration: (2 - index) * 160 }
-                                    }
-                                }
-                            }
-                        }
-
-                        Item { Layout.fillWidth: true }
+                        active: Bloriko && Bloriko.busy
+                        orbSize: 22
+                        showAvatar: true
+                        avatarSource: Qt.resolvedUrl("../../icon/Bloriko.jpg")
+                        showPulseDots: true
+                        fadeMs: 320
                     }
 
                     Connections {
@@ -880,38 +848,30 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
-                        // 流式尚未产出文本时：内联思考球 + 文案
-                        RowLayout {
+                        // 流式尚未产出文本时：内联思考状态（淡入淡出）
+                        ThinkingStatus {
                             Layout.fillWidth: true
-                            spacing: 8
-                            visible: streaming && (!content || content.length === 0)
-
-                            ThinkingOrb {
-                                size: 20
-                                running: visible
-                                state: "composing"
-                                speed: 1.1
-                                ink: Theme.currentTheme.colors.textColor
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                            Text {
-                                text: Backend ? Backend.tr("正在思考") : "正在思考"
-                                font.pixelSize: 13
-                                color: Theme.currentTheme.colors.textSecondaryColor
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                            Item { Layout.fillWidth: true }
+                            active: streaming && (!content || content.length === 0)
+                            orbSize: 20
+                            orbSpeed: 1.1
+                            showAvatar: false
+                            showPulseDots: true
+                            fadeMs: 280
                         }
 
                         Text {
                             Layout.fillWidth: true
-                            visible: !(streaming && (!content || content.length === 0))
+                            opacity: (streaming && (!content || content.length === 0)) ? 0 : 1
+                            visible: opacity > 0.01 || (content && content.length > 0)
                             text: content || ""
                             font.pixelSize: 13
                             color: Theme.currentTheme.colors.textColor
                             wrapMode: Text.Wrap
                             textFormat: Text.MarkdownText
                             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
+                            Behavior on opacity {
+                                NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
+                            }
                         }
                     }
 

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -23,6 +23,21 @@ Item {
     property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
     property string voiceState: "idle"  // idle | recording | transcribing
     property int maxPendingImages: 4
+    // 仅在「已请求、但尚未出现任何正文/工具输出」时显示「正在思考」
+    property bool awaitingFirstToken: false
+
+    function beginAwaitingReply() {
+        awaitingFirstToken = true
+    }
+
+    function endAwaitingReply() {
+        awaitingFirstToken = false
+    }
+
+    function markReplyStarted() {
+        if (awaitingFirstToken)
+            awaitingFirstToken = false
+    }
 
     // 情感状态 → emoji 映射
     property var emotionMap: ({
@@ -163,6 +178,7 @@ Item {
             streaming: false,
             expanded: false
         })
+        beginAwaitingReply()
         Bloriko.sendMessage(text, imagesJson)
         inputField.text = ""
         clearPendingImages()
@@ -292,6 +308,7 @@ Item {
             expanded: false
         })
         console.log("[Bloriko] 自动发送首页消息到 Agent")
+        beginAwaitingReply()
         Bloriko.sendMessage(text, imagesJson || "[]")
     }
 
@@ -411,6 +428,7 @@ Item {
                             font.pixelSize: 14
                             onClicked: {
                                 messageModel.clear()
+                                endAwaitingReply()
                                 if (Bloriko) Bloriko.clearHistory()
                             }
                         }
@@ -615,7 +633,7 @@ Item {
                             anchors.left: parent.left
                             anchors.verticalCenter: parent.verticalCenter
                             width: implicitWidth
-                            active: Bloriko && Bloriko.busy
+                            active: blorikoPage.awaitingFirstToken
                             orbSize: 18
                             orbSpeed: 1.1
                             orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
@@ -632,7 +650,7 @@ Item {
                             text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
                             color: Theme.currentTheme.colors.textSecondaryColor
-                            opacity: (Bloriko && Bloriko.busy) ? 0 : 1
+                            opacity: blorikoPage.awaitingFirstToken ? 0 : 1
                             visible: opacity > 0.01
                             Behavior on opacity {
                                 NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
@@ -661,7 +679,11 @@ Item {
                         font.pixelSize: 11
                         Layout.alignment: Qt.AlignVCenter
                         enabled: Bloriko && !Bloriko.busy
-                        onClicked: { messageModel.clear(); if (Bloriko) Bloriko.clearHistory() }
+                        onClicked: {
+                            messageModel.clear()
+                            endAwaitingReply()
+                            if (Bloriko) Bloriko.clearHistory()
+                        }
                     }
                 }
 
@@ -698,7 +720,7 @@ Item {
                         anchors.leftMargin: 16
                         anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        active: Bloriko && Bloriko.busy
+                        active: blorikoPage.awaitingFirstToken
                         orbSize: 22
                         showAvatar: true
                         avatarSource: Qt.resolvedUrl("../../icon/Bloriko.jpg")
@@ -710,7 +732,7 @@ Item {
                         target: Bloriko
                         enabled: Bloriko !== null
                         function onBusyChanged() {
-                            if (Bloriko && Bloriko.busy)
+                            if (Bloriko && Bloriko.busy && blorikoPage.awaitingFirstToken)
                                 Qt.callLater(function() { msgView.positionViewAtEnd() })
                         }
                     }
@@ -720,7 +742,7 @@ Item {
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0 && !(Bloriko && Bloriko.busy)
+                    visible: messageModel.count === 0 && !blorikoPage.awaitingFirstToken
 
                     ColumnLayout {
                         id: emptyCol
@@ -848,10 +870,10 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
-                        // 流式尚未产出文本时：内联思考状态（淡入淡出）
+                        // 首 token 前：内联思考状态；有正文后由 footer 已关闭、此处也不再显示
                         ThinkingStatus {
                             Layout.fillWidth: true
-                            active: streaming && (!content || content.length === 0)
+                            active: blorikoPage.awaitingFirstToken && streaming && (!content || content.length === 0)
                             orbSize: 20
                             orbSpeed: 1.1
                             showAvatar: false
@@ -861,7 +883,7 @@ Item {
 
                         Text {
                             Layout.fillWidth: true
-                            opacity: (streaming && (!content || content.length === 0)) ? 0 : 1
+                            opacity: (blorikoPage.awaitingFirstToken && streaming && (!content || content.length === 0)) ? 0 : 1
                             visible: opacity > 0.01 || (content && content.length > 0)
                             text: content || ""
                             font.pixelSize: 13
@@ -1743,11 +1765,21 @@ Item {
         target: Bloriko; enabled: Bloriko !== null
 
         function onBusyChanged() {
-            if (Bloriko && Bloriko.busy)
+            if (!Bloriko) return
+            if (Bloriko.busy) {
+                // 发送路径已 beginAwaitingReply；若 busy 从外部拉起也补上
+                if (!awaitingFirstToken)
+                    beginAwaitingReply()
                 Qt.callLater(function() { msgView.positionViewAtEnd() })
+            } else {
+                endAwaitingReply()
+            }
         }
 
         function onTextUpdated(text) {
+            // 一旦有流式正文（含空串之后的首段），结束「正在思考」
+            if (text && String(text).length > 0)
+                markReplyStarted()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
                 messageModel.set(lastIdx, {role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true})
@@ -1758,6 +1790,8 @@ Item {
         }
 
         function onToolCallStarted(toolName, argsJson) {
+            // 工具调用也算「已开始产出」，不再显示正在思考
+            markReplyStarted()
             var insertIdx = messageModel.count
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 var item = messageModel.get(i)
@@ -1785,10 +1819,12 @@ Item {
         }
 
         function onErrorOccurred(msg) {
+            endAwaitingReply()
             messageModel.append({role: "error", content: msg, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
+            markReplyStarted()
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {
                     messageModel.set(i, {role: "assistant", content: content, streaming: false})

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -26,20 +26,58 @@ Item {
     property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
     property string voiceState: "idle"  // idle | recording | transcribing
     property int maxPendingImages: 4
-    // 仅在「已请求、但尚未出现任何正文/工具输出」时显示「正在思考」
-    property bool awaitingFirstToken: false
+    // Agent 活动阶段：idle | thinking | replying | working
+    // thinking = 首 token 前；replying = 正在流出正文；working = 调用工具
+    property string agentPhase: "idle"
+    readonly property bool agentActive: agentPhase !== "idle"
+    readonly property bool awaitingFirstToken: agentPhase === "thinking"
+    readonly property string agentPhaseLabel: {
+        if (agentPhase === "thinking")
+            return Backend ? Backend.tr("正在思考") : "正在思考"
+        if (agentPhase === "replying")
+            return Backend ? Backend.tr("正在回复") : "正在回复"
+        if (agentPhase === "working")
+            return Backend ? Backend.tr("正在工作") : "正在工作"
+        return ""
+    }
+    readonly property string agentPhaseOrbState: {
+        if (agentPhase === "working")
+            return "working"
+        if (agentPhase === "replying")
+            return "composing"
+        return "composing"  // thinking
+    }
 
     function beginAwaitingReply() {
-        awaitingFirstToken = true
+        agentPhase = "thinking"
     }
 
     function endAwaitingReply() {
-        awaitingFirstToken = false
+        agentPhase = "idle"
     }
 
+    function setAgentPhase(phase) {
+        if (agentPhase === "idle" && phase !== "thinking" && phase !== "idle") {
+            // 允许从 thinking 进入 replying/working；busy 外不强制
+        }
+        agentPhase = phase
+    }
+
+    function markReplying() {
+        if (agentPhase === "idle")
+            return
+        agentPhase = "replying"
+    }
+
+    function markWorking() {
+        if (agentPhase === "idle")
+            return
+        agentPhase = "working"
+    }
+
+    /** @deprecated 兼容旧调用：首 token 出现后进入「正在回复」 */
     function markReplyStarted() {
-        if (awaitingFirstToken)
-            awaitingFirstToken = false
+        markReplying()
     }
 
     // 情感状态 → emoji 映射
@@ -701,7 +739,9 @@ Item {
                             anchors.left: parent.left
                             anchors.verticalCenter: parent.verticalCenter
                             width: implicitWidth
-                            active: blorikoPage.awaitingFirstToken
+                            active: blorikoPage.agentActive
+                            label: blorikoPage.agentPhaseLabel
+                            orbState: blorikoPage.agentPhaseOrbState
                             orbSize: 18
                             orbSpeed: 1.1
                             orbInk: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
@@ -718,7 +758,7 @@ Item {
                             text: Backend ? Backend.tr("就绪") : "就绪"
                             font.pixelSize: 11
                             color: Theme.currentTheme.colors.textSecondaryColor
-                            opacity: blorikoPage.awaitingFirstToken ? 0 : 1
+                            opacity: blorikoPage.agentActive ? 0 : 1
                             visible: opacity > 0.01
                             Behavior on opacity {
                                 NumberAnimation { duration: 280; easing.type: Easing.InOutQuad }
@@ -769,7 +809,7 @@ Item {
 
                 onCountChanged: Qt.callLater(function() { msgView.positionViewAtEnd() })
 
-                // Agent 忙碌时在列表底部展示「正在思考」（淡入淡出，不写入 messageModel）
+                // 列表底部活动状态：思考 / 回复 / 工作（淡入淡出）
                 footer: Item {
                     id: thinkingFooterHost
                     width: msgView.width
@@ -788,7 +828,9 @@ Item {
                         anchors.leftMargin: 16
                         anchors.rightMargin: 16
                         anchors.topMargin: 8
-                        active: blorikoPage.awaitingFirstToken
+                        active: blorikoPage.agentActive
+                        label: blorikoPage.agentPhaseLabel
+                        orbState: blorikoPage.agentPhaseOrbState
                         orbSize: 22
                         showAvatar: true
                         avatarSource: Qt.resolvedUrl("../../icon/Bloriko.jpg")
@@ -800,7 +842,7 @@ Item {
                         target: Bloriko
                         enabled: Bloriko !== null
                         function onBusyChanged() {
-                            if (Bloriko && Bloriko.busy && blorikoPage.awaitingFirstToken)
+                            if (Bloriko && Bloriko.busy && blorikoPage.agentActive)
                                 Qt.callLater(function() { msgView.positionViewAtEnd() })
                         }
                     }
@@ -810,7 +852,7 @@ Item {
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0 && !blorikoPage.awaitingFirstToken
+                    visible: messageModel.count === 0 && !blorikoPage.agentActive
 
                     ColumnLayout {
                         id: emptyCol
@@ -939,10 +981,13 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
-                        // 首 token 前：内联思考状态；有正文后由 footer 已关闭、此处也不再显示
+                        // 流式气泡内：仅在「正在思考」且尚无正文时显示内联状态；
+                        // 出字后由列表 footer 显示「正在回复」，气泡只渲染正文
                         ThinkingStatus {
                             Layout.fillWidth: true
                             active: blorikoPage.awaitingFirstToken && streaming && (!content || content.length === 0)
+                            label: blorikoPage.agentPhaseLabel
+                            orbState: blorikoPage.agentPhaseOrbState
                             orbSize: 20
                             orbSpeed: 1.1
                             showAvatar: false
@@ -1844,8 +1889,8 @@ Item {
         function onBusyChanged() {
             if (!Bloriko) return
             if (Bloriko.busy) {
-                // 发送路径已 beginAwaitingReply；若 busy 从外部拉起也补上
-                if (!awaitingFirstToken)
+                // 发送路径已 beginAwaitingReply；若 busy 从外部拉起也进入 thinking
+                if (agentPhase === "idle")
                     beginAwaitingReply()
                 Qt.callLater(function() { msgView.positionViewAtEnd() })
             } else {
@@ -1854,9 +1899,9 @@ Item {
         }
 
         function onTextUpdated(text) {
-            // 一旦有流式正文（含空串之后的首段），结束「正在思考」
+            // 有正文 → 「正在回复」（不再显示「正在思考」）
             if (text && String(text).length > 0)
-                markReplyStarted()
+                markReplying()
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
                 messageModel.set(lastIdx, {
@@ -1873,13 +1918,16 @@ Item {
         }
 
         function onToolCallStarted(toolName, argsJson) {
-            markReplyStarted()
+            markWorking()
             startToolInGroup(toolName, argsJson)
             Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallFinished(toolName, argsJson, result) {
             finishToolInGroup(toolName, argsJson, result)
+            // 工具结束后若仍 busy，回到「正在回复」等待后续正文；若已 idle 由 onBusyChanged 清理
+            if (Bloriko && Bloriko.busy && agentPhase === "working")
+                markReplying()
         }
 
         function onErrorOccurred(msg) {
@@ -1892,7 +1940,11 @@ Item {
         }
 
         function onMessageAdded(role, content, toolCallsJson) {
-            markReplyStarted()
+            // 最终 assistant 落盘：若仍 busy 显示「正在回复」，否则结束
+            if (Bloriko && Bloriko.busy)
+                markReplying()
+            else
+                endAwaitingReply()
             for (var i = messageModel.count - 1; i >= 0; i--) {
                 if (messageModel.get(i).role === "assistant" && messageModel.get(i).streaming) {
                     messageModel.set(i, {

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -256,11 +256,18 @@ Item {
             return
         }
         var text = (win.pendingBlorikoMessage || "").trim()
-        if (text.length === 0)
+        var imagesJson = win.pendingBlorikoImagesJson || "[]"
+        var hasImages = false
+        try {
+            var arr = JSON.parse(imagesJson)
+            hasImages = arr && arr.length > 0
+        } catch (e) { hasImages = false }
+        if (text.length === 0 && !hasImages)
             return
 
-        console.log("[Bloriko] 收到首页待处理消息:", text.substring(0, 80))
+        console.log("[Bloriko] 收到首页待处理消息:", text.substring(0, 80), "images=", imagesJson)
         win.pendingBlorikoMessage = ""
+        win.pendingBlorikoImagesJson = "[]"
 
         if (!Bloriko) {
             console.error("[Bloriko] processPendingHomeMessage: Bloriko 后端不可用")
@@ -269,6 +276,7 @@ Item {
         if (Bloriko.busy) {
             console.warn("[Bloriko] Agent 正忙，延迟重试首页消息")
             win.pendingBlorikoMessage = text
+            win.pendingBlorikoImagesJson = imagesJson
             pendingMessageRetryTimer.restart()
             return
         }
@@ -276,7 +284,7 @@ Item {
         messageModel.append({
             role: "user",
             content: text,
-            imagesJson: "[]",
+            imagesJson: imagesJson || "[]",
             toolName: "",
             toolArgs: "",
             toolResult: "",
@@ -284,7 +292,7 @@ Item {
             expanded: false
         })
         console.log("[Bloriko] 自动发送首页消息到 Agent")
-        Bloriko.sendMessage(text)
+        Bloriko.sendMessage(text, imagesJson || "[]")
     }
 
     Component.onCompleted: {
@@ -1720,10 +1728,14 @@ Item {
         }
 
         function onTranscriptionReady(text) {
-            appendTranscription(text)
+            // 仅当前页可见时写入，避免与首页输入条抢结果
+            if (blorikoPage.visible)
+                appendTranscription(text)
         }
 
         function onTranscriptionFailed(msg) {
+            if (!blorikoPage.visible)
+                return
             messageModel.append({
                 role: "error",
                 content: msg || (Backend ? Backend.tr("语音识别失败") : "语音识别失败"),

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -604,10 +604,30 @@ Item {
                         }
                     }
 
+                    // 忙碌态：点阵思考球 + 「正在思考」
+                    RowLayout {
+                        spacing: 6
+                        Layout.alignment: Qt.AlignVCenter
+                        visible: Bloriko && Bloriko.busy
+
+                        ThinkingOrb {
+                            size: 18
+                            running: visible
+                            state: "composing"
+                            speed: 1.1
+                            ink: Theme.accentColor || Theme.currentTheme.colors.primaryColor || "#0078D4"
+                        }
+                        Text {
+                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            font.pixelSize: 11
+                            color: Theme.accentColor || "#0078D4"
+                        }
+                    }
                     Text {
-                        text: Bloriko && Bloriko.busy ? (Backend ? Backend.tr("思考中...") : "思考中...") : (Backend ? Backend.tr("就绪") : "就绪")
+                        visible: !(Bloriko && Bloriko.busy)
+                        text: Backend ? Backend.tr("就绪") : "就绪"
                         font.pixelSize: 11
-                        color: Bloriko && Bloriko.busy ? (Theme.accentColor || "#0078D4") : Theme.currentTheme.colors.textSecondaryColor
+                        color: Theme.currentTheme.colors.textSecondaryColor
                         Layout.alignment: Qt.AlignVCenter
                     }
 
@@ -650,11 +670,89 @@ Item {
 
                 onCountChanged: Qt.callLater(function() { msgView.positionViewAtEnd() })
 
+                // Agent 忙碌时在列表底部展示「正在思考」动画（不写入 messageModel）
+                footer: Item {
+                    width: msgView.width
+                    height: thinkingFooter.visible ? thinkingFooter.height + 12 : 0
+                    visible: Bloriko && Bloriko.busy
+
+                    RowLayout {
+                        id: thinkingFooter
+                        anchors.left: parent.left
+                        anchors.leftMargin: 16
+                        anchors.right: parent.right
+                        anchors.rightMargin: 16
+                        anchors.top: parent.top
+                        anchors.topMargin: 8
+                        spacing: 10
+
+                        Rectangle {
+                            width: 22; height: 22; radius: 11; clip: true; color: "transparent"
+                            Layout.alignment: Qt.AlignVCenter
+                            Image {
+                                anchors.fill: parent
+                                source: Qt.resolvedUrl("../../icon/Bloriko.jpg")
+                                fillMode: Image.PreserveAspectCrop
+                                mipmap: true
+                            }
+                        }
+
+                        ThinkingOrb {
+                            size: 22
+                            running: thinkingFooter.visible
+                            state: "composing"
+                            speed: 1.15
+                            ink: Theme.currentTheme.colors.textColor
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        Text {
+                            text: Backend ? Backend.tr("正在思考") : "正在思考"
+                            font.pixelSize: 13
+                            color: Theme.currentTheme.colors.textSecondaryColor
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        // 三点脉冲（补充文字节奏感）
+                        Row {
+                            spacing: 3
+                            Layout.alignment: Qt.AlignVCenter
+                            Repeater {
+                                model: 3
+                                Rectangle {
+                                    width: 4; height: 4; radius: 2
+                                    color: Theme.currentTheme.colors.textSecondaryColor
+                                    opacity: 0.35
+                                    SequentialAnimation on opacity {
+                                        loops: Animation.Infinite
+                                        running: thinkingFooter.visible
+                                        PauseAnimation { duration: index * 160 }
+                                        NumberAnimation { to: 1.0; duration: 320; easing.type: Easing.InOutQuad }
+                                        NumberAnimation { to: 0.35; duration: 320; easing.type: Easing.InOutQuad }
+                                        PauseAnimation { duration: (2 - index) * 160 }
+                                    }
+                                }
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    Connections {
+                        target: Bloriko
+                        enabled: Bloriko !== null
+                        function onBusyChanged() {
+                            if (Bloriko && Bloriko.busy)
+                                Qt.callLater(function() { msgView.positionViewAtEnd() })
+                        }
+                    }
+                }
+
                 // 空状态
                 Item {
                     anchors.centerIn: parent
                     width: 280; height: emptyCol.implicitHeight
-                    visible: messageModel.count === 0
+                    visible: messageModel.count === 0 && !(Bloriko && Bloriko.busy)
 
                     ColumnLayout {
                         id: emptyCol
@@ -782,9 +880,33 @@ Item {
                             Image { anchors.fill: parent; source: Qt.resolvedUrl("../../icon/Bloriko.jpg"); fillMode: Image.PreserveAspectCrop; mipmap: true }
                         }
 
+                        // 流式尚未产出文本时：内联思考球 + 文案
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            visible: streaming && (!content || content.length === 0)
+
+                            ThinkingOrb {
+                                size: 20
+                                running: visible
+                                state: "composing"
+                                speed: 1.1
+                                ink: Theme.currentTheme.colors.textColor
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            Text {
+                                text: Backend ? Backend.tr("正在思考") : "正在思考"
+                                font.pixelSize: 13
+                                color: Theme.currentTheme.colors.textSecondaryColor
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                            Item { Layout.fillWidth: true }
+                        }
+
                         Text {
                             Layout.fillWidth: true
-                            text: content || "..."
+                            visible: !(streaming && (!content || content.length === 0))
+                            text: content || ""
                             font.pixelSize: 13
                             color: Theme.currentTheme.colors.textColor
                             wrapMode: Text.Wrap
@@ -1660,6 +1782,11 @@ Item {
     Connections {
         target: Bloriko; enabled: Bloriko !== null
 
+        function onBusyChanged() {
+            if (Bloriko && Bloriko.busy)
+                Qt.callLater(function() { msgView.positionViewAtEnd() })
+        }
+
         function onTextUpdated(text) {
             var lastIdx = messageModel.count - 1
             if (lastIdx >= 0 && messageModel.get(lastIdx).role === "assistant" && messageModel.get(lastIdx).streaming) {
@@ -1667,6 +1794,7 @@ Item {
             } else {
                 messageModel.append({role: "assistant", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: true, expanded: false})
             }
+            Qt.callLater(function() { msgView.positionViewAtEnd() })
         }
 
         function onToolCallStarted(toolName, argsJson) {

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -1302,6 +1302,16 @@ Item {
                 Layout.fillWidth: true
                 model: modelModel
                 textRole: "name"
+                // 选中即写入，避免仅依赖「确定」时 loadModels 冲掉索引
+                onActivated: function(index) {
+                    if (index < 0 || index >= modelModel.count) return
+                    var m = modelModel.get(index)
+                    if (Backend) Backend.setGlobalAIModel(m.id)
+                    if (Bloriko && typeof Bloriko.setModel === "function")
+                        Bloriko.setModel(m.id)
+                    modelCombo.currentIndex = index
+                    updateCurrentModelLabel()
+                }
             }
             RowLayout {
                 Layout.fillWidth: true
@@ -1317,16 +1327,36 @@ Item {
                     highlighted: true
                     Layout.fillWidth: true
                     onClicked: {
+                        // 先记下用户选中的模型 id，再改供应商/刷新列表。
+                        // 若先 loadModels() 会 clear ListModel，ComboBox 索引被重置，导致无法切换模型。
+                        var selectedModelId = ""
+                        var selectedModelIndex = modelComboDlg.currentIndex
+                        if (selectedModelIndex >= 0 && selectedModelIndex < modelModel.count) {
+                            selectedModelId = modelModel.get(selectedModelIndex).id || ""
+                        }
+
                         if (providerComboDlg.currentIndex >= 0 && providerComboDlg.currentIndex < providerModel.count) {
                             var p = providerModel.get(providerComboDlg.currentIndex)
                             if (Backend) Backend.setGlobalAIProvider(p.key)
                             providerCombo.currentIndex = providerComboDlg.currentIndex
                         }
+
+                        if (selectedModelId.length > 0) {
+                            if (Backend) Backend.setGlobalAIModel(selectedModelId)
+                            if (Bloriko && typeof Bloriko.setModel === "function")
+                                Bloriko.setModel(selectedModelId)
+                        }
+
                         loadModels()
-                        if (modelComboDlg.currentIndex >= 0 && modelComboDlg.currentIndex < modelModel.count) {
-                            var m = modelModel.get(modelComboDlg.currentIndex)
-                            if (Backend) Backend.setGlobalAIModel(m.id)
-                            modelCombo.currentIndex = modelComboDlg.currentIndex
+                        // loadModels 后按已写入的全局模型对齐索引与胶囊文案
+                        if (selectedModelId.length > 0) {
+                            for (var i = 0; i < modelModel.count; i++) {
+                                if (modelModel.get(i).id === selectedModelId) {
+                                    modelCombo.currentIndex = i
+                                    modelComboDlg.currentIndex = i
+                                    break
+                                }
+                            }
                         }
                         updateCurrentModelLabel()
                         modelSelectDlg.close()

--- a/qml/pages/BlorikoPage.qml
+++ b/qml/pages/BlorikoPage.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
 import QtQuick.Window 2.15
+import Qt.labs.platform 1.1 as Platform
 import RinUI
 import "../components"
 
@@ -14,10 +15,14 @@ Item {
     ListModel { id: modelModel }
     ListModel { id: roleModel }
     ListModel { id: historyListModel }
+    ListModel { id: pendingImagesModel }
 
     property bool historyPanelOpen: false
     property string conversationTitle: ""
     property string currentEmotion: "neutral"
+    property string currentModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
+    property string voiceState: "idle"  // idle | recording | transcribing
+    property int maxPendingImages: 4
 
     // 情感状态 → emoji 映射
     property var emotionMap: ({
@@ -63,18 +68,114 @@ Item {
             for (var i = 0; i < models.length; i++)
                 modelModel.append(models[i])
             // 根据全局设置选中当前模型
+            var selected = false
             if (Backend) {
                 var globalModel = Backend.getGlobalAIModel()
                 for (var j = 0; j < modelModel.count; j++) {
                     if (modelModel.get(j).id === globalModel) {
-                        modelCombo.currentIndex = j
-                        return
+                        if (modelCombo) modelCombo.currentIndex = j
+                        selected = true
+                        break
                     }
                 }
             }
-            if (modelCombo.currentIndex < 0 && modelModel.count > 0)
-                modelCombo.currentIndex = 0
+            if (!selected && modelModel.count > 0) {
+                if (modelCombo) modelCombo.currentIndex = 0
+            }
+            updateCurrentModelLabel()
         } catch(e) { console.error("[Bloriko] loadModels error:", e) }
+    }
+
+    function updateCurrentModelLabel() {
+        if (modelModel.count > 0 && modelCombo && modelCombo.currentIndex >= 0 && modelCombo.currentIndex < modelModel.count) {
+            currentModelLabel = modelModel.get(modelCombo.currentIndex).name || modelModel.get(modelCombo.currentIndex).id || (Backend ? Backend.tr("选择模型") : "选择模型")
+            return
+        }
+        if (Bloriko && typeof Bloriko.getCurrentModelName === "function") {
+            var n = Bloriko.getCurrentModelName()
+            if (n && n.length > 0) {
+                currentModelLabel = n
+                return
+            }
+        }
+        currentModelLabel = Backend ? Backend.tr("选择模型") : "选择模型"
+    }
+
+    function pathFromFileUrl(url) {
+        var s = (url || "").toString()
+        if (s.indexOf("file://") === 0) {
+            s = decodeURIComponent(s.substring(Qt.platform.os === "windows" ? 8 : 7))
+        }
+        return s
+    }
+
+    function fileUrlFromPath(path) {
+        if (!path) return ""
+        var s = path.toString()
+        if (s.indexOf("file://") === 0) return s
+        if (Qt.platform.os === "windows")
+            return "file:///" + s.replace(/\\/g, "/")
+        return "file://" + s
+    }
+
+    function pendingImagesJson() {
+        var arr = []
+        for (var i = 0; i < pendingImagesModel.count; i++)
+            arr.push(pendingImagesModel.get(i).path)
+        return JSON.stringify(arr)
+    }
+
+    function addPendingImage(path) {
+        if (!path || path.length === 0) return
+        if (pendingImagesModel.count >= maxPendingImages) {
+            console.warn("[Bloriko] 已达最大图片数", maxPendingImages)
+            return
+        }
+        for (var i = 0; i < pendingImagesModel.count; i++) {
+            if (pendingImagesModel.get(i).path === path)
+                return
+        }
+        pendingImagesModel.append({ path: path, previewUrl: fileUrlFromPath(path) })
+    }
+
+    function clearPendingImages() {
+        pendingImagesModel.clear()
+    }
+
+    function doSendMessage() {
+        if (!Bloriko) return
+        if (Bloriko.busy) {
+            Bloriko.cancelAgent()
+            return
+        }
+        var text = inputField.text.trim()
+        var imagesJson = pendingImagesJson()
+        var hasImages = pendingImagesModel.count > 0
+        if (text.length === 0 && !hasImages)
+            return
+        messageModel.append({
+            role: "user",
+            content: text,
+            imagesJson: imagesJson,
+            toolName: "",
+            toolArgs: "",
+            toolResult: "",
+            streaming: false,
+            expanded: false
+        })
+        Bloriko.sendMessage(text, imagesJson)
+        inputField.text = ""
+        clearPendingImages()
+    }
+
+    function appendTranscription(text) {
+        if (!text || text.length === 0) return
+        var cur = inputField.text || ""
+        if (cur.length > 0 && !/\s$/.test(cur))
+            cur += " "
+        inputField.text = cur + text
+        inputField.cursorPosition = inputField.text.length
+        inputField.forceActiveFocus()
     }
 
     function loadRoles() {
@@ -130,9 +231,13 @@ Item {
         try {
             var msgs = JSON.parse(Bloriko.getHistoryMessages())
             for (var i = 0; i < msgs.length; i++) {
+                var imgs = msgs[i].imagesJson || "[]"
+                if ((!imgs || imgs === "[]") && msgs[i].images && msgs[i].images.length)
+                    imgs = JSON.stringify(msgs[i].images)
                 messageModel.append({
                     role: msgs[i].role,
                     content: msgs[i].content,
+                    imagesJson: imgs || "[]",
                     toolName: msgs[i].toolName || "",
                     toolArgs: msgs[i].toolArgs || "",
                     toolResult: msgs[i].toolResult || "",
@@ -171,6 +276,7 @@ Item {
         messageModel.append({
             role: "user",
             content: text,
+            imagesJson: "[]",
             toolName: "",
             toolArgs: "",
             toolResult: "",
@@ -185,7 +291,11 @@ Item {
         console.log("[Bloriko] onCompleted, Bloriko:", Bloriko)
         loadProviders()
         loadRoles()
-        if (Bloriko) Bloriko.loadLatestSession()
+        updateCurrentModelLabel()
+        if (Bloriko) {
+            voiceState = Bloriko.voiceState || "idle"
+            Bloriko.loadLatestSession()
+        }
         // 延迟重试：防止上下文属性延迟加载导致数据为空
         retryTimer.start()
         // 页面首次加载后处理首页跳转消息（在会话加载之后）
@@ -588,11 +698,52 @@ Item {
                         visible: role === "user"
                         anchors.right: parent.right; anchors.rightMargin: 16
                         anchors.top: parent.top; anchors.topMargin: 4
-                        width: Math.min(Math.max(userTxt.implicitWidth + 24, 50), parent.width * 0.65)
-                        spacing: 0
+                        width: Math.min(Math.max(
+                            Math.max(userTxt.implicitWidth + 24, userImagesRow.visible ? 120 : 0),
+                            50
+                        ), parent.width * 0.65)
+                        spacing: 6
+
+                        // 图片附件预览
+                        Flow {
+                            id: userImagesRow
+                            width: parent.width
+                            spacing: 4
+                            visible: {
+                                try {
+                                    var arr = JSON.parse(imagesJson || "[]")
+                                    return arr && arr.length > 0
+                                } catch (e) { return false }
+                            }
+                            property var imageList: {
+                                try { return JSON.parse(imagesJson || "[]") } catch (e) { return [] }
+                            }
+                            Repeater {
+                                model: userImagesRow.imageList
+                                delegate: Rectangle {
+                                    width: 88; height: 88
+                                    radius: 8
+                                    color: "#00000022"
+                                    clip: true
+                                    Image {
+                                        anchors.fill: parent
+                                        source: {
+                                            var p = modelData || ""
+                                            if (!p) return ""
+                                            if (p.indexOf("file://") === 0 || p.indexOf("data:") === 0) return p
+                                            return blorikoPage.fileUrlFromPath(p)
+                                        }
+                                        fillMode: Image.PreserveAspectCrop
+                                        asynchronous: true
+                                    }
+                                }
+                            }
+                        }
 
                         Rectangle {
-                            width: parent.width; height: userTxt.contentHeight + 16
+                            width: parent.width
+                            height: (content && content.length > 0) ? (userTxt.contentHeight + 16) : 0
+                            visible: content && content.length > 0
                             radius: 8
                             color: Theme.accentColor || "#0078D4"
 
@@ -827,14 +978,13 @@ Item {
                 }
             }
 
-            // ===== 输入栏 =====
+            // ===== 输入栏（图示一体圆角卡片） =====
             Rectangle {
                 Layout.fillWidth: true
-                Layout.preferredHeight: (Bloriko && Bloriko.busy ? progressBar.height + 4 : 0) + inputRow.implicitHeight + 16
+                Layout.preferredHeight: (Bloriko && Bloriko.busy ? progressBar.height + 4 : 0) + inputCard.implicitHeight + 20
                 color: Theme.currentTheme.colors.cardColor || "#FFFFFF"
                 Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: Theme.currentTheme.colors.controlBorderColor }
 
-                // 生成中的进度条
                 ProgressBar {
                     id: progressBar
                     anchors.top: parent.top; anchors.topMargin: 1
@@ -843,93 +993,335 @@ Item {
                     visible: Bloriko && Bloriko.busy
                 }
 
-                ColumnLayout {
-                    id: inputRow
-                    anchors.fill: parent; anchors.margins: 8; anchors.leftMargin: 12; anchors.rightMargin: 12
-                    spacing: 6
+                // 一体输入卡片
+                Rectangle {
+                    id: inputCard
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: 10
+                    anchors.topMargin: Bloriko && Bloriko.busy ? progressBar.height + 8 : 10
+                    implicitHeight: inputCardCol.implicitHeight + 16
+                    radius: 22
+                    color: Theme.currentTheme.colors.controlColor || Theme.currentTheme.colors.cardColor || "#FFFFFF"
+                    border.color: inputField.activeFocus
+                        ? (Theme.accentColor || "#0078D4")
+                        : (Theme.currentTheme.colors.controlBorderColor || "#E0E0E0")
+                    border.width: 1
 
-                    RowLayout {
-                        Layout.fillWidth: true; spacing: 8
+                    ColumnLayout {
+                        id: inputCardCol
+                        anchors.fill: parent
+                        anchors.margins: 10
+                        spacing: 8
 
-                        ComboBox {
-                            id: providerCombo
-                            Layout.preferredWidth: 130
-                            model: providerModel; textRole: "name"
-                            font.pixelSize: 10
-                            enabled: Bloriko && !Bloriko.busy
-                            onActivated: function(index) {
-                                var item = providerModel.get(index)
-                                // 写入全局配置，所有 AI 功能同步
-                                if (Backend) Backend.setGlobalAIProvider(item.key)
-                                loadModels()
-                            }
-                        }
-
-                        ComboBox {
-                            id: modelCombo
+                        // 待发送图片预览
+                        Flow {
                             Layout.fillWidth: true
-                            model: modelModel; textRole: "name"
-                            font.pixelSize: 10
-                            enabled: Bloriko && !Bloriko.busy && modelModel.count > 0
-                            onActivated: function(index) {
-                                if (modelModel.count > 0 && Backend)
-                                    Backend.setGlobalAIModel(modelModel.get(index).id)
-                            }
-                        }
-                    }
+                            spacing: 6
+                            visible: pendingImagesModel.count > 0
 
-                    RowLayout {
-                        Layout.fillWidth: true; spacing: 8
-
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: Math.max(inputField.implicitHeight + 12, 36)
-                            radius: 8
-                            color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
-                            border.color: inputField.activeFocus ? (Theme.accentColor || "#0078D4") : (Theme.currentTheme.colors.controlBorderColor || "#E0E0E0")
-                            border.width: 1
-
-                            TextArea {
-                                id: inputField
-                                anchors.fill: parent; anchors.margins: 6
-                                placeholderText: (Backend ? Backend.tr("向 Blora Agent 说些什么... (Enter 发送, Shift+Enter 换行)") : "向 Blora Agent 说些什么... (Enter 发送, Shift+Enter 换行)")
-                                wrapMode: TextArea.Wrap
-                                font.pixelSize: 13
-                                color: Theme.currentTheme.colors.textColor
-                                enabled: Bloriko && !Bloriko.busy
-                                background: Item {}
-
-                                Keys.onPressed: function(event) {
-                                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                        if (event.modifiers & Qt.ShiftModifier) {
-                                            inputField.insert(inputField.cursorPosition, "\n")
-                                        } else {
-                                            sendBtn.clicked(); event.accepted = true
+                            Repeater {
+                                model: pendingImagesModel
+                                delegate: Item {
+                                    width: 64; height: 64
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        radius: 10
+                                        color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                                        clip: true
+                                        Image {
+                                            anchors.fill: parent
+                                            source: model.previewUrl
+                                            fillMode: Image.PreserveAspectCrop
+                                            asynchronous: true
                                         }
+                                    }
+                                    RoundButton {
+                                        anchors.top: parent.top
+                                        anchors.right: parent.right
+                                        anchors.margins: -4
+                                        width: 20; height: 20
+                                        flat: true
+                                        icon.name: "ic_fluent_dismiss_20_regular"
+                                        font.pixelSize: 10
+                                        onClicked: pendingImagesModel.remove(index)
                                     }
                                 }
                             }
                         }
 
-                        Button {
-                            id: sendBtn
-                            icon.name: Bloriko && Bloriko.busy ? "ic_fluent_stop_20_regular" : "ic_fluent_send_20_regular"
-                            Layout.preferredWidth: 36; Layout.preferredHeight: 36
-                            highlighted: true
-                            enabled: {
-                                if (!Bloriko) return false
-                                if (Bloriko.busy) return true
-                                return inputField.text.trim().length > 0
-                            }
-                            onClicked: {
-                                if (Bloriko.busy) { Bloriko.cancelAgent(); return }
-                                var text = inputField.text.trim()
-                                if (text.length === 0) return
-                                messageModel.append({role: "user", content: text, toolName: "", toolArgs: "", toolResult: "", streaming: false, expanded: false})
-                                Bloriko.sendMessage(text)
-                                inputField.text = ""
+                        TextArea {
+                            id: inputField
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Math.min(Math.max(implicitHeight, 28), 120)
+                            placeholderText: (Backend ? Backend.tr("向 Blora Agent 说些什么...") : "向 Blora Agent 说些什么...")
+                            wrapMode: TextArea.Wrap
+                            font.pixelSize: 14
+                            color: Theme.currentTheme.colors.textColor
+                            enabled: Bloriko && !Bloriko.busy
+                            background: Item {}
+                            topPadding: 2
+                            bottomPadding: 2
+                            leftPadding: 4
+                            rightPadding: 4
+
+                            Keys.onPressed: function(event) {
+                                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                    if (event.modifiers & Qt.ShiftModifier) {
+                                        inputField.insert(inputField.cursorPosition, "\n")
+                                    } else {
+                                        doSendMessage()
+                                        event.accepted = true
+                                    }
+                                }
                             }
                         }
+
+                        // 底栏：+ | 模型胶囊 | spacer | mic | send
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            RoundButton {
+                                id: addImageBtn
+                                Layout.preferredWidth: 32
+                                Layout.preferredHeight: 32
+                                flat: true
+                                icon.name: "ic_fluent_add_20_regular"
+                                enabled: Bloriko && !Bloriko.busy && pendingImagesModel.count < maxPendingImages
+                                ToolTip.visible: hovered
+                                ToolTip.text: Backend ? Backend.tr("添加图片") : "添加图片"
+                                ToolTip.delay: 400
+                                onClicked: imageFileDialog.open()
+                            }
+
+                            // 模型胶囊（单击打开模型切换对话框）
+                            Rectangle {
+                                id: modelPill
+                                Layout.preferredHeight: 32
+                                Layout.preferredWidth: Math.min(modelPillRow.implicitWidth + 16, 180)
+                                Layout.maximumWidth: 200
+                                radius: 16
+                                color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                                border.color: Theme.currentTheme.colors.controlBorderColor || "#E0E0E0"
+                                border.width: 1
+                                opacity: Bloriko && !Bloriko.busy ? 1.0 : 0.55
+
+                                RowLayout {
+                                    id: modelPillRow
+                                    anchors.centerIn: parent
+                                    anchors.leftMargin: 8
+                                    anchors.rightMargin: 8
+                                    spacing: 4
+                                    Icon {
+                                        icon: "ic_fluent_lightbulb_20_regular"
+                                        size: 14
+                                        color: Theme.currentTheme.colors.textColor
+                                    }
+                                    Text {
+                                        text: currentModelLabel
+                                        font.pixelSize: 12
+                                        color: Theme.currentTheme.colors.textColor
+                                        elide: Text.ElideRight
+                                        Layout.maximumWidth: 140
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    enabled: Bloriko && !Bloriko.busy
+                                    onClicked: modelSelectDlg.open()
+                                }
+                            }
+
+                            Item { Layout.fillWidth: true }
+
+                            RoundButton {
+                                id: micBtn
+                                Layout.preferredWidth: 32
+                                Layout.preferredHeight: 32
+                                flat: true
+                                icon.name: voiceState === "recording"
+                                    ? "ic_fluent_mic_record_20_filled"
+                                    : (voiceState === "transcribing"
+                                        ? "ic_fluent_spinner_ios_20_regular"
+                                        : "ic_fluent_mic_20_regular")
+                                highlighted: voiceState === "recording"
+                                enabled: Bloriko && !Bloriko.busy && voiceState !== "transcribing"
+                                ToolTip.visible: hovered
+                                ToolTip.text: {
+                                    if (voiceState === "recording")
+                                        return Backend ? Backend.tr("录音中，再次点击结束") : "录音中，再次点击结束"
+                                    if (voiceState === "transcribing")
+                                        return Backend ? Backend.tr("识别中...") : "识别中..."
+                                    return Backend ? Backend.tr("语音输入") : "语音输入"
+                                }
+                                ToolTip.delay: 400
+                                onClicked: {
+                                    if (!Bloriko) return
+                                    if (voiceState === "recording")
+                                        Bloriko.stopVoiceCaptureAndTranscribe()
+                                    else if (voiceState === "idle")
+                                        Bloriko.startVoiceCapture()
+                                }
+                            }
+
+                            RoundButton {
+                                id: sendBtn
+                                Layout.preferredWidth: 34
+                                Layout.preferredHeight: 34
+                                highlighted: true
+                                icon.name: Bloriko && Bloriko.busy
+                                    ? "ic_fluent_stop_20_regular"
+                                    : "ic_fluent_arrow_up_20_filled"
+                                enabled: {
+                                    if (!Bloriko) return false
+                                    if (Bloriko.busy) return true
+                                    return inputField.text.trim().length > 0 || pendingImagesModel.count > 0
+                                }
+                                ToolTip.visible: hovered
+                                ToolTip.text: Bloriko && Bloriko.busy
+                                    ? (Backend ? Backend.tr("停止") : "停止")
+                                    : (Backend ? Backend.tr("发送") : "发送")
+                                ToolTip.delay: 400
+                                onClicked: doSendMessage()
+                            }
+                        }
+                    }
+                }
+
+                // 隐藏的 modelCombo / providerCombo：保留 id 供 loadModels 使用
+                Item {
+                    width: 0; height: 0; visible: false
+                    ComboBox {
+                        id: providerCombo
+                        model: providerModel
+                        textRole: "name"
+                        onActivated: function(index) {
+                            var item = providerModel.get(index)
+                            if (Backend) Backend.setGlobalAIProvider(item.key)
+                            loadModels()
+                        }
+                    }
+                    ComboBox {
+                        id: modelCombo
+                        model: modelModel
+                        textRole: "name"
+                        onActivated: function(index) {
+                            if (modelModel.count > 0 && Backend)
+                                Backend.setGlobalAIModel(modelModel.get(index).id)
+                            updateCurrentModelLabel()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Platform.FileDialog {
+        id: imageFileDialog
+        title: Backend ? Backend.tr("选择图片") : "选择图片"
+        fileMode: Platform.FileDialog.OpenFiles
+        nameFilters: [
+            Backend ? Backend.tr("图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)") : "图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)",
+            Backend ? Backend.tr("所有文件 (*)") : "所有文件 (*)"
+        ]
+        onAccepted: {
+            var files = imageFileDialog.files || []
+            for (var i = 0; i < files.length; i++) {
+                if (pendingImagesModel.count >= maxPendingImages)
+                    break
+                addPendingImage(pathFromFileUrl(files[i]))
+            }
+            // 部分平台也提供 file 单选
+            if (files.length === 0 && imageFileDialog.file)
+                addPendingImage(pathFromFileUrl(imageFileDialog.file))
+        }
+    }
+
+    // 模型切换对话框
+    Dialog {
+        id: modelSelectDlg
+        title: Backend ? Backend.tr("切换模型") : "切换模型"
+        modal: true
+        width: 360
+        standardButtons: Dialog.NoButton
+
+        onOpened: {
+            loadProviders()
+            providerComboDlg.currentIndex = providerCombo.currentIndex
+            modelComboDlg.currentIndex = modelCombo.currentIndex
+        }
+
+        contentItem: ColumnLayout {
+            spacing: 12
+            Text {
+                text: modelSelectDlg.title
+                font.pixelSize: 16
+                font.bold: true
+                color: Theme.currentTheme.colors.textColor
+                Layout.fillWidth: true
+            }
+            Text {
+                text: Backend ? Backend.tr("供应商") : "供应商"
+                font.pixelSize: 12
+                color: Theme.currentTheme.colors.textSecondaryColor
+                Layout.fillWidth: true
+            }
+            ComboBox {
+                id: providerComboDlg
+                Layout.fillWidth: true
+                model: providerModel
+                textRole: "name"
+                onActivated: function(index) {
+                    var item = providerModel.get(index)
+                    if (Backend) Backend.setGlobalAIProvider(item.key)
+                    providerCombo.currentIndex = index
+                    loadModels()
+                    modelComboDlg.currentIndex = modelCombo.currentIndex >= 0 ? modelCombo.currentIndex : 0
+                }
+            }
+            Text {
+                text: Backend ? Backend.tr("模型") : "模型"
+                font.pixelSize: 12
+                color: Theme.currentTheme.colors.textSecondaryColor
+                Layout.fillWidth: true
+            }
+            ComboBox {
+                id: modelComboDlg
+                Layout.fillWidth: true
+                model: modelModel
+                textRole: "name"
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+                Button {
+                    text: Backend ? Backend.tr("取消") : "取消"
+                    flat: true
+                    Layout.fillWidth: true
+                    onClicked: modelSelectDlg.close()
+                }
+                Button {
+                    text: Backend ? Backend.tr("确定") : "确定"
+                    highlighted: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        if (providerComboDlg.currentIndex >= 0 && providerComboDlg.currentIndex < providerModel.count) {
+                            var p = providerModel.get(providerComboDlg.currentIndex)
+                            if (Backend) Backend.setGlobalAIProvider(p.key)
+                            providerCombo.currentIndex = providerComboDlg.currentIndex
+                        }
+                        loadModels()
+                        if (modelComboDlg.currentIndex >= 0 && modelComboDlg.currentIndex < modelModel.count) {
+                            var m = modelModel.get(modelComboDlg.currentIndex)
+                            if (Backend) Backend.setGlobalAIModel(m.id)
+                            modelCombo.currentIndex = modelComboDlg.currentIndex
+                        }
+                        updateCurrentModelLabel()
+                        modelSelectDlg.close()
                     }
                 }
             }
@@ -1311,6 +1703,8 @@ Item {
             conversationTitle = Bloriko ? (Bloriko.title || "") : ""
             currentEmotion = Bloriko ? (Bloriko.emotion || "neutral") : "neutral"
             syncRoleCombo()
+            loadProviders()
+            updateCurrentModelLabel()
         }
 
         function onRoleChanged() {
@@ -1319,6 +1713,27 @@ Item {
 
         function onTitleChanged(title) {
             conversationTitle = title
+        }
+
+        function onVoiceStateChanged(state) {
+            voiceState = state || "idle"
+        }
+
+        function onTranscriptionReady(text) {
+            appendTranscription(text)
+        }
+
+        function onTranscriptionFailed(msg) {
+            messageModel.append({
+                role: "error",
+                content: msg || (Backend ? Backend.tr("语音识别失败") : "语音识别失败"),
+                imagesJson: "[]",
+                toolName: "",
+                toolArgs: "",
+                toolResult: "",
+                streaming: false,
+                expanded: false
+            })
         }
 
         function onStatusMessage(msg) {

--- a/qml/pages/Download.qml
+++ b/qml/pages/Download.qml
@@ -44,7 +44,9 @@ FluentPage {
         colorType: downloadPage._sourceColor(downloadPage._currentSource)
     }
 
-    // 配置变更监听
+    // 配置变更 / 整合包导入反馈
+    property string _mrpackStatus: ""
+
     Connections {
         target: Backend
         function onConfigChanged(key, value) {
@@ -52,6 +54,50 @@ FluentPage {
                 _currentSource = Backend.getDownloadSource()
             }
         }
+        function onDownloadNotify(title, text, success) {
+            mrpackInfoBar.severity = success ? Severity.Success : Severity.Error
+            mrpackInfoBar.title = title || ""
+            mrpackInfoBar.text = text || ""
+            mrpackInfoBar.opacity = 1
+            mrpackInfoBar.visible = true
+            mrpackInfoBarTimer.restart()
+        }
+        function onMrpackImportProgress(phase, current, total, message) {
+            var label = message || phase || ""
+            if (total > 0)
+                label = "[" + phase + " " + current + "/" + total + "] " + (message || "")
+            else if (phase)
+                label = "[" + phase + "] " + (message || "")
+            downloadPage._mrpackStatus = label
+            mrpackInfoBar.severity = Severity.Info
+            mrpackInfoBar.title = Backend ? Backend.tr("正在导入整合包") : "正在导入整合包"
+            mrpackInfoBar.text = label
+            mrpackInfoBar.opacity = 1
+            mrpackInfoBar.visible = true
+            // 导入中不自动隐藏
+            mrpackInfoBarTimer.stop()
+        }
+        function onMrpackImportFinished(requestId, ok, instanceName, message) {
+            mrpackInfoBar.severity = ok ? Severity.Success : Severity.Error
+            mrpackInfoBar.title = ok
+                ? (Backend ? Backend.tr("整合包导入成功") : "整合包导入成功")
+                : (Backend ? Backend.tr("整合包导入失败") : "整合包导入失败")
+            mrpackInfoBar.text = ok
+                ? ((instanceName || "") + (message ? " · " + message : ""))
+                : (message || "")
+            mrpackInfoBar.opacity = 1
+            mrpackInfoBar.visible = true
+            downloadPage._mrpackStatus = ""
+            mrpackInfoBarTimer.restart()
+            if (ok)
+                refreshDlStatusBar()
+        }
+    }
+
+    Timer {
+        id: mrpackInfoBarTimer
+        interval: 5000
+        onTriggered: mrpackInfoBar.visible = false
     }
 
     // ── 下载任务状态（稳定 ListModel，避免每秒销毁重建）──
@@ -300,6 +346,14 @@ FluentPage {
     // ── 页面内容主体 ──
     content: ColumnLayout {
         spacing: 12
+
+        InfoBar {
+            id: mrpackInfoBar
+            Layout.fillWidth: true
+            visible: false
+            timeout: -1
+            closable: true
+        }
 
         // ── 当前下载（仅当有任务时显示）──
         // 注意：不要用 RinUI Frame(clip:true) + MouseArea(anchors.fill)

--- a/qml/pages/Home.qml
+++ b/qml/pages/Home.qml
@@ -628,6 +628,15 @@ FluentPage {
                     Layout.fillWidth: true
                     model: homeModelModel
                     textRole: "name"
+                    onActivated: function(index) {
+                        if (index < 0 || index >= homeModelModel.count) return
+                        var m = homeModelModel.get(index)
+                        if (Backend) Backend.setGlobalAIModel(m.id)
+                        if (Bloriko && typeof Bloriko.setModel === "function")
+                            Bloriko.setModel(m.id)
+                        homeModelCombo.currentIndex = index
+                        homeUpdateModelLabel()
+                    }
                 }
                 RowLayout {
                     Layout.fillWidth: true
@@ -643,16 +652,33 @@ FluentPage {
                         highlighted: true
                         Layout.fillWidth: true
                         onClicked: {
+                            // 先保存选中的模型 id，避免 loadModels clear 冲掉 ComboBox 索引
+                            var selectedModelId = ""
+                            var selectedModelIndex = homeModelComboDlg.currentIndex
+                            if (selectedModelIndex >= 0 && selectedModelIndex < homeModelModel.count)
+                                selectedModelId = homeModelModel.get(selectedModelIndex).id || ""
+
                             if (homeProviderComboDlg.currentIndex >= 0 && homeProviderComboDlg.currentIndex < homeProviderModel.count) {
                                 var p = homeProviderModel.get(homeProviderComboDlg.currentIndex)
                                 if (Backend) Backend.setGlobalAIProvider(p.key)
                                 homeProviderCombo.currentIndex = homeProviderComboDlg.currentIndex
                             }
+
+                            if (selectedModelId.length > 0) {
+                                if (Backend) Backend.setGlobalAIModel(selectedModelId)
+                                if (Bloriko && typeof Bloriko.setModel === "function")
+                                    Bloriko.setModel(selectedModelId)
+                            }
+
                             homeLoadModels()
-                            if (homeModelComboDlg.currentIndex >= 0 && homeModelComboDlg.currentIndex < homeModelModel.count) {
-                                var m = homeModelModel.get(homeModelComboDlg.currentIndex)
-                                if (Backend) Backend.setGlobalAIModel(m.id)
-                                homeModelCombo.currentIndex = homeModelComboDlg.currentIndex
+                            if (selectedModelId.length > 0) {
+                                for (var i = 0; i < homeModelModel.count; i++) {
+                                    if (homeModelModel.get(i).id === selectedModelId) {
+                                        homeModelCombo.currentIndex = i
+                                        homeModelComboDlg.currentIndex = i
+                                        break
+                                    }
+                                }
                             }
                             homeUpdateModelLabel()
                             homeModelDlg.close()

--- a/qml/pages/Home.qml
+++ b/qml/pages/Home.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
 import QtQuick.Window 2.15
 import Qt5Compat.GraphicalEffects
+import Qt.labs.platform 1.1 as Platform
 import RinUI
 import "../components"
 
@@ -15,6 +16,127 @@ FluentPage {
     property string currentVersion: ""
     property string showAccountOnHome: "compact"
     property var pluginHomeCards: []
+
+    property string homeModelLabel: (Backend ? Backend.tr("选择模型") : "选择模型")
+    property string homeVoiceState: "idle"
+    property int homeMaxImages: 4
+    ListModel { id: homePendingImages }
+    ListModel { id: homeProviderModel }
+    ListModel { id: homeModelModel }
+
+    function homeFileUrlFromPath(path) {
+        if (!path) return ""
+        var s = path.toString()
+        if (s.indexOf("file://") === 0) return s
+        if (Qt.platform.os === "windows")
+            return "file:///" + s.replace(/\\/g, "/")
+        return "file://" + s
+    }
+
+    function homePathFromFileUrl(url) {
+        var s = (url || "").toString()
+        if (s.indexOf("file://") === 0)
+            s = decodeURIComponent(s.substring(Qt.platform.os === "windows" ? 8 : 7))
+        return s
+    }
+
+    function homePendingImagesJson() {
+        var arr = []
+        for (var i = 0; i < homePendingImages.count; i++)
+            arr.push(homePendingImages.get(i).path)
+        return JSON.stringify(arr)
+    }
+
+    function homeAddImage(path) {
+        if (!path || path.length === 0) return
+        if (homePendingImages.count >= homeMaxImages) return
+        for (var i = 0; i < homePendingImages.count; i++) {
+            if (homePendingImages.get(i).path === path) return
+        }
+        homePendingImages.append({ path: path, previewUrl: homeFileUrlFromPath(path) })
+    }
+
+    function homeLoadProviders() {
+        homeProviderModel.clear()
+        if (!Bloriko) return
+        try {
+            var providers = JSON.parse(Bloriko.getProviders())
+            for (var i = 0; i < providers.length; i++)
+                homeProviderModel.append(providers[i])
+            if (Backend) {
+                var gp = Backend.getGlobalAIProvider()
+                for (var j = 0; j < homeProviderModel.count; j++) {
+                    if (homeProviderModel.get(j).key === gp) {
+                        homeProviderCombo.currentIndex = j
+                        break
+                    }
+                }
+            }
+            homeLoadModels()
+        } catch (e) { console.warn("[Home] loadProviders", e) }
+    }
+
+    function homeLoadModels() {
+        homeModelModel.clear()
+        if (!Bloriko) return
+        try {
+            var models = JSON.parse(Bloriko.getModels())
+            for (var i = 0; i < models.length; i++)
+                homeModelModel.append(models[i])
+            var selected = false
+            if (Backend) {
+                var gm = Backend.getGlobalAIModel()
+                for (var j = 0; j < homeModelModel.count; j++) {
+                    if (homeModelModel.get(j).id === gm) {
+                        homeModelCombo.currentIndex = j
+                        selected = true
+                        break
+                    }
+                }
+            }
+            if (!selected && homeModelModel.count > 0)
+                homeModelCombo.currentIndex = 0
+            homeUpdateModelLabel()
+        } catch (e) { console.warn("[Home] loadModels", e) }
+    }
+
+    function homeUpdateModelLabel() {
+        if (homeModelModel.count > 0 && homeModelCombo.currentIndex >= 0 && homeModelCombo.currentIndex < homeModelModel.count) {
+            homeModelLabel = homeModelModel.get(homeModelCombo.currentIndex).name || homeModelModel.get(homeModelCombo.currentIndex).id
+            return
+        }
+        if (Bloriko && typeof Bloriko.getCurrentModelName === "function") {
+            var n = Bloriko.getCurrentModelName()
+            if (n && n.length > 0) { homeModelLabel = n; return }
+        }
+        homeModelLabel = Backend ? Backend.tr("选择模型") : "选择模型"
+    }
+
+    function homeAppendTranscription(text) {
+        if (!text || text.length === 0) return
+        var cur = aiInput.text || ""
+        if (cur.length > 0 && !/\s$/.test(cur)) cur += " "
+        aiInput.text = cur + text
+        aiInput.cursorPosition = aiInput.text.length
+        aiInput.forceActiveFocus()
+    }
+
+    function homeSendToBloriko() {
+        var text = aiInput.text.trim()
+        var imagesJson = homePendingImagesJson()
+        var hasImages = homePendingImages.count > 0
+        if (text === "" && !hasImages)
+            return
+        console.log("[Home] 发送到 Blora Agent 页处理:", text.substring(0, 80), "images=", imagesJson)
+        var win = Window.window
+        if (win && typeof win.navigateToBlorikoWithMessage === "function") {
+            win.navigateToBlorikoWithMessage(text, imagesJson)
+        } else {
+            console.error("[Home] 无法获取主窗口或 navigateToBlorikoWithMessage")
+        }
+        aiInput.text = ""
+        homePendingImages.clear()
+    }
 
     function loadPluginHomeCards() {
         pluginHomeCards = []
@@ -57,6 +179,9 @@ FluentPage {
         }
 
         showAccountOnHome = Backend.getShowAccountOnHome()
+        homeLoadProviders()
+        if (Bloriko)
+            homeVoiceState = Bloriko.voiceState || "idle"
 
         // 插件卡片与远程刷新放到下一帧，让 StackView 动画/首帧先完成；
         // Backend 内还有 TTL / in-flight，短时间反复进入不会重复打网。
@@ -247,48 +372,311 @@ FluentPage {
         RowLayout {
             Layout.fillWidth: true
             spacing: 10
-            
+
             Image {
                 source: Qt.resolvedUrl("../../icon/Bloriko.jpg")
-                sourceSize { width: 35; height: 35 }
+                sourceSize { width: 40; height: 40 }
                 fillMode: Image.PreserveAspectCrop
+                Layout.alignment: Qt.AlignBottom
+                Layout.bottomMargin: 8
                 layer.enabled: true
                 layer.effect: OpacityMask {
                     maskSource: Rectangle {
-                        width: 35
-                        height: 35
-                        radius: 8
+                        width: 40
+                        height: 40
+                        radius: 10
                     }
                 }
-            }
-            
-            TextField {
-                id: aiInput
-                placeholderText: (Backend ? Backend.tr("关于 Minecraft 的任何问题，可以问 Blora Agent 哦 ~") : "关于 Minecraft 的任何问题，可以问 Blora Agent 哦 ~")
-                Layout.fillWidth: true
-                padding: 10
-                onAccepted: sendBtn.clicked()
             }
 
-            Button {
-                id: sendBtn
-                icon.name: "ic_fluent_send_20_regular"
-                text: (Backend ? Backend.tr("发送") : "发送")
-                highlighted: true
-                onClicked: {
-                    var text = aiInput.text.trim()
-                    if (text === "")
-                        return
-                    console.log("[Home] 发送到 Blora Agent 页处理:", text.substring(0, 80))
-                    // 跳转到 Blora Agent 页面并由 Blora Agent 处理
-                    var win = Window.window
-                    if (win && typeof win.navigateToBlorikoWithMessage === "function") {
-                        win.navigateToBlorikoWithMessage(text)
-                    } else {
-                        console.error("[Home] 无法获取主窗口或 navigateToBlorikoWithMessage")
+            // 一体输入卡片（与 Blora Agent 页布局对齐）
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: homeInputCol.implicitHeight + 16
+                radius: 22
+                color: Theme.currentTheme.colors.controlColor || Theme.currentTheme.colors.cardColor || "#FFFFFF"
+                border.color: aiInput.activeFocus
+                    ? (Theme.accentColor || "#0078D4")
+                    : (Theme.currentTheme.colors.controlBorderColor || "#E0E0E0")
+                border.width: 1
+
+                ColumnLayout {
+                    id: homeInputCol
+                    anchors.fill: parent
+                    anchors.margins: 10
+                    spacing: 8
+
+                    Flow {
+                        Layout.fillWidth: true
+                        spacing: 6
+                        visible: homePendingImages.count > 0
+                        Repeater {
+                            model: homePendingImages
+                            delegate: Item {
+                                width: 56; height: 56
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: 10
+                                    color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                                    clip: true
+                                    Image {
+                                        anchors.fill: parent
+                                        source: model.previewUrl
+                                        fillMode: Image.PreserveAspectCrop
+                                        asynchronous: true
+                                    }
+                                }
+                                RoundButton {
+                                    anchors.top: parent.top
+                                    anchors.right: parent.right
+                                    anchors.margins: -4
+                                    width: 20; height: 20
+                                    flat: true
+                                    icon.name: "ic_fluent_dismiss_20_regular"
+                                    onClicked: homePendingImages.remove(index)
+                                }
+                            }
+                        }
                     }
-                    aiInput.text = ""
+
+                    TextArea {
+                        id: aiInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.min(Math.max(implicitHeight, 28), 96)
+                        placeholderText: (Backend ? Backend.tr("关于 Minecraft 的任何问题，可以问 Blora Agent 哦 ~") : "关于 Minecraft 的任何问题，可以问 Blora Agent 哦 ~")
+                        wrapMode: TextArea.Wrap
+                        font.pixelSize: 14
+                        color: Theme.currentTheme.colors.textColor
+                        background: Item {}
+                        topPadding: 2; bottomPadding: 2; leftPadding: 4; rightPadding: 4
+                        Keys.onPressed: function(event) {
+                            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                if (event.modifiers & Qt.ShiftModifier) {
+                                    aiInput.insert(aiInput.cursorPosition, "\n")
+                                } else {
+                                    homeSendToBloriko()
+                                    event.accepted = true
+                                }
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        RoundButton {
+                            Layout.preferredWidth: 32
+                            Layout.preferredHeight: 32
+                            flat: true
+                            icon.name: "ic_fluent_add_20_regular"
+                            enabled: homePendingImages.count < homeMaxImages
+                            ToolTip.visible: hovered
+                            ToolTip.text: Backend ? Backend.tr("添加图片") : "添加图片"
+                            ToolTip.delay: 400
+                            onClicked: homeImageDialog.open()
+                        }
+
+                        Rectangle {
+                            Layout.preferredHeight: 32
+                            Layout.preferredWidth: Math.min(homeModelPillRow.implicitWidth + 16, 180)
+                            Layout.maximumWidth: 200
+                            radius: 16
+                            color: Theme.currentTheme.colors.controlAltSecondaryColor || "#F0F0F0"
+                            border.color: Theme.currentTheme.colors.controlBorderColor || "#E0E0E0"
+                            border.width: 1
+                            RowLayout {
+                                id: homeModelPillRow
+                                anchors.centerIn: parent
+                                anchors.leftMargin: 8; anchors.rightMargin: 8
+                                spacing: 4
+                                Icon { icon: "ic_fluent_lightbulb_20_regular"; size: 14; color: Theme.currentTheme.colors.textColor }
+                                Text {
+                                    text: homeModelLabel
+                                    font.pixelSize: 12
+                                    color: Theme.currentTheme.colors.textColor
+                                    elide: Text.ElideRight
+                                    Layout.maximumWidth: 140
+                                }
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    homeLoadProviders()
+                                    homeModelDlg.open()
+                                }
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        RoundButton {
+                            Layout.preferredWidth: 32
+                            Layout.preferredHeight: 32
+                            flat: true
+                            highlighted: homeVoiceState === "recording"
+                            icon.name: homeVoiceState === "recording"
+                                ? "ic_fluent_mic_record_20_filled"
+                                : (homeVoiceState === "transcribing"
+                                    ? "ic_fluent_spinner_ios_20_regular"
+                                    : "ic_fluent_mic_20_regular")
+                            enabled: Bloriko && homeVoiceState !== "transcribing"
+                            ToolTip.visible: hovered
+                            ToolTip.text: homeVoiceState === "recording"
+                                ? (Backend ? Backend.tr("录音中，再次点击结束") : "录音中，再次点击结束")
+                                : (Backend ? Backend.tr("语音输入") : "语音输入")
+                            ToolTip.delay: 400
+                            onClicked: {
+                                if (!Bloriko) return
+                                if (homeVoiceState === "recording")
+                                    Bloriko.stopVoiceCaptureAndTranscribe()
+                                else if (homeVoiceState === "idle")
+                                    Bloriko.startVoiceCapture()
+                            }
+                        }
+
+                        RoundButton {
+                            id: sendBtn
+                            Layout.preferredWidth: 34
+                            Layout.preferredHeight: 34
+                            highlighted: true
+                            icon.name: "ic_fluent_arrow_up_20_filled"
+                            enabled: aiInput.text.trim().length > 0 || homePendingImages.count > 0
+                            ToolTip.visible: hovered
+                            ToolTip.text: Backend ? Backend.tr("发送") : "发送"
+                            ToolTip.delay: 400
+                            onClicked: homeSendToBloriko()
+                        }
+                    }
                 }
+            }
+
+            // 隐藏 ComboBox，供模型对话框与 loadModels 复用
+            Item {
+                width: 0; height: 0; visible: false
+                ComboBox { id: homeProviderCombo; model: homeProviderModel; textRole: "name" }
+                ComboBox { id: homeModelCombo; model: homeModelModel; textRole: "name" }
+            }
+        }
+
+        Platform.FileDialog {
+            id: homeImageDialog
+            title: Backend ? Backend.tr("选择图片") : "选择图片"
+            fileMode: Platform.FileDialog.OpenFiles
+            nameFilters: [
+                Backend ? Backend.tr("图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)") : "图片 (*.png *.jpg *.jpeg *.gif *.webp *.bmp)",
+                Backend ? Backend.tr("所有文件 (*)") : "所有文件 (*)"
+            ]
+            onAccepted: {
+                var files = homeImageDialog.files || []
+                for (var i = 0; i < files.length; i++) {
+                    if (homePendingImages.count >= homeMaxImages) break
+                    homeAddImage(homePathFromFileUrl(files[i]))
+                }
+                if (files.length === 0 && homeImageDialog.file)
+                    homeAddImage(homePathFromFileUrl(homeImageDialog.file))
+            }
+        }
+
+        Dialog {
+            id: homeModelDlg
+            title: Backend ? Backend.tr("切换模型") : "切换模型"
+            modal: true
+            width: 360
+            standardButtons: Dialog.NoButton
+            onOpened: {
+                homeLoadProviders()
+                homeProviderComboDlg.currentIndex = homeProviderCombo.currentIndex
+                homeModelComboDlg.currentIndex = homeModelCombo.currentIndex
+            }
+            contentItem: ColumnLayout {
+                spacing: 12
+                Text {
+                    text: homeModelDlg.title
+                    font.pixelSize: 16; font.bold: true
+                    color: Theme.currentTheme.colors.textColor
+                    Layout.fillWidth: true
+                }
+                Text {
+                    text: Backend ? Backend.tr("供应商") : "供应商"
+                    font.pixelSize: 12
+                    color: Theme.currentTheme.colors.textSecondaryColor
+                    Layout.fillWidth: true
+                }
+                ComboBox {
+                    id: homeProviderComboDlg
+                    Layout.fillWidth: true
+                    model: homeProviderModel
+                    textRole: "name"
+                    onActivated: function(index) {
+                        var item = homeProviderModel.get(index)
+                        if (Backend) Backend.setGlobalAIProvider(item.key)
+                        homeProviderCombo.currentIndex = index
+                        homeLoadModels()
+                        homeModelComboDlg.currentIndex = homeModelCombo.currentIndex >= 0 ? homeModelCombo.currentIndex : 0
+                    }
+                }
+                Text {
+                    text: Backend ? Backend.tr("模型") : "模型"
+                    font.pixelSize: 12
+                    color: Theme.currentTheme.colors.textSecondaryColor
+                    Layout.fillWidth: true
+                }
+                ComboBox {
+                    id: homeModelComboDlg
+                    Layout.fillWidth: true
+                    model: homeModelModel
+                    textRole: "name"
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+                    Button {
+                        text: Backend ? Backend.tr("取消") : "取消"
+                        flat: true
+                        Layout.fillWidth: true
+                        onClicked: homeModelDlg.close()
+                    }
+                    Button {
+                        text: Backend ? Backend.tr("确定") : "确定"
+                        highlighted: true
+                        Layout.fillWidth: true
+                        onClicked: {
+                            if (homeProviderComboDlg.currentIndex >= 0 && homeProviderComboDlg.currentIndex < homeProviderModel.count) {
+                                var p = homeProviderModel.get(homeProviderComboDlg.currentIndex)
+                                if (Backend) Backend.setGlobalAIProvider(p.key)
+                                homeProviderCombo.currentIndex = homeProviderComboDlg.currentIndex
+                            }
+                            homeLoadModels()
+                            if (homeModelComboDlg.currentIndex >= 0 && homeModelComboDlg.currentIndex < homeModelModel.count) {
+                                var m = homeModelModel.get(homeModelComboDlg.currentIndex)
+                                if (Backend) Backend.setGlobalAIModel(m.id)
+                                homeModelCombo.currentIndex = homeModelComboDlg.currentIndex
+                            }
+                            homeUpdateModelLabel()
+                            homeModelDlg.close()
+                        }
+                    }
+                }
+            }
+        }
+
+        Connections {
+            target: Bloriko
+            enabled: Bloriko !== null
+            function onVoiceStateChanged(state) { homeVoiceState = state || "idle" }
+            function onTranscriptionReady(text) {
+                // 仅当首页输入框聚焦或刚发起录音时写入，避免与 Agent 页抢结果
+                if (homePage.visible)
+                    homeAppendTranscription(text)
+            }
+            function onTranscriptionFailed(msg) {
+                if (homePage.visible)
+                    console.warn("[Home] STT failed:", msg)
+            }
+            function onProvidersChanged() {
+                if (homePage.visible) homeLoadProviders()
             }
         }
         

--- a/test_mrpack_io.py
+++ b/test_mrpack_io.py
@@ -1,0 +1,145 @@
+"""Smoke tests for official-compatible mrpack export/import."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import types
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Headless CI / servers may lack PySide6; stub enough for modules.log import chain.
+if "PySide6" not in sys.modules:
+    for name in (
+        "PySide6",
+        "PySide6.QtCore",
+        "PySide6.QtGui",
+        "PySide6.QtWidgets",
+        "PySide6.QtNetwork",
+    ):
+        sys.modules[name] = MagicMock()
+
+import modules.mrpack_export as export_mod
+import modules.mrpack_import as import_mod
+
+
+def _make_fake_instance(root: Path) -> Path:
+    inst = root / "versions" / "TestPack"
+    (inst / "mods").mkdir(parents=True)
+    (inst / "config").mkdir(parents=True)
+    # tiny fake jar
+    mod = inst / "mods" / "local-mod.jar"
+    mod.write_bytes(b"PK\x03\x04fake-mod-content-for-hash")
+    cfg = inst / "config" / "demo.toml"
+    cfg.write_text("enabled = true\n", encoding="utf-8")
+    # minimal version json
+    (inst / "TestPack.json").write_text(
+        json.dumps(
+            {
+                "id": "1.20.1",
+                "inheritsFrom": "1.20.1",
+                "mainClass": "net.fabricmc.loader.impl.launch.knot.KnotClient",
+                "libraries": [
+                    {"name": "net.fabricmc:fabric-loader:0.15.11"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return inst
+
+
+def test_export_uses_overrides_not_files_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        inst = _make_fake_instance(root)
+        out = root / "out.mrpack"
+        ok = export_mod.export_to_mrpack(
+            str(inst),
+            str(out),
+            name="Test Pack",
+            version="1.0.0",
+            summary="unit",
+            resolve_cdn=False,  # force all into overrides
+        )
+        assert ok, "export should succeed"
+        assert out.is_file()
+        with zipfile.ZipFile(out, "r") as zf:
+            names = [n.replace("\\", "/") for n in zf.namelist()]
+            assert "modrinth.index.json" in names
+            assert any(n.startswith("overrides/") for n in names), names
+            assert not any(
+                n == "files" or n.startswith("files/") for n in names
+            ), f"legacy files/ must not appear: {names}"
+            index = json.loads(zf.read("modrinth.index.json"))
+            assert index["game"] == "minecraft"
+            assert index["formatVersion"] == 1
+            assert "minecraft" in index["dependencies"]
+            # with resolve_cdn=False everything is override-only
+            assert index["files"] == []
+            assert any(n.endswith("mods/local-mod.jar") for n in names)
+            assert any(n.endswith("config/demo.toml") for n in names)
+
+
+def test_import_reads_index_and_extracts_overrides():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        inst = _make_fake_instance(root)
+        pack = root / "pack.mrpack"
+        assert export_mod.export_to_mrpack(
+            str(inst), str(pack), "Demo", "1.0.0", resolve_cdn=False
+        )
+        dest_root = root / "import_mc"
+        result = import_mod.import_mrpack(
+            str(pack),
+            minecraft_dir=str(dest_root),
+            instance_name="ImportedDemo",
+            install_game=False,
+        )
+        assert result["ok"], result
+        dest = Path(result["instance_path"])
+        assert (dest / "mods" / "local-mod.jar").is_file()
+        assert (dest / "config" / "demo.toml").is_file()
+        assert (dest / "bloret-mrpack-meta.json").is_file()
+
+
+def test_parse_dependencies():
+    mc, loader, ver = import_mod.parse_dependencies(
+        {"minecraft": "1.20.1", "fabric-loader": "0.15.11"}
+    )
+    assert mc == "1.20.1"
+    assert loader == "fabric"
+    assert ver == "0.15.11"
+
+
+def test_legacy_files_prefix_still_extracts():
+    """旧 Bloret 错误格式 files/ 仍应能解压。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        pack = root / "legacy.mrpack"
+        index = {
+            "formatVersion": 1,
+            "game": "minecraft",
+            "versionId": "1.0.0",
+            "name": "Legacy",
+            "files": [],
+            "dependencies": {"minecraft": "1.20.1"},
+        }
+        with zipfile.ZipFile(pack, "w") as zf:
+            zf.writestr("modrinth.index.json", json.dumps(index))
+            zf.writestr("files/config/old.txt", b"legacy-override")
+        dest = root / "mc" / "versions" / "L"
+        dest.mkdir(parents=True)
+        n = import_mod.extract_overrides(str(pack), dest)
+        assert n >= 1
+        assert (dest / "config" / "old.txt").read_text() == "legacy-override"
+
+
+if __name__ == "__main__":
+    test_export_uses_overrides_not_files_dir()
+    test_import_reads_index_and_extracts_overrides()
+    test_parse_dependencies()
+    test_legacy_files_prefix_still_extracts()
+    print("all mrpack smoke tests passed")


### PR DESCRIPTION
## Summary
- Align `.mrpack` **export** with official Modrinth App layout: remote files go into `modrinth.index.json` with CDN `downloads`; local files go into ZIP `overrides/` (no legacy `files/` directory).
- Replace default **import** path with built-in `modules/mrpack_import.py` (parse index → install game/loader → download content → extract overrides), with optional `BLORET_MRPACK_INSTALL_BIN` external fallback.
- Export dialog supports candidate selection; Backend exposes `getMrpackExportCandidates` / `requestMrpackExportWithSelection` / `requestMrpackImport` + progress signals.
- Update `MRPACK_FORMAT_RESEARCH.md` and add `test_mrpack_io.py` smoke tests.

## Test plan
- [x] `python test_mrpack_io.py` (overrides export, round-trip import without game install, legacy `files/` extract, dependency parse)
- [ ] Export an instance → open `.mrpack` and confirm `modrinth.index.json` + `overrides/`, no root `files/`
- [ ] Import a standard `.mrpack` via Download page without `mrpack-install` installed
- [ ] Optional: set `BLORET_MRPACK_INSTALL_BIN` and confirm external fallback still works