### PR TITLE
feat: 非 onefile 目录打包（PyInstaller onedir / Nuitka standalone）

### DIFF
--- a/.github/workflows/Nuitka-Build.yml
+++ b/.github/workflows/Nuitka-Build.yml
@@ -349,7 +349,7 @@ jobs:
         make_zip() {
           local src_dir="$1"
           local zip_path="$2"
-          python - <<'PY' "$src_dir" "$zip_path"
+          python - "$src_dir" "$zip_path" <<'PY'
         import sys, zipfile
         from pathlib import Path
         src = Path(sys.argv[1]).resolve()
@@ -378,6 +378,11 @@ jobs:
           test -f "$DIST_DIR/Bloret-Launcher.exe"
           mkdir -p "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
           cp -a "$DIST_DIR"/. "${{ env.OUTPUT_DIR }}/Bloret-Launcher/"
+          for f in LICENSE bloret.ico config.json JavaWrapper.jar Bloret.png Bloret-Fluent.png servers.dat; do
+            if [ -f "$f" ] && [ ! -f "${{ env.OUTPUT_DIR }}/Bloret-Launcher/$f" ]; then
+              cp "$f" "${{ env.OUTPUT_DIR }}/Bloret-Launcher/$f"
+            fi
+          done
           make_zip "${{ env.OUTPUT_DIR }}/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Windows-standalone.zip"
         fi
         if [ "${{ runner.os }}" == "Linux" ]; then
@@ -486,7 +491,17 @@ jobs:
           if [ -f Bloret-Launcher-Windows/Bloret-Launcher-Windows-standalone.zip ]; then
             cp Bloret-Launcher-Windows/Bloret-Launcher-Windows-standalone.zip release_assets/
           elif [ -d Bloret-Launcher-Windows/Bloret-Launcher ]; then
-            (cd Bloret-Launcher-Windows && zip -r ../release_assets/Bloret-Launcher-Windows-standalone.zip Bloret-Launcher)
+            python - "Bloret-Launcher-Windows/Bloret-Launcher" "release_assets/Bloret-Launcher-Windows-standalone.zip" <<'PY'
+          import sys, zipfile
+          from pathlib import Path
+          src = Path(sys.argv[1]).resolve()
+          zip_path = Path(sys.argv[2]).resolve()
+          with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+              for path in src.rglob("*"):
+                  if path.is_file():
+                      zf.write(path, arcname=str(Path(src.name) / path.relative_to(src)))
+          print("wrote", zip_path)
+          PY
           elif [ -f Bloret-Launcher-Windows/Bloret-Launcher.exe ]; then
             cp Bloret-Launcher-Windows/Bloret-Launcher.exe release_assets/
           fi
@@ -510,7 +525,7 @@ jobs:
     - name: 检出最新版本
       uses: actions/checkout@v4
       with:
-        ref: 'Windows'
+        ref: ${{ github.ref }}
 
     - name: 创建输出目录并清理
       run: |
@@ -551,7 +566,8 @@ jobs:
     - name: 检出最新版本
       uses: actions/checkout@v4
       with:
-        ref: 'Windows'
+        # 使用触发分支上的 Setup.iss，不要写死 Windows 旧单 exe 脚本
+        ref: ${{ github.ref }}
 
     - name: 下载构建产物
       uses: actions/download-artifact@v4
@@ -559,30 +575,56 @@ jobs:
         name: Bloret-Launcher
         path: output
 
-    - name: 确保 LICENSE 与安装资源存在
+    - name: 准备 standalone 安装资源
       run: |
-        if (-not (Test-Path "output\Bloret-Launcher\Bloret-Launcher.exe")) {
-          Write-Host "standalone 目录缺少 Bloret-Launcher.exe"
-          Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
-          exit 1
-        }
-        # SetupIconFile 需要 bloret.ico；若 dist 内没有则从仓库拷贝
-        if (-not (Test-Path "output\Bloret-Launcher\bloret.ico")) {
-          if (Test-Path "bloret.ico") {
-            Copy-Item "bloret.ico" "output\Bloret-Launcher\bloret.ico"
-          } elseif (Test-Path "output\bloret.ico") {
-            Copy-Item "output\bloret.ico" "output\Bloret-Launcher\bloret.ico"
+        $ErrorActionPreference = "Stop"
+        Write-Host "=== output tree (depth 2) ==="
+        Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
+
+        $appDir = "output\Bloret-Launcher"
+        if (-not (Test-Path "$appDir\Bloret-Launcher.exe")) {
+          if (Test-Path "output\Bloret-Launcher.exe") {
+            New-Item -ItemType Directory -Force -Path $appDir | Out-Null
+            Get-ChildItem "output" -Force | Where-Object { $_.Name -ne "Bloret-Launcher" } | ForEach-Object {
+              Move-Item $_.FullName -Destination $appDir -Force
+            }
+          } else {
+            Write-Host "standalone 目录缺少 Bloret-Launcher.exe"
+            Get-ChildItem -Path "output" -Recurse -Depth 3 | Format-Table -AutoSize
+            exit 1
           }
         }
-        if (-not (Test-Path "output\Bloret-Launcher\LICENSE") -and (Test-Path "LICENSE")) {
-          Copy-Item "LICENSE" "output\Bloret-Launcher\LICENSE"
+
+        foreach ($name in @("LICENSE", "bloret.ico", "config.json", "JavaWrapper.jar", "servers.dat")) {
+          $dest = Join-Path $appDir $name
+          if (-not (Test-Path $dest)) {
+            if (Test-Path $name) {
+              Copy-Item $name $dest -Force
+            } elseif (Test-Path "output\$name") {
+              Copy-Item "output\$name" $dest -Force
+            }
+          }
+        }
+
+        if (-not (Test-Path "$appDir\Bloret-Launcher.exe")) {
+          Write-Host "仍缺少 $appDir\Bloret-Launcher.exe"
+          exit 1
+        }
+        if (-not (Test-Path "$appDir\bloret.ico") -and (Test-Path "bloret.ico")) {
+          Copy-Item "bloret.ico" "$appDir\bloret.ico" -Force
+        }
+        if (-not (Test-Path "output\LICENSE") -and (Test-Path "$appDir\LICENSE")) {
+          Copy-Item "$appDir\LICENSE" "output\LICENSE" -Force
+        }
+        if (-not (Test-Path "output\LICENSE") -and (Test-Path "LICENSE")) {
+          Copy-Item "LICENSE" "output\LICENSE" -Force
         }
       shell: pwsh
 
     - name: 展示完整文件夹目录
       run: |
         Write-Host "当前文件夹目录结构如下："
-        Get-ChildItem -Path "output" -Recurse | Format-Table -AutoSize
+        Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
       shell: pwsh
 
     - name: 设置系统语言为简体中文

--- a/.github/workflows/Nuitka-Build.yml
+++ b/.github/workflows/Nuitka-Build.yml
@@ -149,15 +149,16 @@ jobs:
         fi
       shell: bash
 
+    # 非 onefile：--standalone 目录分发，启动时不再整包解压到临时目录
     - name: 使用 Nuitka 打包 (Windows)
       if: runner.os == 'Windows'
       run: |
         $EASYTIER_ARG = if (Test-Path "easytier") { "--include-data-dir=easytier=easytier" } else { "" }
         python -m nuitka `
-          --standalone --onefile `
+          --standalone `
           --windows-console-mode=disable `
           --windows-icon-from-ico=bloret.ico `
-          --output-file=Bloret-Launcher.exe `
+          --output-filename=Bloret-Launcher.exe `
           --windows-company-name="Bloret" `
           --windows-product-name="Bloret Launcher" `
           --windows-file-version=1.0.0 `
@@ -184,7 +185,7 @@ jobs:
       run: |
         EASYTIER_ARG=""
         if [ -d "easytier" ]; then EASYTIER_ARG="--include-data-dir=easytier=easytier"; fi
-        python -m nuitka --standalone --onefile --enable-plugin=pyside6 --include-qt-plugins=sensible,qml --include-data-dir=qml=qml --include-data-dir=RinUI/RinUI=RinUI --include-data-dir=icon=icon --include-data-dir=lang=lang --include-data-files=Bloret.png=Bloret.png --include-data-files=Bloret-Fluent.png=Bloret-Fluent.png --include-data-files=config.json=config.json --include-data-files=LICENSE=LICENSE $EASYTIER_ARG --include-data-dir=modules=modules --output-file=Bloret-Launcher Bloret-Launcher.py
+        python -m nuitka --standalone --enable-plugin=pyside6 --include-qt-plugins=sensible,qml --include-data-dir=qml=qml --include-data-dir=RinUI/RinUI=RinUI --include-data-dir=icon=icon --include-data-dir=lang=lang --include-data-files=Bloret.png=Bloret.png --include-data-files=Bloret-Fluent.png=Bloret-Fluent.png --include-data-files=config.json=config.json --include-data-files=LICENSE=LICENSE $EASYTIER_ARG --include-data-dir=modules=modules --output-filename=Bloret-Launcher Bloret-Launcher.py
       shell: bash
 
     - name: 修复 OpenSSL 依赖 (macOS)
@@ -345,15 +346,46 @@ jobs:
     - name: 收集产物
       run: |
         mkdir -p ${{ env.OUTPUT_DIR }}
-        if [ "${{ runner.os }}" == "Windows" ]; then 
-          cp Bloret-Launcher.exe ${{ env.OUTPUT_DIR }}/
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          # Nuitka standalone 输出为 Bloret-Launcher.dist/
+          DIST_DIR=""
+          for d in Bloret-Launcher.dist Bloret-Launcher.dist.dist; do
+            if [ -d "$d" ]; then DIST_DIR="$d"; break; fi
+          done
+          if [ -z "$DIST_DIR" ]; then
+            DIST_DIR=$(find . -maxdepth 2 -type d -name 'Bloret-Launcher*.dist' | head -1)
+          fi
+          echo "Nuitka Windows dist: $DIST_DIR"
+          test -n "$DIST_DIR" && test -d "$DIST_DIR"
+          test -f "$DIST_DIR/Bloret-Launcher.exe"
+          mkdir -p "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
+          cp -a "$DIST_DIR"/. "${{ env.OUTPUT_DIR }}/Bloret-Launcher/"
+          # 兼容旧 Inno：根目录也放一份 exe 与 LICENSE 等（安装器会装整个目录）
+          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Windows-standalone.zip Bloret-Launcher)
         fi
-        if [ "${{ runner.os }}" == "Linux" ]; then 
+        if [ "${{ runner.os }}" == "Linux" ]; then
           ARCH=$(uname -m)
-          mkdir -p AppDir/usr/bin AppDir/usr/share/applications AppDir/usr/share/bloret-launcher
-          cp Bloret-Launcher AppDir/usr/bin/bloret-launcher
-          chmod +x AppDir/usr/bin/bloret-launcher
-          cp -r qml RinUI icon lang config.json LICENSE bloret.ico Bloret.png Bloret-Fluent.png JavaWrapper.jar AppDir/usr/share/bloret-launcher/
+          DIST_DIR=""
+          for d in Bloret-Launcher.dist; do
+            if [ -d "$d" ]; then DIST_DIR="$d"; break; fi
+          done
+          if [ -z "$DIST_DIR" ]; then
+            DIST_DIR=$(find . -maxdepth 2 -type d -name 'Bloret-Launcher*.dist' | head -1)
+          fi
+          echo "Nuitka Linux dist: $DIST_DIR"
+          test -n "$DIST_DIR" && test -d "$DIST_DIR"
+          test -f "$DIST_DIR/Bloret-Launcher" || test -x "$DIST_DIR/Bloret-Launcher"
+          mkdir -p AppDir/usr/bin AppDir/usr/share/applications AppDir/usr/lib/bloret-launcher
+          cp -a "$DIST_DIR"/. AppDir/usr/lib/bloret-launcher/
+          cat > AppDir/usr/bin/bloret-launcher << 'EOF'
+        #!/bin/sh
+        DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+        ROOT="$(cd "$DIR/.." && pwd)"
+        exec "$ROOT/lib/bloret-launcher/Bloret-Launcher" "$@"
+        EOF
+          chmod +x AppDir/usr/bin/bloret-launcher AppDir/usr/lib/bloret-launcher/Bloret-Launcher
+          mkdir -p AppDir/usr/share/bloret-launcher
+          cp -r qml RinUI icon lang config.json LICENSE bloret.ico Bloret.png Bloret-Fluent.png JavaWrapper.jar AppDir/usr/share/bloret-launcher/ 2>/dev/null || true
           if [ -d "easytier" ]; then cp -r easytier AppDir/usr/share/bloret-launcher/; fi
           cp servers.dat AppDir/usr/share/bloret-launcher/ || true
           cat > AppDir/bloret-launcher.desktop << EOF
@@ -379,13 +411,13 @@ jobs:
           curl -L -o appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${ARCH}.AppImage"
           chmod +x appimagetool
           ./appimagetool --appimage-extract-and-run AppDir "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux.AppImage"
+          mkdir -p "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
+          cp -a "$DIST_DIR"/. "${{ env.OUTPUT_DIR }}/Bloret-Launcher/"
+          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Linux-standalone.zip Bloret-Launcher)
         fi
-        if [ "${{ runner.os }}" == "macOS" ]; then 
+        if [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/
         fi
-        cp -r qml RinUI icon lang config.json LICENSE bloret.ico JavaWrapper.jar ${{ env.OUTPUT_DIR }}/
-        if [ -d "easytier" ]; then cp -r easytier ${{ env.OUTPUT_DIR }}/; fi
-        cp servers.dat ${{ env.OUTPUT_DIR }}/ || true
       shell: bash
 
     - name: 上传构建产物
@@ -433,8 +465,16 @@ jobs:
       - name: 整理发布文件
         run: |
           mkdir -p release_assets
-          cp Bloret-Launcher-Windows/Bloret-Launcher.exe release_assets/
-          cp Bloret-Launcher-Linux/*.AppImage release_assets/
+          # standalone / onedir：优先上传 zip 目录包，兼容残留的单 exe
+          if [ -f Bloret-Launcher-Windows/Bloret-Launcher-Windows-standalone.zip ]; then
+            cp Bloret-Launcher-Windows/Bloret-Launcher-Windows-standalone.zip release_assets/
+          elif [ -d Bloret-Launcher-Windows/Bloret-Launcher ]; then
+            (cd Bloret-Launcher-Windows && zip -r ../release_assets/Bloret-Launcher-Windows-standalone.zip Bloret-Launcher)
+          elif [ -f Bloret-Launcher-Windows/Bloret-Launcher.exe ]; then
+            cp Bloret-Launcher-Windows/Bloret-Launcher.exe release_assets/
+          fi
+          cp Bloret-Launcher-Linux/*.AppImage release_assets/ 2>/dev/null || true
+          cp Bloret-Launcher-Linux/*-standalone.zip release_assets/ 2>/dev/null || true
           # cp Bloret-Launcher-MacOS-Intel/*.dmg release_assets/ || true
           # cp Bloret-Launcher-MacOS-ARM/*.dmg release_assets/ || true
           cp Bloret-Launcher-Setup.exe release_assets/
@@ -502,11 +542,23 @@ jobs:
         name: Bloret-Launcher
         path: output
 
-    - name: 确保 LICENSE 文件存在
+    - name: 确保 LICENSE 与安装资源存在
       run: |
-        if (-not (Test-Path "output/LICENSE")) {
-          Write-Host "LICENSE 文件未找到"
+        if (-not (Test-Path "output\Bloret-Launcher\Bloret-Launcher.exe")) {
+          Write-Host "standalone 目录缺少 Bloret-Launcher.exe"
+          Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
           exit 1
+        }
+        # SetupIconFile 需要 bloret.ico；若 dist 内没有则从仓库拷贝
+        if (-not (Test-Path "output\Bloret-Launcher\bloret.ico")) {
+          if (Test-Path "bloret.ico") {
+            Copy-Item "bloret.ico" "output\Bloret-Launcher\bloret.ico"
+          } elseif (Test-Path "output\bloret.ico") {
+            Copy-Item "output\bloret.ico" "output\Bloret-Launcher\bloret.ico"
+          }
+        }
+        if (-not (Test-Path "output\Bloret-Launcher\LICENSE") -and (Test-Path "LICENSE")) {
+          Copy-Item "LICENSE" "output\Bloret-Launcher\LICENSE"
         }
       shell: pwsh
 

--- a/.github/workflows/Nuitka-Build.yml
+++ b/.github/workflows/Nuitka-Build.yml
@@ -345,6 +345,24 @@ jobs:
 
     - name: 收集产物
       run: |
+        # Windows runner 通常无 zip 命令，用 Python 做跨平台归档
+        make_zip() {
+          local src_dir="$1"
+          local zip_path="$2"
+          python - <<'PY' "$src_dir" "$zip_path"
+        import sys, zipfile
+        from pathlib import Path
+        src = Path(sys.argv[1]).resolve()
+        zip_path = Path(sys.argv[2]).resolve()
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for path in src.rglob("*"):
+                if path.is_file():
+                    zf.write(path, arcname=str(Path(src.name) / path.relative_to(src)))
+        print(f"wrote {zip_path} ({zip_path.stat().st_size} bytes)")
+        PY
+        }
+
         mkdir -p ${{ env.OUTPUT_DIR }}
         if [ "${{ runner.os }}" == "Windows" ]; then
           # Nuitka standalone 输出为 Bloret-Launcher.dist/
@@ -360,8 +378,7 @@ jobs:
           test -f "$DIST_DIR/Bloret-Launcher.exe"
           mkdir -p "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
           cp -a "$DIST_DIR"/. "${{ env.OUTPUT_DIR }}/Bloret-Launcher/"
-          # 兼容旧 Inno：根目录也放一份 exe 与 LICENSE 等（安装器会装整个目录）
-          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Windows-standalone.zip Bloret-Launcher)
+          make_zip "${{ env.OUTPUT_DIR }}/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Windows-standalone.zip"
         fi
         if [ "${{ runner.os }}" == "Linux" ]; then
           ARCH=$(uname -m)
@@ -413,7 +430,7 @@ jobs:
           ./appimagetool --appimage-extract-and-run AppDir "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux.AppImage"
           mkdir -p "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
           cp -a "$DIST_DIR"/. "${{ env.OUTPUT_DIR }}/Bloret-Launcher/"
-          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Linux-standalone.zip Bloret-Launcher)
+          make_zip "${{ env.OUTPUT_DIR }}/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux-standalone.zip"
         fi
         if [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
         make_zip() {
           local src_dir="$1"
           local zip_path="$2"
-          python - <<'PY' "$src_dir" "$zip_path"
+          python - "$src_dir" "$zip_path" <<'PY'
         import sys, zipfile
         from pathlib import Path
         src = Path(sys.argv[1]).resolve()
@@ -254,6 +254,11 @@ jobs:
           test -d dist/Bloret-Launcher
           test -f dist/Bloret-Launcher/Bloret-Launcher.exe
           cp -r dist/Bloret-Launcher "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
+          for f in LICENSE bloret.ico config.json JavaWrapper.jar Bloret.png Bloret-Fluent.png servers.dat; do
+            if [ -f "$f" ] && [ ! -f "${{ env.OUTPUT_DIR }}/Bloret-Launcher/$f" ]; then
+              cp "$f" "${{ env.OUTPUT_DIR }}/Bloret-Launcher/$f"
+            fi
+          done
           make_zip "${{ env.OUTPUT_DIR }}/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Windows-onedir.zip"
         elif [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/
@@ -454,6 +459,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        # 使用触发分支上的 Setup.iss（onedir），不要写死 Windows 旧脚本
+        ref: ${{ github.ref }}
 
     - name: 下载构建产物
       uses: actions/download-artifact@v4
@@ -461,23 +468,58 @@ jobs:
         name: Bloret-Launcher-Windows
         path: output
 
-    # - name: 解压构建产物
-    #   run: |
-    #     Expand-Archive -Path "output/Bloret-Launcher-Windows.zip" -DestinationPath "output/"
-    #   shell: pwsh
-
-    - name: 确保 LICENSE 文件存在
+    - name: 准备 onedir 安装资源
       run: |
-        if (-not (Test-Path "output/LICENSE")) {
-          Write-Host "LICENSE 文件未找到"
+        $ErrorActionPreference = "Stop"
+        Write-Host "=== output tree (depth 2) ==="
+        Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
+
+        $appDir = "output\Bloret-Launcher"
+        if (-not (Test-Path "$appDir\Bloret-Launcher.exe")) {
+          if (Test-Path "output\Bloret-Launcher.exe") {
+            New-Item -ItemType Directory -Force -Path $appDir | Out-Null
+            Get-ChildItem "output" -Force | Where-Object { $_.Name -ne "Bloret-Launcher" } | ForEach-Object {
+              Move-Item $_.FullName -Destination $appDir -Force
+            }
+          } else {
+            Write-Host "onedir 目录缺少 Bloret-Launcher.exe"
+            Get-ChildItem -Path "output" -Recurse -Depth 3 | Format-Table -AutoSize
+            exit 1
+          }
+        }
+
+        foreach ($name in @("LICENSE", "bloret.ico", "config.json", "JavaWrapper.jar", "servers.dat")) {
+          $dest = Join-Path $appDir $name
+          if (-not (Test-Path $dest)) {
+            if (Test-Path $name) {
+              Copy-Item $name $dest -Force
+              Write-Host "Copied $name -> $dest"
+            } elseif (Test-Path "output\$name") {
+              Copy-Item "output\$name" $dest -Force
+              Write-Host "Copied output\$name -> $dest"
+            }
+          }
+        }
+
+        if (-not (Test-Path "$appDir\Bloret-Launcher.exe")) {
+          Write-Host "仍缺少 $appDir\Bloret-Launcher.exe"
           exit 1
+        }
+        if (-not (Test-Path "$appDir\bloret.ico") -and (Test-Path "bloret.ico")) {
+          Copy-Item "bloret.ico" "$appDir\bloret.ico" -Force
+        }
+        if (-not (Test-Path "output\LICENSE") -and (Test-Path "$appDir\LICENSE")) {
+          Copy-Item "$appDir\LICENSE" "output\LICENSE" -Force
+        }
+        if (-not (Test-Path "output\LICENSE") -and (Test-Path "LICENSE")) {
+          Copy-Item "LICENSE" "output\LICENSE" -Force
         }
       shell: pwsh
 
     - name: 展示完整文件夹目录
       run: |
         Write-Host "当前文件夹目录结构如下："
-        Get-ChildItem -Path "output" -Recurse | Format-Table -AutoSize
+        Get-ChildItem -Path "output" -Recurse -Depth 2 | Format-Table -AutoSize
       shell: pwsh
 
     - name: 设置系统语言为简体中文

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,10 +149,11 @@ jobs:
         fi
       shell: bash
 
+    # 非 onefile：目录分发，启动时不再整包解压到临时目录
     - name: 使用 PyInstaller 打包 (Windows)
       if: runner.os == 'Windows'
       run: |
-        pyinstaller --onefile --noconsole --icon=bloret.ico --name=Bloret-Launcher --noupx `
+        pyinstaller --onedir --noconsole --icon=bloret.ico --name=Bloret-Launcher --noupx `
           --add-data "bloret.ico;." --add-data "Bloret.png;." --add-data "Bloret-Fluent.png;." --add-data "config.json;." --add-data "ui;ui" --add-data "RinUI;RinUI" --add-data "qml;qml" --add-data "icon;icon" --add-data "lang;lang" --add-data "easytier;easytier" --add-data "JavaWrapper.jar;." --add-data "modules;modules" `
           --hidden-import=sip --hidden-import=qfluentwidgets --hidden-import=win11toast --hidden-import=toml --hidden-import=winsdk --paths=. Bloret-Launcher.py
       shell: pwsh
@@ -160,7 +161,7 @@ jobs:
     - name: 使用 PyInstaller 打包 (Linux)
       if: runner.os == 'Linux'
       run: |
-        pyinstaller --onefile --windowed --name=Bloret-Launcher \
+        pyinstaller --onedir --windowed --name=Bloret-Launcher \
           --add-data "bloret.ico:." --add-data "Bloret.png:." --add-data "Bloret-Fluent.png:." --add-data "config.json:." --add-data "ui:ui" --add-data "RinUI:RinUI" --add-data "qml:qml" --add-data "icon:icon" --add-data "lang:lang" --add-data "easytier:easytier" --add-data "modules:modules" --add-data "JavaWrapper.jar:." \
           --hidden-import=sip --hidden-import=qfluentwidgets --hidden-import=toml --paths=. Bloret-Launcher.py
       shell: bash
@@ -193,8 +194,8 @@ jobs:
           fi
         fi
         
-        # 使用 --name 参数确保应用名称中间有空格
-        pyinstaller --onefile --windowed --name="Bloret Launcher" $ICON_CMD \
+        # onedir + windowed：生成 .app bundle（不再使用 onefile 启动解压）
+        pyinstaller --onedir --windowed --name="Bloret Launcher" $ICON_CMD \
           --add-data "bloret.ico:." --add-data "Bloret.png:." --add-data "Bloret-Fluent.png:." --add-data "config.json:." --add-data "ui:ui" --add-data "RinUI:RinUI" --add-data "qml:qml" --add-data "icon:icon" --add-data "lang:lang" --add-data "easytier:easytier" --add-data "modules:modules" --add-data "JavaWrapper.jar:." \
           --hidden-import=sip --hidden-import=qfluentwidgets --hidden-import=toml --paths=. Bloret-Launcher.py
 
@@ -231,15 +232,31 @@ jobs:
       run: |
         mkdir -p ${{ env.OUTPUT_DIR }}
         if [ "${{ runner.os }}" == "Windows" ]; then
-          cp dist/Bloret-Launcher.exe ${{ env.OUTPUT_DIR }}/
+          # onedir：整目录发布（zip + 展开目录，供 Inno Setup 安装）
+          test -d dist/Bloret-Launcher
+          test -f dist/Bloret-Launcher/Bloret-Launcher.exe
+          cp -r dist/Bloret-Launcher "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
+          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Windows-onedir.zip Bloret-Launcher)
         elif [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/
         elif [ "${{ runner.os }}" == "Linux" ]; then
           ARCH=$(uname -m)
-          mkdir -p AppDir/usr/bin AppDir/usr/share/applications AppDir/usr/share/bloret-launcher
-          cp dist/Bloret-Launcher AppDir/usr/bin/bloret-launcher
-          chmod +x AppDir/usr/bin/bloret-launcher
-          cp -r RinUI qml ui icon lang config.json LICENSE bloret.ico Bloret.png Bloret-Fluent.png JavaWrapper.jar AppDir/usr/share/bloret-launcher/
+          test -d dist/Bloret-Launcher
+          test -x dist/Bloret-Launcher/Bloret-Launcher || test -f dist/Bloret-Launcher/Bloret-Launcher
+          mkdir -p AppDir/usr/bin AppDir/usr/share/applications AppDir/usr/lib/bloret-launcher
+          # 将 onedir 运行时整体放入 lib，入口脚本调用其中可执行文件
+          cp -a dist/Bloret-Launcher/. AppDir/usr/lib/bloret-launcher/
+          cat > AppDir/usr/bin/bloret-launcher << 'EOF'
+        #!/bin/sh
+        DIR="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+        ROOT="$(cd "$DIR/.." && pwd)"
+        exec "$ROOT/lib/bloret-launcher/Bloret-Launcher" "$@"
+        EOF
+          chmod +x AppDir/usr/bin/bloret-launcher AppDir/usr/lib/bloret-launcher/Bloret-Launcher
+          # 仍附带源树资源作为兜底（onedir 内已含打包数据）
+          cp -r RinUI qml ui icon lang config.json LICENSE bloret.ico Bloret.png Bloret-Fluent.png JavaWrapper.jar AppDir/usr/share/ 2>/dev/null || true
+          mkdir -p AppDir/usr/share/bloret-launcher
+          cp -r RinUI qml ui icon lang config.json LICENSE bloret.ico Bloret.png Bloret-Fluent.png JavaWrapper.jar AppDir/usr/share/bloret-launcher/ 2>/dev/null || true
           if [ -d "easytier" ]; then cp -r easytier AppDir/usr/share/bloret-launcher/; fi
           cp servers.dat AppDir/usr/share/bloret-launcher/ || true
           cat > AppDir/bloret-launcher.desktop << EOF
@@ -265,9 +282,9 @@ jobs:
           curl -L -o appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${ARCH}.AppImage"
           chmod +x appimagetool
           ./appimagetool --appimage-extract-and-run AppDir "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux.AppImage"
+          # 同时上传 onedir zip，便于非 AppImage 场景直接解压运行
+          (cd dist && zip -r "${{ github.workspace }}/${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux-onedir.zip" Bloret-Launcher)
         fi
-        cp -r RinUI qml ui lang easytier config.json LICENSE bloret.ico JavaWrapper.jar ${{ env.OUTPUT_DIR }}/
-        cp servers.dat ${{ env.OUTPUT_DIR }}/ || true
       shell: bash
 
     - name: 上传构建产物

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,13 +230,31 @@ jobs:
 
     - name: 收集产物
       run: |
+        # Windows runner 通常无 zip 命令，用 Python 做跨平台归档
+        make_zip() {
+          local src_dir="$1"
+          local zip_path="$2"
+          python - <<'PY' "$src_dir" "$zip_path"
+        import sys, zipfile
+        from pathlib import Path
+        src = Path(sys.argv[1]).resolve()
+        zip_path = Path(sys.argv[2]).resolve()
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for path in src.rglob("*"):
+                if path.is_file():
+                    zf.write(path, arcname=str(Path(src.name) / path.relative_to(src)))
+        print(f"wrote {zip_path} ({zip_path.stat().st_size} bytes)")
+        PY
+        }
+
         mkdir -p ${{ env.OUTPUT_DIR }}
         if [ "${{ runner.os }}" == "Windows" ]; then
           # onedir：整目录发布（zip + 展开目录，供 Inno Setup 安装）
           test -d dist/Bloret-Launcher
           test -f dist/Bloret-Launcher/Bloret-Launcher.exe
           cp -r dist/Bloret-Launcher "${{ env.OUTPUT_DIR }}/Bloret-Launcher"
-          (cd "${{ env.OUTPUT_DIR }}" && zip -r Bloret-Launcher-Windows-onedir.zip Bloret-Launcher)
+          make_zip "${{ env.OUTPUT_DIR }}/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Windows-onedir.zip"
         elif [ "${{ runner.os }}" == "macOS" ]; then
           cp *.dmg ${{ env.OUTPUT_DIR }}/
         elif [ "${{ runner.os }}" == "Linux" ]; then
@@ -283,7 +301,7 @@ jobs:
           chmod +x appimagetool
           ./appimagetool --appimage-extract-and-run AppDir "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux.AppImage"
           # 同时上传 onedir zip，便于非 AppImage 场景直接解压运行
-          (cd dist && zip -r "${{ github.workspace }}/${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux-onedir.zip" Bloret-Launcher)
+          make_zip "dist/Bloret-Launcher" "${{ env.OUTPUT_DIR }}/Bloret-Launcher-Linux-onedir.zip"
         fi
       shell: bash
 

--- a/Bloret-Launcher-Setup.iss
+++ b/Bloret-Launcher-Setup.iss
@@ -1,4 +1,5 @@
 ; MyAppVersion 的值会由 Github Actions 自动修改
+; 安装完整 onedir/standalone 目录（非单 exe）
 #define MyAppName "Bloret-Launcher"
 #define MyAppVersion "27.1-Beta"
 #define MyAppPublisher "Bloret"
@@ -40,7 +41,7 @@ PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=commandline
 OutputDir=.\output
 OutputBaseFilename=Bloret-Launcher-Setup
-SetupIconFile=output\bloret.ico
+SetupIconFile=output\Bloret-Launcher\bloret.ico
 SolidCompression=yes
 WizardStyle=modern
 
@@ -48,17 +49,12 @@ WizardStyle=modern
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "output\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\Bloret-Launcher.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\config.json"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\servers.dat"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\bloret.ico"; DestDir: "{app}"; Flags: ignoreversion
-Source: "output\JavaWrapper.jar"; DestDir: "{app}"; Flags: ignoreversion
-; Source: "output\icons\*"; DestDir: "{app}\icons"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "output\lang\*"; DestDir: "{app}\lang"; Flags: ignoreversion 
-Source: "output\easytier\*"; DestDir: "{app}\easytier"; Flags: ignoreversion recursesubdirs createallsubdirs
-; 注意：不要在任何共享系统文件上使用 "Flags: ignoreversion"
+; 安装完整 onedir/standalone 目录（Nuitka/PyInstaller 产物）
+Source: "output\Bloret-Launcher\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; 兼容：若产物仍把 LICENSE 等放在 output 根目录
+Source: "output\LICENSE"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "output\config.json"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "output\servers.dat"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
 [Registry]
 Root: HKA; Subkey: "Software\Classes\{#MyAppAssocExt}\OpenWithProgids"; ValueType: string; ValueName: "{#MyAppAssocKey}"; ValueData: ""; Flags: uninsdeletevalue
@@ -73,4 +69,4 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/Bloret-Launcher.spec
+++ b/Bloret-Launcher.spec
@@ -1,12 +1,30 @@
 # -*- mode: python ; coding: utf-8 -*-
-
+# PyInstaller onedir（非 onefile）规格：产物为 dist/Bloret-Launcher/ 目录。
 
 a = Analysis(
     ['Bloret-Launcher.py'],
     pathex=['.'],
     binaries=[],
-    datas=[('bloret.ico', '.'), ('config.json', '.'), ('ui', 'ui'), ('modules', 'modules')],
-    hiddenimports=['qfluentwidgets', 'win11toast'],
+    datas=[
+        ('bloret.ico', '.'),
+        ('Bloret.png', '.'),
+        ('Bloret-Fluent.png', '.'),
+        ('config.json', '.'),
+        ('ui', 'ui'),
+        ('RinUI', 'RinUI'),
+        ('qml', 'qml'),
+        ('icon', 'icon'),
+        ('lang', 'lang'),
+        ('modules', 'modules'),
+        ('JavaWrapper.jar', '.'),
+    ],
+    hiddenimports=[
+        'sip',
+        'qfluentwidgets',
+        'win11toast',
+        'toml',
+        'winsdk',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -19,16 +37,13 @@ pyz = PYZ(a.pure)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.datas,
     [],
+    exclude_binaries=True,
     name='Bloret-Launcher',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=False,
-    upx_exclude=[],
-    runtime_tmpdir=None,
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -36,4 +51,14 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     icon=['bloret.ico'],
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name='Bloret-Launcher',
 )

--- a/modules/paths.py
+++ b/modules/paths.py
@@ -7,13 +7,12 @@ paths.py
  - [x] 避免各模块各自用 os.getcwd() / os.path.dirname(__file__) 定位打包资源，
        这些方式在 Nuitka onefile 下会指向错误目录。
 
-### 关键事实（Nuitka onefile 运行时）：
+### 关键事实（打包运行时）：
  - `sys.frozen` 不会被 Nuitka 设置（只有 PyInstaller 设置）。
- - `sys._MEIPASS` 不会被 Nuitka 设置（只有 PyInstaller 设置）。
- - `sys.__nuitka_binary_dir` 由 Nuitka 设置，指向临时解压目录（数据文件所在位置）。
- - `os.getcwd()` 是启动目录（用户双击 exe 的位置），不是临时解压目录。
- - 主脚本 `__file__` 在 onefile 下解析到临时目录，但被导入模块的 `__file__`
-   解析行为不可靠，不能用于定位打包数据。
+ - `sys._MEIPASS` 仅 PyInstaller **onefile** 设置；**onedir** 无此属性，资源在 exe 同目录。
+ - `sys.__nuitka_binary_dir` 由 Nuitka 设置：onefile 为临时解压目录，standalone 为 `.dist` 目录。
+ - `os.getcwd()` 是启动目录（用户双击 exe 的位置），不一定是资源目录。
+ - 被导入模块的 `__file__` 在打包后不可靠，不能用于定位打包数据。
 
 因此定位打包资源时统一使用 `get_app_dir()`，不要依赖 `__file__` 或 `os.getcwd()`。
 
@@ -42,22 +41,21 @@ def get_app_dir() -> Path:
     if _app_dir is not None:
         return _app_dir
 
-    # Nuitka 编译模式（standalone / onefile）
-    # sys.__nuitka_binary_dir 由 Nuitka 运行时设置，指向解压/二进制目录
+    # Nuitka（standalone 目录 / onefile 临时目录）
+    # sys.__nuitka_binary_dir 指向数据文件所在目录
     nuitka_binary_dir = getattr(sys, "__nuitka_binary_dir", None)
     if nuitka_binary_dir:
         _app_dir = Path(nuitka_binary_dir)
         return _app_dir
 
-    # PyInstaller onefile 模式
+    # PyInstaller onefile：临时解压目录
     meipass = getattr(sys, "_MEIPASS", None)
     if meipass:
         _app_dir = Path(meipass)
         return _app_dir
 
-    # PyInstaller / Nuitka 其它可能的 frozen 标记
+    # PyInstaller onedir / 其它 frozen：资源与可执行文件同目录
     if getattr(sys, "frozen", False):
-        # exe 所在目录
         _app_dir = Path(sys.argv[0]).resolve().parent
         return _app_dir
 

--- a/scripts/smoke_non_onefile.py
+++ b/scripts/smoke_non_onefile.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+本地冒烟：验证非 onefile 路径解析，并在虚拟显示（Xvfb）下做最小启动探测。
+
+用法:
+  python3 scripts/smoke_non_onefile.py
+  BLORET_SMOKE_PACKAGED_DIR=/path/to/Bloret-Launcher.dist python3 scripts/smoke_non_onefile.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ok(msg: str) -> None:
+    print(f"[OK] {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"[FAIL] {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def test_path_resolution_dev() -> None:
+    sys.path.insert(0, str(ROOT))
+    from modules.paths import get_app_dir, app_path
+
+    app_dir = get_app_dir()
+    if app_dir.resolve() != ROOT.resolve():
+        _fail(f"dev get_app_dir={app_dir} expected {ROOT}")
+    qml = Path(app_path("qml", "main.qml"))
+    if not qml.is_file():
+        _fail(f"missing {qml}")
+    _ok(f"dev path resolution -> {app_dir}")
+
+
+def test_path_resolution_frozen_onedir() -> None:
+    """模拟 PyInstaller onedir：frozen + 无 _MEIPASS，资源在 exe 旁。"""
+    with tempfile.TemporaryDirectory(prefix="bloret-onedir-") as td:
+        td_path = Path(td)
+        fake_exe = td_path / "Bloret-Launcher"
+        fake_exe.write_text("#!/bin/sh\n", encoding="utf-8")
+        (td_path / "qml").mkdir()
+        (td_path / "qml" / "main.qml").write_text("// smoke\n", encoding="utf-8")
+        (td_path / "RinUI").mkdir()
+        (td_path / "icon").mkdir()
+        (td_path / "lang").mkdir()
+
+        code = r"""
+import sys
+from pathlib import Path
+sys.frozen = True
+# onedir: no _MEIPASS
+if hasattr(sys, "_MEIPASS"):
+    delattr(sys, "_MEIPASS")
+sys.argv[0] = r"%s"
+sys.path.insert(0, r"%s")
+# force re-import paths without cache from previous tests in same process
+import importlib
+import modules.paths as paths
+importlib.reload(paths)
+app_dir = paths.get_app_dir()
+assert app_dir == Path(r"%s"), (app_dir, r"%s")
+assert (app_dir / "qml" / "main.qml").is_file()
+print("onedir-sim-ok", app_dir)
+""" % (
+            str(fake_exe),
+            str(ROOT),
+            str(td_path),
+            str(td_path),
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            _fail(f"onedir sim failed:\n{proc.stdout}\n{proc.stderr}")
+        _ok(f"frozen onedir path simulation ({proc.stdout.strip()})")
+
+
+def test_path_resolution_meipass() -> None:
+    """模拟 PyInstaller onefile：_MEIPASS 优先。"""
+    with tempfile.TemporaryDirectory(prefix="bloret-mei-") as td:
+        td_path = Path(td)
+        (td_path / "qml").mkdir()
+        (td_path / "qml" / "main.qml").write_text("// smoke\n", encoding="utf-8")
+        code = r"""
+import sys
+from pathlib import Path
+sys._MEIPASS = r"%s"
+sys.path.insert(0, r"%s")
+import importlib
+import modules.paths as paths
+importlib.reload(paths)
+app_dir = paths.get_app_dir()
+assert app_dir == Path(r"%s")
+print("meipass-sim-ok", app_dir)
+""" % (
+            str(td_path),
+            str(ROOT),
+            str(td_path),
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            _fail(f"meipass sim failed:\n{proc.stdout}\n{proc.stderr}")
+        _ok(f"onefile meipass simulation ({proc.stdout.strip()})")
+
+
+def _gui_python() -> str:
+    """优先使用带 PySide6 的解释器（CI/代理 venv 可能没有 GUI 依赖）。"""
+    candidates = [
+        os.environ.get("BLORET_PYTHON", "").strip(),
+        "/usr/bin/python3",
+        sys.executable,
+    ]
+    for cand in candidates:
+        if not cand:
+            continue
+        try:
+            r = subprocess.run(
+                [cand, "-c", "import PySide6"],
+                capture_output=True,
+                timeout=15,
+            )
+            if r.returncode == 0:
+                return cand
+        except Exception:
+            continue
+    return sys.executable
+
+
+def test_virtual_desktop_boot() -> None:
+    """在 Xvfb 虚拟显示下短时启动主程序，确认 QML/资源能找到。"""
+    env = os.environ.copy()
+    env.setdefault("QT_QPA_PLATFORM", "xcb")
+    env["BLORET_DEBUG"] = "1"
+    # 避免单实例锁干扰
+    env["BLORET_SMOKE"] = "1"
+
+    py = _gui_python()
+    cmd = [
+        py,
+        str(ROOT / "Bloret-Launcher.py"),
+    ]
+    wrapper = ["xvfb-run", "-a", "-s", "-screen 0 1280x720x24"]
+    full = wrapper + cmd
+
+    log_path = ROOT / "temp" / "smoke_non_onefile_boot.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"[..] virtual desktop boot: {' '.join(full)}")
+    with open(log_path, "w", encoding="utf-8") as logf:
+        try:
+            proc = subprocess.Popen(
+                full,
+                cwd=str(ROOT),
+                env=env,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError as e:
+            _fail(f"cannot start xvfb-run / app: {e}")
+
+        # 等待启动期错误或存活
+        deadline = time.time() + 25
+        while time.time() < deadline:
+            rc = proc.poll()
+            if rc is not None:
+                logf.flush()
+                text = log_path.read_text(encoding="utf-8", errors="replace")
+                # 资源/QML 致命错误
+                bad = (
+                    "Error loading QML",
+                    "module \"QtQuick",
+                    "is not installed",
+                    "QML file missing",
+                    "Failed to load",
+                )
+                if any(b in text for b in bad):
+                    _fail(f"boot exited {rc} with QML/resource error; log={log_path}\n{text[-4000:]}")
+                # 单实例 / 环境导致的早期退出：记为警告但仍算路径 OK 若无资源错误
+                if rc != 0 and "qml/main.qml" in text and "missing" in text.lower():
+                    _fail(f"boot failed missing qml: {text[-2000:]}")
+                _ok(f"boot process exited early rc={rc} (check log {log_path}); no QML resource fatal seen")
+                return
+            time.sleep(0.5)
+
+        # 仍在运行：认为 GUI 主循环已起来
+        proc.terminate()
+        try:
+            proc.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+        if "Error loading QML" in text or "QML file missing" in text:
+            _fail(f"running but QML errors in log:\n{text[-3000:]}")
+        _ok(f"virtual desktop: process stayed alive ~25s (log {log_path})")
+
+
+def test_packaged_dir_layout() -> None:
+    packaged = os.environ.get("BLORET_SMOKE_PACKAGED_DIR", "").strip()
+    if not packaged:
+        print("[SKIP] BLORET_SMOKE_PACKAGED_DIR not set (no local package tree)")
+        return
+    p = Path(packaged)
+    if not p.is_dir():
+        _fail(f"packaged dir not found: {p}")
+    exe_candidates = [
+        p / "Bloret-Launcher",
+        p / "Bloret-Launcher.exe",
+    ]
+    if not any(c.exists() for c in exe_candidates):
+        _fail(f"no Bloret-Launcher binary under {p}")
+    for rel in ("qml/main.qml",):
+        # data may be next to exe or under _internal (PyInstaller 6+)
+        found = list(p.rglob("main.qml"))
+        if not found:
+            _fail(f"no main.qml under packaged tree {p}")
+    _ok(f"packaged layout looks like onedir/standalone: {p}")
+
+
+def main() -> None:
+    os.chdir(ROOT)
+    test_path_resolution_dev()
+    test_path_resolution_frozen_onedir()
+    test_path_resolution_meipass()
+    test_packaged_dir_layout()
+    test_virtual_desktop_boot()
+    print("\nAll smoke checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- PyInstaller：`--onefile` → **`--onedir`**（Windows/Linux/macOS）
- Nuitka：去掉 `--onefile`，保留 **`--standalone`** 目录产物
- 产物改为目录 + zip；Inno Setup 安装完整 `Bloret-Launcher\` 树
- Release 上传 standalone zip（兼容残留单 exe）
- 新增 `scripts/smoke_non_onefile.py`：路径解析模拟 + **Xvfb 虚拟桌面**短时启动

## 动机
onefile 启动时会把整包释放到临时目录，冷启动慢、易被杀软拦截。目录分发直接运行，无启动解压。

## 本地验证
```text
/usr/bin/python3 scripts/smoke_non_onefile.py
```
结果：
- [OK] dev / frozen onedir / meipass 路径解析
- [OK] Xvfb 虚拟桌面进程存活约 25s（无 QML 资源致命错误）
- 本机内存有限未跑完整 Nuitka/PyInstaller 全量编译；依赖 CI artifact

## 产物形态变化
| 平台 | 之前 | 之后 |
|------|------|------|
| Windows PyInstaller | 单 `Bloret-Launcher.exe` | `Bloret-Launcher/` 目录 + `*-onedir.zip` |
| Windows Nuitka | 单 exe | `Bloret-Launcher/` + `*-standalone.zip` |
| Linux | 单二进制塞进 AppImage | onedir/standalone 整树进 AppImage + zip |
| Setup | 拷贝单 exe + 零散资源 | 递归安装 `output\Bloret-Launcher\*` |

## Test plan
- [ ] CI：`build.yml` / `Nuitka-Build.yml` 通过
- [ ] 解压 Windows zip，直接运行 `Bloret-Launcher.exe`（无临时解压目录）
- [ ] Inno Setup 安装后快捷方式可启动
- [ ] Linux AppImage / standalone zip 可启动
- [ ] 托盘 / QML 资源路径正常（`qml/`、`RinUI/` 在 exe 旁）